### PR TITLE
Class-Specific Spells

### DIFF
--- a/docs/Design Docs/Class-Specific Spells.md
+++ b/docs/Design Docs/Class-Specific Spells.md
@@ -1,0 +1,53 @@
+TODO: Fill this out, for now it will store my ideas
+
+Class-Specific Spells! Upgrades that you can only get as a character of the class
+Maybe they should have a 100% probability of at least one showing up in level up choice
+
+At the very least, implement one spell for each class to come with the initial PR
+For existing class-types
+
+Cleric:
+Regenerate
+Heal 5 hit points for every stack of the regenerate effect, stack decreases by 1 every round
+Implementation: Use an effect for regenerate
+
+Necromancer:
+
+Dark bolt
+Send a bolt of necromantic damage to an enemy, heal 50% of that damage, damage similar to an unupgraded arrow, helps with the health costs of raising dead
+Implementation: Use a spell card is fine
+
+Hex
+Pairs well with decoy, enemy takes damage equal to the damage they deal for rounds equal to the stacks of the spell
+
+Far-Gazer:
+Sniping Stance
+Adds % damage to first hit of the next attack equal to stamina expended / 10, encourages you to stay still, removes cap from Long Arrow/Shot/Whatever that spell is called
+Implementation: Probably another effect, expires after a turn, listens for damage somehow. May be kinda hard to implement
+
+Archer:
+Pinning Shots
+Any enemies hit by attacks with this modifier have their stamina reduced to 0 for a round
+
+
+Witch:
+Voodoo Doll
+Deal half the damage dealt to this enemy once the effect expires, stacks increase how many turns the cumulative damage is stored for
+
+Glacial Freeze [Freeze Upgrade]
+Deals damage while frozen equal to number of curses * 10/max mana capped to max mana, increases vulnerability by 50%
+
+Complex Bloat [Bloat Upgrade]
+Can store a single spell in Complex Bloat by casting it before Bloat [Mainly for vortex], the spell is ignored when cast
+Implementation: May be really hard to implement, if so maybe cut it for now
+
+Gambler:
+Roll The Dice
+Randomly modify the damage of the next spell combo by anywhere between 50% and 200%
+
+Lucky Shot
+Ranged attack that deals variable damage, has a chance to ricochet to a nearby enemy
+
+Shuffle The Cards
+Randomize the targets health, mana and stamina (max health may turn into max stamina, max stamina may turn to max health etc)
+Implementation: Store current values and make sure they remain consistent after shuffling, you don't want to instakill someone because they had 0 stamina and their health turned to stamina

--- a/docs/Design Docs/Class-Specific Spells.md
+++ b/docs/Design Docs/Class-Specific Spells.md
@@ -6,48 +6,48 @@ Maybe they should have a 100% probability of at least one showing up in level up
 At the very least, implement one spell for each class to come with the initial PR
 For existing class-types
 
-Cleric:
-Regenerate
+# Cleric:
+## Regenerate
 Heal 5 hit points for every stack of the regenerate effect, stack decreases by 1 every round
 Implementation: Use an effect for regenerate
 
-Necromancer:
+# Necromancer:
 
-Dark bolt
+## Dark bolt
 Send a bolt of necromantic damage to an enemy, heal 50% of that damage, damage similar to an unupgraded arrow, helps with the health costs of raising dead
 Implementation: Use a spell card is fine
 
-Hex
+## Hex
 Pairs well with decoy, enemy takes damage equal to the damage they deal for rounds equal to the stacks of the spell
 
-Far-Gazer:
-Sniping Stance
+# Far-Gazer:
+## Sniping Stance
 Adds % damage to first hit of the next attack equal to stamina expended / 10, encourages you to stay still, removes cap from Long Arrow/Shot/Whatever that spell is called
 Implementation: Probably another effect, expires after a turn, listens for damage somehow. May be kinda hard to implement
 
-Archer:
-Pinning Shots
+# Archer:
+## Pinning Shots
 Any enemies hit by attacks with this modifier have their stamina reduced to 0 for a round
 
 
-Witch:
-Voodoo Doll
+# Witch:
+## Voodoo Doll
 Deal half the damage dealt to this enemy once the effect expires, stacks increase how many turns the cumulative damage is stored for
 
-Glacial Freeze [Freeze Upgrade]
+## Glacial Freeze [Freeze Upgrade]
 Deals damage while frozen equal to number of curses * 10/max mana capped to max mana, increases vulnerability by 50%
 
-Complex Bloat [Bloat Upgrade]
+## Complex Bloat [Bloat Upgrade]
 Can store a single spell in Complex Bloat by casting it before Bloat [Mainly for vortex], the spell is ignored when cast
 Implementation: May be really hard to implement, if so maybe cut it for now
 
-Gambler:
-Roll The Dice
+# Gambler:
+## Roll The Dice
 Randomly modify the damage of the next spell combo by anywhere between 50% and 200%
 
-Lucky Shot
+## Lucky Shot
 Ranged attack that deals variable damage, has a chance to ricochet to a nearby enemy
 
-Shuffle The Cards
+## Shuffle The Cards
 Randomize the targets health, mana and stamina (max health may turn into max stamina, max stamina may turn to max health etc)
 Implementation: Store current values and make sure they remain consistent after shuffling, you don't want to instakill someone because they had 0 stamina and their health turned to stamina

--- a/public/localization/localization.json
+++ b/public/localization/localization.json
@@ -249,6 +249,7 @@
         "explain cast": "<h1>How to Forge Spells!</h1>Click on a spell or use its keyboard hotkey to queue it up. Left click on a target to unleash the queued spell.<br/><br/>Or if you change your mind, press 🍞 to clear a queued spell.",
         "explain move": "<h1>How to Move</h1>Hold right mouse button to walk towards your cursor.",
         "spell_heal": "Heals all targets for 🍞.❕Will not heal beyond maximum health.❕Stackable.",
+        "spell_regenerate": "Regenerate 30 hit points for 🍞.❕ turns Stacks increase duration. ",
         "spell_arrow": "Fires an arrow that deals 🍞 damage to the first unit that it strikes.❕Cannot pass through walls.",
         "spell_bleed": "Deals more damage based on how much health the target is missing.❕❕ For example:❕Target with 🍞% health will die.❕🍞% health: 🍞% of max health as damage❕Target with full health will take no damage.❕",
         "spell_bloat": "When a unit cursed with 🍞 dies, it will explode dealing 🍞 damage to all units within the explosion radius.❕Multiple stacks of 🍞 will increase the amount of damage done when the unit explodes.",

--- a/public/localization/localization.json
+++ b/public/localization/localization.json
@@ -249,7 +249,7 @@
         "explain cast": "<h1>How to Forge Spells!</h1>Click on a spell or use its keyboard hotkey to queue it up. Left click on a target to unleash the queued spell.<br/><br/>Or if you change your mind, press 🍞 to clear a queued spell.",
         "explain move": "<h1>How to Move</h1>Hold right mouse button to walk towards your cursor.",
         "spell_heal": "Heals all targets for 🍞.❕Will not heal beyond maximum health.❕Stackable.",
-        "spell_regenerate": "Regenerate 30 hit points for 🍞.❕ turns Stacks increase duration. ",
+        "spell_regenerate": "Regenerate 30 hit points for 🍞 turns ❕ Stacks increase duration. ",
         "spell_arrow": "Fires an arrow that deals 🍞 damage to the first unit that it strikes.❕Cannot pass through walls.",
         "spell_bleed": "Deals more damage based on how much health the target is missing.❕❕ For example:❕Target with 🍞% health will die.❕🍞% health: 🍞% of max health as damage❕Target with full health will take no damage.❕",
         "spell_bloat": "When a unit cursed with 🍞 dies, it will explode dealing 🍞 damage to all units within the explosion radius.❕Multiple stacks of 🍞 will increase the amount of damage done when the unit explodes.",

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -21,6 +21,7 @@ import bleed from './bleed';
 import heal from './add_heal';
 import heal_greater from './heal_greater';
 import heal_mass from './heal_mass';
+import regenerate from './regenerate';
 import send_mana from './send_mana';
 import target_circle from './target_circle';
 import connect from './connect';
@@ -207,6 +208,7 @@ export function registerCards(overworld: Overworld) {
   registerSpell(heal, overworld);
   registerSpell(heal_greater, overworld);
   registerSpell(heal_mass, overworld);
+  registerSpell(regenerate, overworld)
   registerSpell(send_mana, overworld);
   registerSpell(shield, overworld);
   registerSpell(fortify, overworld);
@@ -333,6 +335,7 @@ function cardToUpgrade(c: ICard, overworld: Overworld): IUpgrade {
     modName: c.modName,
     type: 'card',
     cardCategory: c.category,
+    mageTypes: c.mageTypes,
     description: () => i18n(c.description).trim(),
     thumbnail,
     maxCopies: 1,

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -447,6 +447,7 @@ export interface ICard {
   category: CardCategory;
   manaCost: number;
   healthCost: number;
+  mageTypes?: Player.MageType[];
   probability: number;
   thumbnail: string;
   // The path for the animation effect when the spell is cast

--- a/src/cards/regenerate.ts
+++ b/src/cards/regenerate.ts
@@ -1,0 +1,90 @@
+import * as Unit from '../entity/Unit';
+import * as Image from '../graphics/Image';
+import * as Pickup from '../entity/Pickup';
+import { Spell, refundLastSpell } from './index';
+import { CardCategory, UnitType } from '../types/commonTypes';
+import * as config from '../config'
+import type Underworld from '../Underworld';
+import { playDefaultSpellAnimation, playDefaultSpellSFX } from './cardUtils';
+import { CardRarity, probabilityMap } from '../types/commonTypes';
+import { getOrInitModifier } from './util';
+
+export const id = 'regenerate';
+const imageName = 'spellIconHeal.png';
+var regenLen = 1;
+const spell: Spell = {
+    card: {
+        id,
+        category: CardCategory.Blessings,
+        sfx: 'heal',
+        supportQuantity: true,
+        manaCost: 25,
+        healthCost: 0,
+        cooldown: 2,
+        expenseScaling: 3,
+        mageTypes: ['Cleric'],
+        probability: probabilityMap[CardRarity.COMMON],
+        thumbnail: 'spellIconHeal.png',
+        animationPath: 'spell-effects/potionPickup',
+        description: ['spell_regenerate', regenLen.toString()],
+        effect: async (state, card, quantity, underworld, prediction) => {
+            // .filter: only target living units
+            regenLen = quantity;
+            const targets = state.targetedUnits.filter(u => u.alive);
+            if (targets.length) {
+                let spellAnimationPromise = Promise.resolve();
+                targets.forEach(t => {
+                    spellAnimationPromise = Image.addOneOffAnimation(t, 'spell-effects/potionPickup', {}, { loop: false, animationSpeed: 0.3 });
+                })
+                await Promise.all([spellAnimationPromise, playDefaultSpellSFX(card, prediction)]);
+                for (let unit of targets) {
+                    Unit.addModifier(unit, id, underworld, prediction, quantity);
+                }
+            } else {
+                refundLastSpell(state, prediction);
+            }
+            return state;
+        },
+    },
+    modifiers: {
+        add,
+        subsprite: {
+            imageName,
+            alpha: 1.0,
+            anchor: {
+                x: 0.5,
+                y: 0.5,
+            },
+            scale: {
+                x: 1,
+                y: 1,
+            },
+        },
+    },
+    events: {
+        onTurnEnd: async (unit: Unit.IUnit, prediction: boolean, underworld: Underworld) => {
+            // Decrement how many turns left the unit is frozen
+            const modifier = unit.modifiers[id];
+            if (modifier) {
+                if (modifier.quantity > 0) {
+                    Unit.takeDamage(unit, 30, undefined, underworld, prediction);
+                }
+                modifier.quantity--;
+            }
+        },
+    },
+};
+
+function add(unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, quantity: number = 1) {
+    getOrInitModifier(unit, id, { isCurse: true, quantity }, () => {
+        // Add event
+        if (!unit.onTurnEndEvents.includes(id)) {
+            unit.onTurnEndEvents.push(id);
+        }
+
+        // Add subsprite image
+        Image.addSubSprite(unit.image, imageName);
+    });
+}
+
+export default spell;


### PR DESCRIPTION
Make mage types feel more unique by offering spells that are only offered if you belong to the certain magetype, currently a draft as its not complete but I wanted to put up a PR to gauge approval and see if there are any thoughts about the idea, inside the PR is a design document with a few ideas floating around for each class type, implemented so far is the Regenerate spell for clerics that allows you to apply a regenerating effect on a target to heal 30 hit points, stackable for extending the duration, a powerful healing option that could synergize well with a necromancer or summons that helps keep them topped up, but useless if you're killed

If the idea is well-received, the goal would be to get in at least one class-specific spell with this PR

# Implemented

# Cleric
## Regenerate
Heal 30 hit points each round, stackable to increase duration
Implementation: Use an effect for regenerate
![image](https://github.com/jdoleary/Spellmasons/assets/30060146/ce04e7c0-a178-45c6-a467-e26987748281)
Reused heal art, would probably want to get a different icon before this is implemented

# Ideas

# Necromancer

## Dark bolt
Send a bolt of necromantic damage to an enemy, heal 50% of that damage, damage similar to an unupgraded arrow, helps with the health costs of raising dead
Implementation: Use a spell card is fine

## Hex
Pairs well with decoy, enemy takes damage equal to the damage they deal for rounds equal to the stacks of the spell

# Far-Gazer
## Sniping Stance
Adds % damage to first hit of the next attack equal to stamina expended / 10, encourages you to stay still, removes cap from Long Arrow/Shot/Whatever that spell is called
Implementation: Probably another effect, expires after a turn, listens for damage somehow. May be kinda hard to implement

# Archer
## Pinning Shots
Any enemies hit by attacks with this modifier have their stamina reduced to 0 for a round


# Witch
## Voodoo Doll
Deal half the damage dealt to this enemy once the effect expires, stacks increase how many turns the cumulative damage is stored for

## Glacial Freeze [Freeze Upgrade]
Deals damage while frozen equal to (number of curses * 10/max mana). 
capped to max mana, increases vulnerability by 50%

## Complex Bloat [Bloat Upgrade]
Can store a single spell in Complex Bloat by casting it before Bloat [Mainly for vortex], the spell is ignored when initially cast
Implementation: May be really hard to implement, if so maybe cut it for now

# Gambler
## Roll The Dice
Randomly modify the damage of the next spell combo by anywhere between 50% and 200%

## Lucky Shot
Ranged attack that deals variable damage, has a chance to ricochet to a nearby enemy

## Shuffle The Cards
Randomize the targets health, mana and stamina (max health may turn into max stamina, max stamina may turn to max health etc)
Implementation: Store current values and make sure they remain consistent after shuffling, you don't want to instakill someone because they had 0 stamina and their health turned to stamina