### PR TITLE
Bug fixes

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -992,7 +992,7 @@ export default class Underworld {
     // Note: this block must come after updating the camera position
     for (let marker of globalThis.attentionMarkers) {
       // Draw Attention Icon to show the enemy will hurt you next turn
-      drawUnitMarker(marker.imagePath, marker.pos, marker.scale);
+      drawUnitMarker(marker.imagePath, marker.pos, marker.unitSpriteScaleY, marker.markerScale);
     }
   }
   drawPlayerThoughts() {

--- a/src/cards/blood_curse.ts
+++ b/src/cards/blood_curse.ts
@@ -8,6 +8,7 @@ import { CardCategory } from '../types/commonTypes';
 import floatingText from '../graphics/FloatingText';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { getOrInitModifier } from './util';
+import { suffocateCardId, updateSuffocate } from './suffocate';
 
 export const id = 'Blood Curse';
 export function hasBloodCurse(unit: IUnit): boolean {
@@ -35,9 +36,13 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean) {
   if (!prediction) {
     updateTooltip(unit);
   }
-}
-function remove(unit: IUnit, underworld: Underworld) {
 
+  if (unit.modifiers[suffocateCardId]) {
+    updateSuffocate(unit, underworld, prediction);
+  }
+}
+
+function remove(unit: IUnit, underworld: Underworld) {
   unit.health /= healthMultiplier;
   unit.health = Math.round(unit.health);
   unit.healthMax /= healthMultiplier;

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -8,6 +8,7 @@ import { animateMitosis } from './clone';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { getOrInitModifier } from './util';
 import { isPickup } from '../entity/Pickup';
+import { suffocateCardId, updateSuffocate } from './suffocate';
 
 const id = 'split';
 const splitLimit = 3;
@@ -96,6 +97,10 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
     changeStatWithCap(unit, 'staminaMax', addMultiplier);
     changeStatWithCap(unit, 'damage', addMultiplier);
     unit.moveSpeed *= addMultiplier;
+  }
+
+  if (unit.modifiers[suffocateCardId]) {
+    updateSuffocate(unit, underworld, prediction);
   }
 }
 const spell: Spell = {

--- a/src/cards/suffocate.ts
+++ b/src/cards/suffocate.ts
@@ -42,6 +42,16 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
   }
 }
 
+export function getSuffocateBuildup(unit: Unit.IUnit): number {
+  const modifier = unit.modifiers[suffocateCardId];
+  if (!modifier) {
+    console.warn("Checking for suffocate buildup when the Unit does not have suffocate");
+    return 0;
+  }
+
+  return modifier.buildup;
+}
+
 // Will kill the unit if buildup > current health, else will update the tooltip
 // returns true if the unit is killed
 export function updateSuffocate(unit: Unit.IUnit, underworld: Underworld, prediction: boolean): boolean {

--- a/src/cards/suffocate.ts
+++ b/src/cards/suffocate.ts
@@ -30,6 +30,27 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
   // Buildup doubles every 2 stacks until > hp, then unit dies
   modifier.buildup = Math.floor(10 * Math.pow(2, (modifier.quantity - 1) / 2));
 
+  // returns true if it kills the unit
+  if (updateSuffocate(unit, underworld, prediction)) {
+    // nothing to do here
+  }
+  else if (!prediction) {
+    // Show that suffocate was added to the unit
+    // Temporarily use floating text until spell animation is finished
+    floatingText({ coords: unit, text: suffocateCardId });
+    updateTooltip(unit);
+  }
+}
+
+// Will kill the unit if buildup > current health, else will update the tooltip
+// returns true if the unit is killed
+export function updateSuffocate(unit: Unit.IUnit, underworld: Underworld, prediction: boolean): boolean {
+  const modifier = unit.modifiers[suffocateCardId];
+  if (!modifier) {
+    console.warn("Checking for suffocate buildup when the Unit does not have suffocate");
+    return false;
+  }
+  //if the buildup of suffocate is greater than unit's health, kill it and make floating text
   if (modifier.buildup >= unit.health) {
     Unit.die(unit, underworld, prediction);
     if (!prediction) {
@@ -38,17 +59,22 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
         style: { fill: colors.healthRed },
       });
     }
+    return true;
   }
-  else if (!prediction) {
-    // Temporarily use floating text until spell animation is finished
-    floatingText({ coords: unit, text: suffocateCardId });
-    updateTooltip(unit);
-  }
+
+  updateTooltip(unit);
+
+  return false;
 }
+
 export function updateTooltip(unit: Unit.IUnit) {
-  if (unit.modifiers[suffocateCardId]) {
+  const modifier = unit.modifiers[suffocateCardId];
+  if (modifier) {
+    // calculate turns until suffocation
+    const turnsUntilSuffocation = Math.ceil(2 * Math.log2(unit.health / 10) + 1) - modifier.quantity;
+
     // Set tooltip:
-    unit.modifiers[suffocateCardId].tooltip = `Suffocate ${unit.modifiers[suffocateCardId].quantity} | ${unit.modifiers[suffocateCardId].buildup} damage`
+    modifier.tooltip = `${turnsUntilSuffocation} Turns until suffocation`
   }
 }
 

--- a/src/cards/summon_generic.ts
+++ b/src/cards/summon_generic.ts
@@ -190,11 +190,6 @@ ${manaMax ? `🔵 ${manaMax} + ${unitSource.unitProps.manaPerTurn} ${i18n('Mana'
                         underworld,
                         prediction
                     );
-                    if (unit.image) {
-                        const quantityScaleModifier = 1 + 0.3 * (quantity - 1);
-                        unit.image.sprite.scale.x = unit.image.sprite.scale.x * quantityScaleModifier;
-                        unit.image.sprite.scale.y = unit.image.sprite.scale.y * quantityScaleModifier;
-                    }
 
                     addUnitTarget(unit, state);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,8 +21,8 @@ export const UNIT_SIZE_RADIUS = 50 / 2;
 export const SELECTABLE_RADIUS = 36;
 
 export const HEALTH_BAR_UI_Y_POS = 30;
-export const UNIT_UI_BAR_HEIGHT = 5;
-export const UNIT_UI_BAR_WIDTH = 34;
+export const UNIT_UI_BAR_HEIGHT = 6;
+export const UNIT_UI_BAR_WIDTH = 36;
 
 export const LOB_PROJECTILE_SPEED = 600; // in millis
 export const UNIT_SIZE = COLLISION_MESH_RADIUS * 2;

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -103,12 +103,6 @@ export type IUnit = HasSpace & HasLife & HasMana & HasStamina & {
   attackRange: number;
   name?: string;
   isMiniboss: boolean;
-  // A copy of the units current scale for the prediction copy
-  // prediction copies do not have an image property, so this property is saved here
-  // so that it may be accessed without making prediction units have a partial Image property
-  // (prediction units are known to not have an image, this shall not change, other parts of the code
-  // depends on this expectation)
-  predictionScale?: number;
   // Denotes that this is a prediction copy of a unit
   isPrediction?: boolean;
   faction: Faction;
@@ -1369,7 +1363,6 @@ export function copyForPredictionUnit(u: IUnit, underworld: Underworld): IUnit {
   return {
     ...rest,
     isPrediction: true,
-    image: image,
     // prediction units INTENTIONALLY share a reference to the original
     // unit's path so that we can get the efficiency gains of
     // cached paths per unit.  If we made a deep copy instead, the

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1369,9 +1369,7 @@ export function copyForPredictionUnit(u: IUnit, underworld: Underworld): IUnit {
   return {
     ...rest,
     isPrediction: true,
-    // A copy of the units y scale just for the prediction unit so that it will know
-    // how high up to display the attentionMarker
-    predictionScale: image?.sprite.scale.y,
+    image: image,
     // prediction units INTENTIONALLY share a reference to the original
     // unit's path so that we can get the efficiency gains of
     // cached paths per unit.  If we made a deep copy instead, the

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -379,7 +379,7 @@ export function removeModifier(unit: IUnit, key: string, underworld: Underworld)
   unit.onAgroEvents = unit.onAgroEvents.filter((e) => e !== key);
   unit.onTurnStartEvents = unit.onTurnStartEvents.filter((e) => e !== key);
   unit.onTurnEndEvents = unit.onTurnEndEvents.filter((e) => e !== key);
-  unit.onDrawSelectedEvents = unit.onTurnEndEvents.filter((e) => e !== key);
+  unit.onDrawSelectedEvents = unit.onDrawSelectedEvents.filter((e) => e !== key);
   delete unit.modifiers[key];
 
 }

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -43,6 +43,7 @@ import { skyBeam } from '../VisualEffects';
 import seedrandom from 'seedrandom';
 import { summoningSicknessId } from '../modifierSummoningSickness';
 import * as log from '../log';
+import { suffocateCardId, updateSuffocate } from '../cards/suffocate';
 
 const elCautionBox = document.querySelector('#caution-box') as HTMLElement;
 const elCautionBoxText = document.querySelector('#caution-box-text') as HTMLElement;
@@ -944,6 +945,10 @@ export function takeDamage(unit: IUnit, amount: number, damageFromVec2: Vec2 | u
   // If taking damage (not healing) and health is 0 or less...
   if (amount > 0 && unit.health <= 0) {
     die(unit, underworld, prediction);
+  }
+
+  if (unit.modifiers[suffocateCardId]) {
+    updateSuffocate(unit, underworld, prediction);
   }
 
   if (unit.id == globalThis.player?.unit.id && !prediction) {

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -105,6 +105,8 @@ export type IUnit = HasSpace & HasLife & HasMana & HasStamina & {
   isMiniboss: boolean;
   // Denotes that this is a prediction copy of a unit
   isPrediction?: boolean;
+  // For attention markers
+  predictionScale?: number;
   faction: Faction;
   UITargetCircleOffsetY: number;
   defaultImagePath: string;
@@ -1363,6 +1365,12 @@ export function copyForPredictionUnit(u: IUnit, underworld: Underworld): IUnit {
   return {
     ...rest,
     isPrediction: true,
+    // A copy of the units current scale for the prediction copy
+    // prediction copies do not have an image property, so this property is saved here
+    // so that it may be accessed without making prediction units have a partial Image property
+    // (prediction units are known to not have an image, this shall not change, other parts of the code
+    // depends on this expectation)
+    predictionScale: image?.sprite.scale.y,
     // prediction units INTENTIONALLY share a reference to the original
     // unit's path so that we can get the efficiency gains of
     // cached paths per unit.  If we made a deep copy instead, the

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -311,13 +311,13 @@ export function adjustUnitDifficulty(unit: IUnit, difficulty: number) {
     unit.damage = Math.round(unit.damage * quantityStatModifier);
 
     if (unit.image) {
-      // this final scale of the unit will always be less than the
-      const maxMultiplier = config.UNIT_MINIBOSS_SCALE_MULTIPLIER;
+      // this final scale of the unit will always be less than the max multiplier
+      const maxMultiplier = 4;
       // ensures scale = 1 at strength = 1
       const strAdj = unit.strength - 1;
       // calculate scale multiplier with diminishing formula
       // 11 is an arbitrary number that controls the speed at which the scale approaches the max
-      const quantityScaleModifier = 1 + (maxMultiplier - 1) * (strAdj / (strAdj + 11));
+      const quantityScaleModifier = 1 + (maxMultiplier - 1) * (strAdj / (strAdj + 6));
       unit.image.sprite.scale.x *= quantityScaleModifier;
       unit.image.sprite.scale.y *= quantityScaleModifier;
     }

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -23,6 +23,7 @@ import { inPortal } from '../entity/Player';
 import { getPerkText } from '../Perk';
 import { View } from '../views';
 import { gripthulu_id } from '../entity/units/gripthulu';
+import { getSuffocateBuildup, suffocateCardId } from '../cards/suffocate';
 
 const TEXT_OUT_OF_RANGE = 'Out of Range';
 // Graphics for rendering above board and walls but beneath units and doodads,
@@ -351,7 +352,7 @@ export function drawHealthBarAboveHead(unitIndex: number, underworld: Underworld
         globalThis.unitOverlayGraphics.drawRect(
           healthBarFill.x,
           // Stack the health bar above the mana bar
-          healthBarFill.y - config.UNIT_UI_BAR_HEIGHT / zoom,
+          healthBarFill.y - healthBarFill.height,
           healthBarFill.width,
           healthBarFill.height
         );
@@ -362,7 +363,7 @@ export function drawHealthBarAboveHead(unitIndex: number, underworld: Underworld
         globalThis.unitOverlayGraphics.drawRect(
           healthBarFill.x,
           // Stack the health bar above the mana bar
-          healthBarFill.y - config.UNIT_UI_BAR_HEIGHT / zoom,
+          healthBarFill.y - healthBarFill.height,
           healthBarFill.width,
           healthBarFill.height
         );
@@ -384,7 +385,7 @@ export function drawHealthBarAboveHead(unitIndex: number, underworld: Underworld
             globalThis.unitOverlayGraphics.drawRect(
               healthBarFill.x,
               // Stack the health bar above the mana bar
-              healthBarFill.y - config.UNIT_UI_BAR_HEIGHT / zoom,
+              healthBarFill.y - healthBarFill.height,
               healthBarFill.width,
               healthBarFill.height);
 
@@ -398,6 +399,22 @@ export function drawHealthBarAboveHead(unitIndex: number, underworld: Underworld
               }
             }
           }
+        }
+
+        // draw suffocate bar over hp
+        if (predictionUnit?.modifiers[suffocateCardId]) {
+          const buildup = getSuffocateBuildup(predictionUnit);
+
+          healthBarFill = getFillRect(u, 0, healthBarMax, 0, buildup, zoom);
+          globalThis.unitOverlayGraphics.lineStyle(0, 0x000000, 1.0);
+          globalThis.unitOverlayGraphics.beginFill(0x440088, 1);
+          globalThis.unitOverlayGraphics.drawRect(
+            healthBarFill.x,
+            // Stack the health bar over hp
+            healthBarFill.y - healthBarFill.height,
+            healthBarFill.width,
+            healthBarFill.height
+          );
         }
       }
 

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -625,7 +625,9 @@ export async function runPredictions(underworld: Underworld) {
             if (unitSource) {
               const targets = unitSource.getUnitAttackTargets(u, underworld);
               if (targets.length) {
-                globalThis.attentionMarkers.push({ imagePath: Unit.subTypeToAttentionMarkerImage(u), pos: clone(u), unitSpriteScaleY: u.image?.sprite.scale.y || 1, markerScale: 1 });
+                // use u.predictionScale here since we are dealing with prediction units
+                // prediction units don't have images, and thus sprite.scale.y
+                globalThis.attentionMarkers.push({ imagePath: Unit.subTypeToAttentionMarkerImage(u), pos: clone(u), unitSpriteScaleY: u.predictionScale || 1, markerScale: 1 });
               }
             }
           } else {
@@ -640,7 +642,9 @@ export async function runPredictions(underworld: Underworld) {
                   const canAttack = underworld.canUnitAttackTarget(u, target);
                   underworld.incrementTargetsNextTurnDamage(targets, u.damage, canAttack);
                   if (target === globalThis.player.unit && canAttack) {
-                    globalThis.attentionMarkers.push({ imagePath: Unit.subTypeToAttentionMarkerImage(u), pos: clone(u), unitSpriteScaleY: u.image?.sprite.scale.y || 1, markerScale: 1 });
+                    // use u.predictionScale here since we are dealing with prediction units
+                    // prediction units don't have images, and thus sprite.scale.y
+                    globalThis.attentionMarkers.push({ imagePath: Unit.subTypeToAttentionMarkerImage(u), pos: clone(u), unitSpriteScaleY: u.predictionScale || 1, markerScale: 1 });
                   }
                 }
               }

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -391,10 +391,10 @@ export function drawHealthBarAboveHead(unitIndex: number, underworld: Underworld
             // Display a death marker if a unit is currently alive, but wont be after cast
             if (u.alive && !predictionUnit.alive) {
               if (globalThis.player && u.faction === globalThis.player.unit.faction) {
-                drawUnitMarker('badgeDeathAlly.png', u, 2)
+                drawUnitMarker('badgeDeathAlly.png', u, u.image?.sprite.scale.y, 2)
               }
               else {
-                drawUnitMarker('badgeDeath.png', u, 1.5)
+                drawUnitMarker('badgeDeath.png', u, u.image?.sprite.scale.y, 1.5)
               }
             }
           }
@@ -474,20 +474,20 @@ export function getFillRect(unit: Unit.IUnit, min: number, max: number, value1: 
   }
 }
 
-export function drawUnitMarker(imagePath: string, pos: Vec2, extraScale: number = 1) {
+export function drawUnitMarker(imagePath: string, pos: Vec2, unitYScale: number = 1, extraMarkerScale: number = 1) {
   const zoom = getCamera().zoom;
   // 1/zoom keeps the attention marker the same size regardless of the level of zoom
   // Math.sin makes the attention marker swell and shink so it grabs the player's attention
   // + 1 makes it go from 0 to 2 instead of -1 to 1
   // / 8 limits the change in size
-  const markerScale = ((1 / zoom) + (Math.sin(Date.now() / 500) + 1) / 8) * extraScale;
+  const markerScale = ((1 / zoom) + (Math.sin(Date.now() / 500) + 1) / 8) * extraMarkerScale;
   const markerHeightHalf = 16 * markerScale;
   const markerMarginAboveHealthBar = 10;
 
   // Offset marker just above the head of the unit, where pos = unit positon
   const markerPosition = withinCameraBounds({
     x: pos.x, y: pos.y
-      - config.HEALTH_BAR_UI_Y_POS * extraScale
+      - config.HEALTH_BAR_UI_Y_POS * unitYScale
       - config.UNIT_UI_BAR_HEIGHT / zoom
       - markerHeightHalf
       - markerMarginAboveHealthBar / zoom
@@ -608,7 +608,7 @@ export async function runPredictions(underworld: Underworld) {
             if (unitSource) {
               const targets = unitSource.getUnitAttackTargets(u, underworld);
               if (targets.length) {
-                globalThis.attentionMarkers.push({ imagePath: Unit.subTypeToAttentionMarkerImage(u), pos: clone(u), scale: u.predictionScale || 1 });
+                globalThis.attentionMarkers.push({ imagePath: Unit.subTypeToAttentionMarkerImage(u), pos: clone(u), unitSpriteScaleY: u.image?.sprite.scale.y || 1, markerScale: 1 });
               }
             }
           } else {
@@ -623,7 +623,7 @@ export async function runPredictions(underworld: Underworld) {
                   const canAttack = underworld.canUnitAttackTarget(u, target);
                   underworld.incrementTargetsNextTurnDamage(targets, u.damage, canAttack);
                   if (target === globalThis.player.unit && canAttack) {
-                    globalThis.attentionMarkers.push({ imagePath: Unit.subTypeToAttentionMarkerImage(u), pos: clone(u), scale: u.predictionScale || 1 });
+                    globalThis.attentionMarkers.push({ imagePath: Unit.subTypeToAttentionMarkerImage(u), pos: clone(u), unitSpriteScaleY: u.image?.sprite.scale.y || 1, markerScale: 1 });
                   }
                 }
               }

--- a/src/types/globalTypesHeadless.d.ts
+++ b/src/types/globalTypesHeadless.d.ts
@@ -177,8 +177,8 @@ declare global {
     // set to true once superMe is used
     var isSuperMe: undefined | boolean;
     // Shows icons above the heads of enemies who will damage you next turn
-    // scale is the scale of the unit.  Larger units need their marker positioned higher
-    var attentionMarkers: undefined | { imagePath: string, pos: Vec2, scale: number }[];
+    // Larger units need their marker positioned higher, which is why we need scaleY
+    var attentionMarkers: undefined | { imagePath: string, pos: Vec2, unitSpriteScaleY: number, markerScale: number }[];
     // Shows icon for units that will be successfully resurrected
     var resMarkers: undefined | Vec2[];
     // True if client player has casted this turn;

--- a/src/types/globalTypesMain.d.ts
+++ b/src/types/globalTypesMain.d.ts
@@ -111,8 +111,8 @@ declare global {
     // set to true once superMe is used
     var isSuperMe: undefined | boolean;
     // Shows icons above the heads of enemies who will damage you next turn
-    // scale is the scale of the unit.  Larger units need their marker positioned higher
-    var attentionMarkers: undefined | { imagePath: string, pos: Vec2, unitSpriteScaleY: number, markerScale: number = 1 }[];
+    // Larger units need their marker positioned higher, which is why we need scaleY
+    var attentionMarkers: undefined | { imagePath: string, pos: Vec2, unitSpriteScaleY: number, markerScale: number }[];
     // Shows icon for units that will be successfully resurrected
     var resMarkers: undefined | Vec2[];
     // True if client player has casted this turn;

--- a/src/types/globalTypesMain.d.ts
+++ b/src/types/globalTypesMain.d.ts
@@ -112,7 +112,7 @@ declare global {
     var isSuperMe: undefined | boolean;
     // Shows icons above the heads of enemies who will damage you next turn
     // scale is the scale of the unit.  Larger units need their marker positioned higher
-    var attentionMarkers: undefined | { imagePath: string, pos: Vec2, scale: number }[];
+    var attentionMarkers: undefined | { imagePath: string, pos: Vec2, unitSpriteScaleY: number, markerScale: number = 1 }[];
     // Shows icon for units that will be successfully resurrected
     var resMarkers: undefined | Vec2[];
     // True if client player has casted this turn;


### PR DESCRIPTION
Closes #167 

Closes #170 

Closes #176 

Closes #178 

Closes #179 

Also:
- Suffocate shows turns until suffocation instead of buildup value
- Added purple buildup bar when unit has suffocate.
- Suffocate immediately updates when a unit takes damage, is split, or is blood cursed, instead of waiting until next turn.