### PR TITLE
Player state source of truth

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3808,11 +3808,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
   sendPlayerThinking(thoughts: { target?: Vec2, cardIds: string[] }) {
     sendPlayerThinkingThrottled(thoughts, this);
   }
-  syncPlayers(players: Player.IPlayerSerialized[]) {
+  syncPlayers(players: Player.IPlayerSerialized[], isClientPlayerSourceOfTruth: boolean) {
     console.log('sync: Syncing players', JSON.stringify(players.map(p => p.clientId)));
     // Clear previous players array
     const previousPlayersLength = this.players.length;
-    players.forEach((p, i) => Player.load(p, i, this));
+    players.forEach((p, i) => Player.load(p, i, this, isClientPlayerSourceOfTruth));
     if (this.players.length < previousPlayersLength) {
       console.error('Unexpected, syncPlayers: loaded players array is smaller');
       this.players.splice(previousPlayersLength);

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -397,8 +397,9 @@ export function load(player: IPlayerSerialized, index: number, underworld: Under
 
   if (isClientPlayerSourceOfTruth) {
     // Current client's player is the source of truth for their player object
-    // and the below properties should NOT be overwritten by the server's state of 
-    // their player.
+    // and the below properties should remain the value that they are on this
+    // clients globalPlayer object instead of being overwritten by the server's
+    // player object.
     // This is because the client can make local changes that occur immediately which
     // might be wrongfully overwritten by a server SYNC_PLAYERS such as getting
     // a summon spell or rerolling.

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -376,7 +376,7 @@ export function serialize(player: IPlayer): IPlayerSerialized {
   }
 }
 // load rehydrates a player entity from IPlayerSerialized
-export function load(player: IPlayerSerialized, index: number, underworld: Underworld) {
+export function load(player: IPlayerSerialized, index: number, underworld: Underworld, isClientPlayerSourceOfTruth: boolean) {
   const reassignedUnit = underworld.units.find(u => u.id == player.unit.id);
   if (!reassignedUnit) {
     if (!isHost(underworld.pie)) {
@@ -394,6 +394,26 @@ export function load(player: IPlayerSerialized, index: number, underworld: Under
     ...player,
     unit: reassignedUnit,
   };
+
+  if (isClientPlayerSourceOfTruth) {
+    // Current client's player is the source of truth for their player object
+    // and the below properties should NOT be overwritten by the server's state of 
+    // their player.
+    // This is because the client can make local changes that occur immediately which
+    // might be wrongfully overwritten by a server SYNC_PLAYERS such as getting
+    // a summon spell or rerolling.
+    if (globalThis.player && playerLoaded.clientId == globalThis.player.clientId) {
+      playerLoaded.cardsInToolbar = globalThis.player.cardsInToolbar;
+      playerLoaded.inventory = globalThis.player.inventory;
+      playerLoaded.freeSpells = globalThis.player.freeSpells;
+      playerLoaded.upgrades = globalThis.player.upgrades;
+      playerLoaded.upgradesLeftToChoose = globalThis.player.upgradesLeftToChoose;
+      playerLoaded.perksLeftToChoose = globalThis.player.perksLeftToChoose;
+      playerLoaded.reroll = globalThis.player.reroll;
+      playerLoaded.attributePerks = globalThis.player.attributePerks;
+      playerLoaded.statPointsUnspent = globalThis.player.statPointsUnspent;
+    }
+  }
   // Backwards compatibility after property name change
   // @ts-ignore cards was renamed to cardsInToolbar, this is for backwards compatibility
   if (player.cards) {
@@ -488,6 +508,16 @@ export function enterPortal(player: IPlayer, underworld: Underworld) {
   if (parseInt(highScore) < underworld.levelIndex) {
     console.log('New farthest level record!', mageTypeFarthestLevel, '->', underworld.levelIndex);
     storageSet(mageTypeFarthestLevel, underworld.levelIndex.toString());
+  }
+
+  if (player == globalThis.player) {
+    // At the end of each level ensure the server has an up-to-date state
+    // of the current client's player object.
+    // The client is the source of truth for it's own player object
+    underworld.pie.sendData({
+      type: MESSAGE_TYPES.CLIENT_SEND_PLAYER_TO_SERVER,
+      player: serialize(player)
+    });
   }
 
 

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -371,7 +371,7 @@ function joinGameAsPlayer(asPlayerClientId: string, overworld: Overworld, fromCl
 
 
       const players = underworld.players.map(Player.serialize)
-      // Overwrite client's own player object because the client is switching players
+      // isClientPlayerSourceOfTruth: false; Overwrite client's own player object because the client is switching players
       underworld.syncPlayers(players, false);
     }
   }
@@ -975,12 +975,12 @@ async function handleLoadGameState(payload: {
     underworld.units = units.filter(u => !u.flaggedForRemoval).map(u => Unit.load(u, underworld, false));
   }
   // Note: Players should sync after units are loaded so
+  // that the player.unit reference is synced
+  // with up to date units
+  if (players) {
     // isClientPlayerSourceOfTruth: false; loading a new game means the player should be 
     // fully overwritten
     underworld.syncPlayers(players, false);
-  // with up to date units
-  if (players) {
-    underworld.syncPlayers(players);
   }
   // After a load always start all players with endedTurn == false so that
   // it doesn't skip the player turn if players rejoin out of order

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -76,6 +76,35 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
         underworld.playerThoughts[thinkingPlayer.clientId] = { ...payload, currentDrawLocation, lerp: 0 };
       }
       break;
+    case MESSAGE_TYPES.CLIENT_SEND_PLAYER_TO_SERVER:
+      // This message is only ever handled by the host.  It is for the client
+      // to send it's Player state to the host because the client is the source of truth for the player object
+      if (isHost(overworld.pie) && overworld.underworld) {
+        const { player } = payload;
+        const foundPlayerIndex = overworld.underworld.players.findIndex(p => p.clientId == player.clientId);
+        if (foundPlayerIndex !== undefined) {
+          // Report Differences to evaluate where client server player desyncs are ocurring
+          const currentPlayer = overworld.underworld.players[foundPlayerIndex];
+          if (currentPlayer) {
+            const currentPlayerSerialized = Player.serialize(currentPlayer);
+            for (let key of new Set([...Object.keys(currentPlayerSerialized), ...Object.keys(player)])) {
+              // @ts-ignore: No index signature with a parameter of type 'string' was found on type 'IPlayerSerialized'.
+              // This is fine because we're just checking inequality to report desyncs
+              if (JSON.stringify(currentPlayerSerialized[key]) != JSON.stringify(player[key])) {
+                // @ts-ignore: No index signature with a parameter of type 'string' was found on type 'IPlayerSerialized'.
+                // This is fine because we're just checking inequality to report desyncs
+                console.error(`CLIENT_SEND_PLAYER_TO_SERVER property desync: property:${key}, host:${currentPlayerSerialized[key]}, client:${player[key]}`);
+              }
+            }
+          }
+          // End Report Differences to evaluate where client server player desyncs are ocurring
+
+
+          // Host loads player data from client to syncronize the state
+          Player.load(player, foundPlayerIndex, overworld.underworld, false);
+        }
+      }
+      break;
     case MESSAGE_TYPES.SET_GAME_MODE:
       const { gameMode } = payload;
       if (underworld.levelIndex <= 1) {
@@ -342,7 +371,8 @@ function joinGameAsPlayer(asPlayerClientId: string, overworld: Overworld, fromCl
 
 
       const players = underworld.players.map(Player.serialize)
-      underworld.syncPlayers(players);
+      // Overwrite client's own player object because the client is switching players
+      underworld.syncPlayers(players, false);
     }
   }
 
@@ -470,7 +500,10 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
         // Units must be synced before players so that the player's
         // associated unit is available for referencing
         underworld.syncUnits(units);
-        underworld.syncPlayers(players);
+        // isClientPlayerSourceOfTruth: true; for regular syncs the client's own player object
+        // is the source of truth so that the server's async player sync call doesn't overwrite
+        // something that happened syncronously on the client
+        underworld.syncPlayers(players, true);
         // Protect against old versions that didn't send lastUnitId with
         // this message
         if (lastUnitId !== undefined) {
@@ -555,7 +588,10 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       // that the player.unit reference is synced
       // with up to date units
       if (players) {
-        underworld.syncPlayers(players);
+        // isClientPlayerSourceOfTruth: true; for regular syncs the client's own player object
+        // is the source of truth so that the server's async player sync call doesn't overwrite
+        // something that happened syncronously on the client
+        underworld.syncPlayers(players, true);
       }
 
       if (pickups) {
@@ -939,7 +975,9 @@ async function handleLoadGameState(payload: {
     underworld.units = units.filter(u => !u.flaggedForRemoval).map(u => Unit.load(u, underworld, false));
   }
   // Note: Players should sync after units are loaded so
-  // that the player.unit reference is synced
+    // isClientPlayerSourceOfTruth: false; loading a new game means the player should be 
+    // fully overwritten
+    underworld.syncPlayers(players, false);
   // with up to date units
   if (players) {
     underworld.syncPlayers(players);

--- a/src/types/MessageTypes.ts
+++ b/src/types/MessageTypes.ts
@@ -39,4 +39,5 @@ export enum MESSAGE_TYPES {
   PREVENT_IDLE_TIMEOUT,
   // Could add typing indicator in future
   CHAT_SENT,
+  CLIENT_SEND_PLAYER_TO_SERVER,
 }


### PR DESCRIPTION
for during game syncs.
The server is the source of truth when loading a game or when changing which player the client is controlling.

This should resolve the issue of player's losing Summon cards or weird behavior like having your upgrade options regenerate if your ally level's up while your choosing your upgrades.

Resolves #188 