### PR TITLE
Fixed Burst Lerp

### DIFF
--- a/docs/Tasks/Bugs.md
+++ b/docs/Tasks/Bugs.md
@@ -51,3 +51,5 @@ question and possible bug when me and my friend die and restart a game it seems 
 ## SoulMuncher
 - Decoy may be affected by co-op/unit difficulty scaling
 - Impossible to deal maximum (50) damage with Burst due to no lower distance threshold
+    - Update: It is actually possible to deal 50 damage with burst, but the two unit circles must overlap almost perfectly
+    - Changed so that max damage is achieved as soon as unit circles touch, and damage linearly lerps to 0 at "out of range" distance.

--- a/src/cards/burst.ts
+++ b/src/cards/burst.ts
@@ -11,8 +11,8 @@ import { makeBurstParticles } from '../graphics/ParticleCollection';
 export const burstCardId = 'Burst';
 const maxDamage = 50;
 function calculateDamage(stack: number, casterPositionAtTimeOfCast: Vec2, casterAttackRange: number, target: Vec2): number {
-  const dist = distance(casterPositionAtTimeOfCast, target)
-  return Math.ceil(lerp(0, maxDamage, 1 - dist / (casterAttackRange + config.COLLISION_MESH_RADIUS * 2)) * stack);
+    const dist = distance(casterPositionAtTimeOfCast, target)
+    return Math.ceil(lerp(maxDamage, 0, (dist - config.COLLISION_MESH_RADIUS) / casterAttackRange) * stack);
 }
 export interface UnitDamage {
   id: number;


### PR DESCRIPTION
Changed so that max damage is achieved as soon as unit circles touch, and damage linearly lerps to 0 at "out of range" distance.