### PR TITLE
Spell Balancing 2

### DIFF
--- a/src/cards/purify.ts
+++ b/src/cards/purify.ts
@@ -34,9 +34,8 @@ const spell: Spell = {
   },
 };
 export function apply(unit: Unit.IUnit, underworld: Underworld) {
-  for (let [modifier, modifierProperties] of Object.entries(
-    unit.modifiers,
-  )) {
+
+  for (let [modifier, modifierProperties] of Object.entries(unit.modifiers)) {
     if (modifierProperties.isCurse) {
       Unit.removeModifier(unit, modifier, underworld);
     }

--- a/src/cards/sacrifice.ts
+++ b/src/cards/sacrifice.ts
@@ -9,8 +9,9 @@ import { playDefaultSpellSFX } from './cardUtils';
 import * as config from '../config';
 import { explain, EXPLAIN_OVERFILL } from '../graphics/Explain';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
-import { die } from '../entity/Unit';
+import { die, takeDamage } from '../entity/Unit';
 
+const damage = config.UNIT_BASE_HEALTH; //40 at time of writing
 export const consumeAllyCardId = 'Sacrifice';
 const spell: Spell = {
   card: {
@@ -31,16 +32,14 @@ const spell: Spell = {
       let promises = [];
       let totalHealthStolen = 0;
       for (let unit of targets) {
-        const unitHealthStolen = unit.health;
+        const unitHealthStolen = Math.min(unit.health, damage * quantity);
         totalHealthStolen += unitHealthStolen;
-        unit.health -= unitHealthStolen;
+        takeDamage(unit, unitHealthStolen, undefined, underworld, prediction);
         const healthTrailPromises = [];
         if (!prediction) {
           const NUMBER_OF_ANIMATED_TRAILS = Math.min(6, unitHealthStolen / 10);
           for (let i = 0; i < quantity * NUMBER_OF_ANIMATED_TRAILS; i++) {
             healthTrailPromises.push(makeManaTrail(unit, caster, underworld, '#ff6767n', '#ff0000').then(() => {
-              const healthStolenPerTrail = Math.floor(unitHealthStolen / NUMBER_OF_ANIMATED_TRAILS)
-              state.casterUnit.health += healthStolenPerTrail;
               if (!prediction) {
                 playDefaultSpellSFX(card, prediction);
                 // Animate
@@ -70,10 +69,12 @@ const spell: Spell = {
             );
           }
         }
-        die(unit, underworld, prediction);
         promises.push((prediction ? Promise.resolve() : Promise.all(healthTrailPromises)));
       }
       await Promise.all(promises);
+
+      state.casterUnit.health += totalHealthStolen;
+
       playDefaultSpellSFX(card, prediction);
       if (totalHealthStolen > 0) {
         if (!prediction) {

--- a/src/cards/sacrifice.ts
+++ b/src/cards/sacrifice.ts
@@ -9,7 +9,7 @@ import { playDefaultSpellSFX } from './cardUtils';
 import * as config from '../config';
 import { explain, EXPLAIN_OVERFILL } from '../graphics/Explain';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
-import { die, takeDamage } from '../entity/Unit';
+import { die } from '../entity/Unit';
 
 const damage = config.UNIT_BASE_HEALTH; //40 at time of writing
 export const consumeAllyCardId = 'Sacrifice';
@@ -33,8 +33,10 @@ const spell: Spell = {
       let totalHealthStolen = 0;
       for (let unit of targets) {
         const unitHealthStolen = Math.min(unit.health, damage * quantity);
+        // This instead of takeDamage() -> ignores shield, not modified by damage mitigation/prevention, doesn't trigger onDamage event
+        unit.health -= unitHealthStolen;
         totalHealthStolen += unitHealthStolen;
-        takeDamage(unit, unitHealthStolen, undefined, underworld, prediction);
+        if (unit.health <= 0) die(unit, underworld, prediction);
         const healthTrailPromises = [];
         if (!prediction) {
           const NUMBER_OF_ANIMATED_TRAILS = Math.min(6, unitHealthStolen / 10);

--- a/src/cards/send_mana.ts
+++ b/src/cards/send_mana.ts
@@ -23,7 +23,7 @@ const spell: Spell = {
     supportQuantity: true,
     manaCost: amount,
     healthCost: 0,
-    expenseScaling: 0,
+    expenseScaling: 1,
     probability: probabilityMap[CardRarity.UNCOMMON],
     thumbnail: 'spellIconSendMana.png',
     animationPath: 'spell-effects/potionPickup',

--- a/src/cards/suffocate.ts
+++ b/src/cards/suffocate.ts
@@ -26,6 +26,8 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
     }
   });
 
+  // One suffocate stack is added per cast and per turn passed
+  // Buildup doubles every 2 stacks until > hp, then unit dies
   modifier.buildup = Math.floor(10 * Math.pow(2, (modifier.quantity - 1) / 2));
 
   if (modifier.buildup >= unit.health) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@
 export const RIGHT_CLICK_DOUBLE_MS_THRESHOLD = 500;
 export const RIGHT_CLICK_DOUBLE_DISTANCE_THRESHOLD = 30;
 
-export const PLAYER_BASE_HEALTH = 40;
+export const PLAYER_BASE_HEALTH = 60; //previously 40
 export const UNIT_MOVE_SPEED = 0.15;
 export const COLLISION_MESH_RADIUS = 32;
 // Though the size of the images for units are generally 64x64, the unit doesn't take up the full height
@@ -30,7 +30,7 @@ export const UNIT_BASE_HEALTH = 40;
 export const UNIT_BASE_MANA = 60;
 export const UNIT_BASE_STAMINA = 300;
 // For game difficulty, I'm making the attack range less than the unit base stamina
-export const PLAYER_BASE_ATTACK_RANGE = UNIT_BASE_STAMINA * 0.8;
+export const PLAYER_BASE_ATTACK_RANGE = 200; // previously 240 | UNIT_BASE_STAMINA * 0.8
 // For game difficulty, player stamina less than the unit stamina so they can't run away without upgrading it
 export const PLAYER_BASE_STAMINA = 200; //previously 210 | UNIT_BASE_STAMINA * 0.7
 export const UNIT_BASE_DAMAGE = 30;

--- a/src/modifierImpendingDoom.ts
+++ b/src/modifierImpendingDoom.ts
@@ -7,7 +7,7 @@ import floatingText from './graphics/FloatingText';
 import * as colors from './graphics/ui/colors';
 
 export const impendingDoomId = 'impendingDoom';
-export default function registerSummoningSickness() {
+export default function registerImpendingDoom() {
   registerModifiers(impendingDoomId, {
     add: (unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, quantity: number = 1) => {
       getOrInitModifier(unit, impendingDoomId, { isCurse: true, quantity, persistBetweenLevels: false }, () => {


### PR DESCRIPTION
Closes #91 
- Contaminate now "chains" with multicast

Closes #23 
- Sacrifice now deals 40 damage per quantity, stealing an equal amount of health but not exceeding the targeted unit's current health.

Closes #118 
- Impending Doom can now be spread via contaminate
- This, like other modifiers, overwrites similar modifiers with less quantity. This means that impending doom is actually the only modifier that overwrites stronger versions of the curse with weaker ones, as more quantity means more turns until death in this case.

Closes #86 
- Player starts with 60 hp and 200 range

Closes #77 
Closes #122
Closes #129 
- Send mana now has default expense scaling

QA'd singleplayer spell interactions