### PR TITLE
Keep on Death property

### DIFF
--- a/src/cards/bloat.ts
+++ b/src/cards/bloat.ts
@@ -19,7 +19,7 @@ const damage = 40;
 export const baseRadius = 140;
 function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity: number, extra?: any) {
   const modifier = getOrInitModifier(unit, id, {
-    isCurse: true, quantity, persistBetweenLevels: false,
+    isCurse: true, quantity,
     originalStats: {
       scaleX: unit.image && unit.image.sprite.scale.x || 1,
       scaleY: unit.image && unit.image.sprite.scale.y || 1,

--- a/src/cards/blood_curse.ts
+++ b/src/cards/blood_curse.ts
@@ -24,7 +24,7 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean) {
     return;
   }
 
-  const modifier = getOrInitModifier(unit, id, { isCurse: true, quantity: 1, persistBetweenLevels: false }, () => {
+  const modifier = getOrInitModifier(unit, id, { isCurse: true, quantity: 1 }, () => {
     // Add event
     unit.onDamageEvents.push(id);
 

--- a/src/cards/conserve.ts
+++ b/src/cards/conserve.ts
@@ -70,7 +70,7 @@ const spell: Spell = {
 };
 
 function add(unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, quantity: number = 1) {
-  getOrInitModifier(unit, conserveSpellId, { isCurse: false, quantity, persistBetweenLevels: false }, () => {
+  getOrInitModifier(unit, conserveSpellId, { isCurse: false, quantity }, () => {
     if (!unit.onTurnStartEvents.includes(conserveSpellId)) {
       unit.onTurnStartEvents.push(conserveSpellId);
     }

--- a/src/cards/debilitate.ts
+++ b/src/cards/debilitate.ts
@@ -54,7 +54,7 @@ const spell: Spell = {
 };
 
 function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, quantity: number = 1) {
-  const modifier = getOrInitModifier(unit, id, { isCurse: true, quantity, persistBetweenLevels: false }, () => {
+  const modifier = getOrInitModifier(unit, id, { isCurse: true, quantity }, () => {
     unit.onDamageEvents.push(id);
   });
 }

--- a/src/cards/fortify.ts
+++ b/src/cards/fortify.ts
@@ -105,7 +105,7 @@ const spell: Spell = {
 };
 
 function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, quantity: number = 1) {
-  const modifier = getOrInitModifier(unit, id, { isCurse: false, quantity, persistBetweenLevels: false }, () => {
+  const modifier = getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
     // Add event
     unit.onDamageEvents.push(id);
     unit.onTurnStartEvents.push(id);

--- a/src/cards/freeze.ts
+++ b/src/cards/freeze.ts
@@ -109,7 +109,7 @@ const spell: Spell = {
 };
 
 function add(unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, quantity: number = 1) {
-  getOrInitModifier(unit, id, { isCurse: true, quantity, persistBetweenLevels: false }, () => {
+  getOrInitModifier(unit, id, { isCurse: true, quantity }, () => {
     unit.radius = config.COLLISION_MESH_RADIUS;
     // Immediately set stamina to 0 so they can't move
     unit.stamina = 0;

--- a/src/cards/immune.ts
+++ b/src/cards/immune.ts
@@ -28,7 +28,7 @@ export function init(unit: Unit.IUnit, underworld: Underworld, prediction: boole
   }
 }
 export function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) {
-  getOrInitModifier(unit, id, { isCurse: false, quantity, persistBetweenLevels: false }, () => {
+  getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
     init(unit, underworld, prediction)
   });
 }

--- a/src/cards/lastwill.ts
+++ b/src/cards/lastwill.ts
@@ -13,7 +13,7 @@ import { getOrInitModifier } from './util';
 export const id = 'Last Will';
 const imageName = 'unknown.png';
 function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity: number) {
-  const modifier = getOrInitModifier(unit, id, { isCurse: false, quantity, persistBetweenLevels: false }, () => {
+  const modifier = getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
     // Add event
     if (!unit.onDeathEvents.includes(id)) {
       unit.onDeathEvents.push(id);

--- a/src/cards/poison.ts
+++ b/src/cards/poison.ts
@@ -28,7 +28,7 @@ function init(unit: Unit.IUnit, underworld: Underworld, prediction: boolean) {
   }
 }
 function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) {
-  const modifier = getOrInitModifier(unit, poisonCardId, { isCurse: true, quantity, persistBetweenLevels: false }, () => {
+  const modifier = getOrInitModifier(unit, poisonCardId, { isCurse: true, quantity }, () => {
     // Add event
     if (!unit.onTurnEndEvents.includes(poisonCardId)) {
       unit.onTurnEndEvents.push(poisonCardId);

--- a/src/cards/protection.ts
+++ b/src/cards/protection.ts
@@ -10,7 +10,7 @@ import { getOrInitModifier } from './util';
 
 export const id = 'Nullify';
 function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, quantity: number = 1) {
-  getOrInitModifier(unit, id, { isCurse: false, quantity, persistBetweenLevels: false }, () => { });
+  getOrInitModifier(unit, id, { isCurse: false, quantity }, () => { });
 }
 export const notifyProtected = throttle((coords: Vec2, prediction: boolean) => {
   // TODO: i18n: Translate

--- a/src/cards/shield.ts
+++ b/src/cards/shield.ts
@@ -106,7 +106,7 @@ function updateTooltip(unit: Unit.IUnit) {
 }
 
 function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, quantity: number = 1) {
-  const modifier = getOrInitModifier(unit, id, { isCurse: false, quantity, persistBetweenLevels: false }, () => {
+  const modifier = getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
     // Add event
     unit.onDamageEvents.push(id);
     // Add subsprite image

--- a/src/cards/slow.ts
+++ b/src/cards/slow.ts
@@ -34,7 +34,6 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
   const modifier = getOrInitModifier(unit, id, {
     isCurse: true,
     quantity,
-    persistBetweenLevels: false,
     originalStats: {
       staminaMax,
       moveSpeed

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -63,7 +63,7 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
   const modifier = getOrInitModifier(unit, id, {
     isCurse: true,
     quantity,
-    persistBetweenLevels: false,
+    keepOnDeath: true,
     originalStats: {
       scaleX: unit.image && unit.image.sprite.scale.x || 1,
       scaleY: unit.image && unit.image.sprite.scale.y || 1,
@@ -73,11 +73,8 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
       damage,
       moveSpeed
     }
-  }, () => {
-    if (!unit.onDeathEvents.includes(id)) {
-      unit.onDeathEvents.push(id);
-    }
-  });
+  }, () => { }); //no first time setup
+
   if (modifier.quantity && modifier.quantity >= splitLimit) {
     return;
   }
@@ -198,21 +195,6 @@ const spell: Spell = {
   modifiers: {
     add,
     remove
-  },
-  events: {
-    onDeath: async (unit: Unit.IUnit, underworld: Underworld, prediction: boolean) => {
-      // Note: Split should NOT be permanent for PLAYER_CONTROLLED UNITS
-      if (unit.unitType !== UnitType.PLAYER_CONTROLLED) {
-        // Special case: Remove the 'split' modifier on death
-        // This is because without this, when a unit dies, the automatic
-        // removing of modifiers would cause split's custom remove function to be invoked
-        // which restores the unit's original size and stats.  However, split's stat changes
-        // should become perminant after death.  This prevents resurrecting a split unit from
-        // restoring the units original size and stats which is unexpected behavior and therefore
-        // undesireable.
-        delete unit.modifiers[id];
-      }
-    }
   }
 };
 export default spell;

--- a/src/cards/suffocate.ts
+++ b/src/cards/suffocate.ts
@@ -13,7 +13,7 @@ import { buildMatchMemberExpression } from '@babel/types';
 
 export const suffocateCardId = 'suffocate';
 function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) {
-  const modifier = getOrInitModifier(unit, suffocateCardId, { isCurse: true, quantity, persistBetweenLevels: false }, () => {
+  const modifier = getOrInitModifier(unit, suffocateCardId, { isCurse: true, quantity }, () => {
     // Add event
     if (!unit.onTurnEndEvents.includes(suffocateCardId)) {
       unit.onTurnEndEvents.push(suffocateCardId);

--- a/src/cards/util.ts
+++ b/src/cards/util.ts
@@ -4,18 +4,21 @@ export interface Modifier {
     [key: string]: any;
     isCurse: boolean;
     quantity: number;
+    // If true, the modifier will not be removed from the unit on death 
+    keepOnDeath?: boolean;
     // If true, the modifier will not be removed in resetPlayerForNextLevel 
-    persistBetweenLevels: boolean;
+    keepBetweenLevels?: boolean;
 }
 // Returns the unit's modifier object for a given key
 // Will initialize a modifier if it doesn't currently exist
-export function getOrInitModifier(unit: IUnit, key: string, { isCurse, quantity, persistBetweenLevels, ...rest }: Modifier, firstTimeSetup: () => void): Modifier {
+export function getOrInitModifier(unit: IUnit, key: string, { isCurse, quantity, keepOnDeath = false, keepBetweenLevels = false, ...rest }: Modifier, firstTimeSetup: () => void): Modifier {
     let modifier = unit.modifiers[key];
     if (!modifier) {
         modifier = {
             isCurse,
             quantity: 0,
-            persistBetweenLevels,
+            keepOnDeath,
+            keepBetweenLevels,
             ...rest
         };
         firstTimeSetup();

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -763,7 +763,9 @@ export function die(unit: IUnit, underworld: Underworld, prediction: boolean) {
   // Note: This must come AFTER onDeathEvents or else it will remove the modifier
   // that added the onDeathEvent and the onDeathEvent won't trigger
   for (let [modifier, _modifierProperties] of Object.entries(unit.modifiers)) {
-    removeModifier(unit, modifier, underworld);
+    if (!_modifierProperties.keepOnDeath) {
+      removeModifier(unit, modifier, underworld);
+    }
   }
 
   if (globalThis.player && globalThis.player.unit == unit) {
@@ -1484,7 +1486,7 @@ export function resetUnitStats(unit: IUnit, underworld: Underworld) {
   Object.keys(unit.modifiers).forEach(modifierKey => {
     const modifier = unit.modifiers[modifierKey];
     if (modifier) {
-      if (!modifier.persistBetweenLevels) {
+      if (!modifier.keepBetweenLevels) {
         removeModifier(unit, modifierKey, underworld);
       }
     }

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -762,8 +762,8 @@ export function die(unit: IUnit, underworld: Underworld, prediction: boolean) {
   // Remove all modifiers
   // Note: This must come AFTER onDeathEvents or else it will remove the modifier
   // that added the onDeathEvent and the onDeathEvent won't trigger
-  for (let [modifier, _modifierProperties] of Object.entries(unit.modifiers)) {
-    if (!_modifierProperties.keepOnDeath) {
+  for (let [modifier, modifierProperties] of Object.entries(unit.modifiers)) {
+    if (!modifierProperties.keepOnDeath) {
       removeModifier(unit, modifier, underworld);
     }
   }

--- a/src/entity/units/vampire.ts
+++ b/src/entity/units/vampire.ts
@@ -41,6 +41,10 @@ const unit: UnitSource = {
   },
   init: (unit: Unit.IUnit, underworld: Underworld) => {
     Unit.addModifier(unit, blood_curse.id, underworld, false);
+    //vampire has innate blood curse property, and keeps it on death 
+    if (unit.modifiers[blood_curse.id]) {
+      unit.modifiers[blood_curse.id].keepOnDeath = true;
+    }
     if (unit.image && unit.image.sprite && unit.image.sprite.filters) {
       unit.image.sprite.filters.push(
         new MultiColorReplaceFilter(

--- a/src/modifierCorpseDecay.ts
+++ b/src/modifierCorpseDecay.ts
@@ -10,7 +10,7 @@ export const corpseDecayId = 'Corpse Decay';
 export default function registerCorpseDecay() {
     registerModifiers(corpseDecayId, {
         add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
-            const modifier = getOrInitModifier(unit, corpseDecayId, { isCurse: true, quantity, persistBetweenLevels: false }, () => {
+            const modifier = getOrInitModifier(unit, corpseDecayId, { isCurse: true, quantity }, () => {
                 // Add event
                 if (!unit.onTurnEndEvents.includes(corpseDecayId)) {
                     unit.onTurnEndEvents.push(corpseDecayId);

--- a/src/modifierImpendingDoom.ts
+++ b/src/modifierImpendingDoom.ts
@@ -10,7 +10,7 @@ export const impendingDoomId = 'impendingDoom';
 export default function registerSummoningSickness() {
   registerModifiers(impendingDoomId, {
     add: (unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, quantity: number = 1) => {
-      getOrInitModifier(unit, impendingDoomId, { isCurse: true, quantity, persistBetweenLevels: false }, () => {
+      getOrInitModifier(unit, impendingDoomId, { isCurse: true, quantity }, () => {
         if (!unit.onTurnEndEvents.includes(impendingDoomId)) {
           unit.onTurnEndEvents.push(impendingDoomId);
         }

--- a/src/modifierSummoningSickness.ts
+++ b/src/modifierSummoningSickness.ts
@@ -16,7 +16,7 @@ export default function registerSummoningSickness() {
                 console.log('Prevented adding summoning sickness to player unit')
                 return
             }
-            getOrInitModifier(unit, summoningSicknessId, { isCurse: true, quantity, persistBetweenLevels: false }, () => {
+            getOrInitModifier(unit, summoningSicknessId, { isCurse: true, quantity }, () => {
                 // Immediately set stamina to 0 so they can't move
                 unit.stamina = 0;
                 // Add event


### PR DESCRIPTION
Closes #137 
- Modifiers now have an optional keep on death property (currently used for split and innate vampire blood curse)

Closes #135 
- Split isn't removed on death

QA - Singleplayer

I needed to merge #131 from master to make sure #135 was fixed, since I made this branch earlier. I don't merge often, so you may want to double check that I didn't break anything, lol. 