### PR TITLE
Quick Witch Fix

### DIFF
--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -168,6 +168,7 @@ export function changeMageType(type: MageType, player?: IPlayer, underworld?: Un
             console.error('Could not find upgrade for', type);
           }
         }
+        break;
       case 'Far Gazer':
         {
           player.unit.attackRange = 2 * player.unit.attackRange;


### PR DESCRIPTION
Fixes an issue where if you choose Witch you'd also get Far Gazer's double range and half stamina.