### PR TITLE
Balance Capture Soul

### DIFF
--- a/src/cards/cardUtils.ts
+++ b/src/cards/cardUtils.ts
@@ -160,7 +160,7 @@ export function calculateCostForSingleCard(card: ICard, timesUsedSoFar: number =
             }
         } else if (caster.mageType == 'Necromancer') {
             if (card.id == captureSoul.id) {
-                cardCost.healthCost = Math.floor(0.9 * caster.unit.healthMax);
+                cardCost.healthCost = 38;
                 cardCost.manaCost = 0;
             } else if (Object.keys(allUnits).includes(card.id.replace(' Miniboss', ''))) {
                 // Make summon spells discounted


### PR DESCRIPTION
#45 
Capture soul now costs a static 38hp when using necro.

I think it would be good to revisit and further balance this at some point. Static cost is good for now.