### PR TITLE
1.26 Polish

### DIFF
--- a/src/Perk.ts
+++ b/src/Perk.ts
@@ -17,17 +17,17 @@ const elPerksEveryLevel = document.getElementById('perkEveryLevel');
 const elPerksEveryTurn = document.getElementById('perkEveryTurn');
 
 export function cleanUpPerkList() {
-    if (elPerksEveryLevel) {
-        elPerksEveryLevel.innerHTML = '';
-    }
-    if (elPerksEveryTurn) {
-        elPerksEveryTurn.innerHTML = '';
-    }
+  if (elPerksEveryLevel) {
+    elPerksEveryLevel.innerHTML = '';
+  }
+  if (elPerksEveryTurn) {
+    elPerksEveryTurn.innerHTML = '';
+  }
 }
 
 // if omitWhen is set to true, it won't  the 'when' attribute of the perk
 export function getPerkText(perk: AttributePerk, omitWhen: boolean = false): string {
-    return `
+  return `
 ${perk.certainty < 1.0 ? `🎲 ${Math.round(perk.certainty * 100)}% chance` : ``}
 ${perkAttributeToIcon(perk.attribute)} +${perkAmountToText(perk.amount, perk.attribute)} ${i18n(perkAttributeToString(perk.attribute))}
 ${omitWhen ? '' : perkWhenToString(perk.when)}`.trim();
@@ -35,394 +35,393 @@ ${omitWhen ? '' : perkWhenToString(perk.when)}`.trim();
 }
 
 function perkAmountToText(amount: number, attribute: string): string {
-    const unit = globalThis.player?.unit;
-    if (unit) {
-        if (attribute == 'attackRange') {
-            // Show attack range as percentage since a whole number
-            // means nothing to users for attack range
-            return `${100 * amount / unit.attackRange}%`;
-        }
-
-    }
-    return `${amount}`
+  // const unit = globalThis.player?.unit;
+  // if (unit) {
+  //     if (attribute == 'attackRange') {
+  //         // Show attack range as percentage since a whole number
+  //         // means nothing to users for attack range
+  //         return `${100 * amount / unit.attackRange}%`;
+  //     }
+  // }
+  return `${amount}`
 }
 
 export interface StatCalamity {
-    unitId: string,
-    stat: string,
-    percent: number
+  unitId: string,
+  stat: string,
+  percent: number
 }
 export function generateRandomStatCalamity(underworld: Underworld, index: number): StatCalamity | undefined {
-    // health, damage, attack range
-    const seedString = getUniqueSeedString(underworld, globalThis.player) + `-${index}-${player?.cursesChosen || 0}`;
-    const seed = seedrandom(seedString);
-    const currentLevelUnitSourceIds = [...new Set(underworld.units.filter(u => u.unitSubType !== UnitSubType.DOODAD).map(u => u.unitSourceId).filter(uid => uid !== spellmasonUnitId))];
-    const unitId: string | undefined = chooseOneOfSeeded(currentLevelUnitSourceIds, seedrandom(`-${index}-${seedString}-unit`));
-    const growthFactor = underworld.levelIndex - LAST_LEVEL_INDEX;
-    const unitSource = allUnits[unitId || ''];
-    if (unitSource) {
-        const stats: (keyof Unit.IUnit)[] = ['healthMax', 'attackRange', 'staminaMax'];
-        if (unitSource.unitProps.damage) {
-            stats.push('damage');
-        }
-        const stat = chooseOneOfSeeded(stats, seed);
-        if (unitId && stat) {
-            return {
-                unitId,
-                stat,
-                percent: randInt(2 + growthFactor, 5 + growthFactor, seed) * 10
-            }
-        } else {
-            console.warn('Could not generate random stat calamity')
-            return undefined;
-        }
-    } else {
-        console.warn('Could not generate random stat calamity')
-        return undefined;
-
+  // health, damage, attack range
+  const seedString = getUniqueSeedString(underworld, globalThis.player) + `-${index}-${player?.cursesChosen || 0}`;
+  const seed = seedrandom(seedString);
+  const currentLevelUnitSourceIds = [...new Set(underworld.units.filter(u => u.unitSubType !== UnitSubType.DOODAD).map(u => u.unitSourceId).filter(uid => uid !== spellmasonUnitId))];
+  const unitId: string | undefined = chooseOneOfSeeded(currentLevelUnitSourceIds, seedrandom(`-${index}-${seedString}-unit`));
+  const growthFactor = underworld.levelIndex - LAST_LEVEL_INDEX;
+  const unitSource = allUnits[unitId || ''];
+  if (unitSource) {
+    const stats: (keyof Unit.IUnit)[] = ['healthMax', 'attackRange', 'staminaMax'];
+    if (unitSource.unitProps.damage) {
+      stats.push('damage');
     }
+    const stat = chooseOneOfSeeded(stats, seed);
+    if (unitId && stat) {
+      return {
+        unitId,
+        stat,
+        percent: randInt(2 + growthFactor, 5 + growthFactor, seed) * 10
+      }
+    } else {
+      console.warn('Could not generate random stat calamity')
+      return undefined;
+    }
+  } else {
+    console.warn('Could not generate random stat calamity')
+    return undefined;
+
+  }
 
 }
 
 // Calamities / Calamity
 export function createCursePerkElement({ cardId, statCalamity }: { cardId?: string, statCalamity?: StatCalamity }, underworld: Underworld) {
-    if (globalThis.headless) {
-        // There is no DOM in headless mode
-        return;
-    }
-    const { pie } = underworld;
-    const element = document.createElement('div');
-    element.classList.add('card', 'upgrade');
-    element.classList.add('perk', 'ui-border', 'cursed');
-    const elCardInner = document.createElement('div');
-    elCardInner.classList.add('card-inner');
-    element.appendChild(elCardInner);
+  if (globalThis.headless) {
+    // There is no DOM in headless mode
+    return;
+  }
+  const { pie } = underworld;
+  const element = document.createElement('div');
+  element.classList.add('card', 'upgrade');
+  element.classList.add('perk', 'ui-border', 'cursed');
+  const elCardInner = document.createElement('div');
+  elCardInner.classList.add('card-inner');
+  element.appendChild(elCardInner);
 
-    const desc = document.createElement('div');
-    desc.classList.add('card-description');
-    const descriptionText = document.createElement('div');
-    if (cardId) {
+  const desc = document.createElement('div');
+  desc.classList.add('card-description');
+  const descriptionText = document.createElement('div');
+  if (cardId) {
 
-        const content = allCards[cardId] as ICard;
-        const thumbHolder = document.createElement('div');
-        const thumbnail = document.createElement('img');
-        thumbnail.src = getSpellThumbnailPath(content.thumbnail);
-        thumbHolder.appendChild(thumbnail);
-        thumbHolder.classList.add('card-thumb');
-        elCardInner.appendChild(thumbHolder);
+    const content = allCards[cardId] as ICard;
+    const thumbHolder = document.createElement('div');
+    const thumbnail = document.createElement('img');
+    thumbnail.src = getSpellThumbnailPath(content.thumbnail);
+    thumbHolder.appendChild(thumbnail);
+    thumbHolder.classList.add('card-thumb');
+    elCardInner.appendChild(thumbHolder);
 
-        const numberOfLevelsToDisable = 2 + Math.floor((underworld.levelIndex - (1 + LAST_LEVEL_INDEX)) / 2);
-        descriptionText.innerHTML = i18n(['disable spell', content.id, numberOfLevelsToDisable.toString()]);
-        desc.appendChild(descriptionText);
-
-        element.addEventListener('click', (e) => {
-            globalThis.timeLastChoseUpgrade = Date.now();
-            // Prevent click from "falling through" upgrade and propagating to vote for overworld level
-            e.stopPropagation();
-
-            pie.sendData({
-                type: MESSAGE_TYPES.CHOOSE_PERK,
-                curse: cardId,
-                disableFor: numberOfLevelsToDisable
-            });
-        });
-    } else if (statCalamity) {
-        const wordMap: { [key: string]: string } = {
-            'attackRange': 'attack range',
-            'damage': 'damage',
-            'healthMax': 'health capacity',
-            'staminaMax': 'stamina capacity'
-        }
-        descriptionText.innerHTML = `${statCalamity.unitId} ${i18n([wordMap[statCalamity.stat] || ''])} + ${statCalamity.percent}%`;
-        desc.appendChild(descriptionText);
-        element.addEventListener('click', (e) => {
-            globalThis.timeLastChoseUpgrade = Date.now();
-            // Prevent click from "falling through" upgrade and propagating to vote for overworld level
-            e.stopPropagation();
-
-            pie.sendData({
-                type: MESSAGE_TYPES.CHOOSE_PERK,
-                statCalamity,
-            });
-        });
-
-    } else {
-        console.error('Invalid calamity')
-    }
-    elCardInner.appendChild(desc);
-    element.addEventListener('mouseenter', (e) => {
-        playSFXKey('click');
-    });
-    return element;
-}
-export function createPerkElement(perk: AttributePerk, player: IPlayer, underworld: Underworld) {
-    if (globalThis.headless) {
-        // There is no DOM in headless mode
-        return;
-    }
-    const { pie } = underworld;
-    const element = document.createElement('div');
-    element.classList.add('card', 'upgrade');
-    element.classList.add('perk', 'ui-border');
-    const elCardInner = document.createElement('div');
-    elCardInner.classList.add('card-inner');
-    element.appendChild(elCardInner);
-
-    const desc = document.createElement('div');
-    desc.classList.add('card-description');
-    const descriptionText = document.createElement('div');
-    descriptionText.innerHTML = getPerkText(perk);
+    const numberOfLevelsToDisable = 2 + Math.floor((underworld.levelIndex - (1 + LAST_LEVEL_INDEX)) / 2);
+    descriptionText.innerHTML = i18n(['disable spell', content.id, numberOfLevelsToDisable.toString()]);
     desc.appendChild(descriptionText);
 
-    elCardInner.appendChild(desc);
     element.addEventListener('click', (e) => {
-        globalThis.timeLastChoseUpgrade = Date.now();
-        // Prevent click from "falling through" upgrade and propagating to vote for overworld level
-        e.stopPropagation();
-        pie.sendData({
-            type: MESSAGE_TYPES.CHOOSE_PERK,
-            perk,
-        });
+      globalThis.timeLastChoseUpgrade = Date.now();
+      // Prevent click from "falling through" upgrade and propagating to vote for overworld level
+      e.stopPropagation();
+
+      pie.sendData({
+        type: MESSAGE_TYPES.CHOOSE_PERK,
+        curse: cardId,
+        disableFor: numberOfLevelsToDisable
+      });
     });
-    element.addEventListener('mouseenter', (e) => {
-        playSFXKey('click');
+  } else if (statCalamity) {
+    const wordMap: { [key: string]: string } = {
+      'attackRange': 'attack range',
+      'damage': 'damage',
+      'healthMax': 'health capacity',
+      'staminaMax': 'stamina capacity'
+    }
+    descriptionText.innerHTML = `${statCalamity.unitId} ${i18n([wordMap[statCalamity.stat] || ''])} + ${statCalamity.percent}%`;
+    desc.appendChild(descriptionText);
+    element.addEventListener('click', (e) => {
+      globalThis.timeLastChoseUpgrade = Date.now();
+      // Prevent click from "falling through" upgrade and propagating to vote for overworld level
+      e.stopPropagation();
+
+      pie.sendData({
+        type: MESSAGE_TYPES.CHOOSE_PERK,
+        statCalamity,
+      });
     });
-    return element;
+
+  } else {
+    console.error('Invalid calamity')
+  }
+  elCardInner.appendChild(desc);
+  element.addEventListener('mouseenter', (e) => {
+    playSFXKey('click');
+  });
+  return element;
+}
+export function createPerkElement(perk: AttributePerk, player: IPlayer, underworld: Underworld) {
+  if (globalThis.headless) {
+    // There is no DOM in headless mode
+    return;
+  }
+  const { pie } = underworld;
+  const element = document.createElement('div');
+  element.classList.add('card', 'upgrade');
+  element.classList.add('perk', 'ui-border');
+  const elCardInner = document.createElement('div');
+  elCardInner.classList.add('card-inner');
+  element.appendChild(elCardInner);
+
+  const desc = document.createElement('div');
+  desc.classList.add('card-description');
+  const descriptionText = document.createElement('div');
+  descriptionText.innerHTML = getPerkText(perk);
+  desc.appendChild(descriptionText);
+
+  elCardInner.appendChild(desc);
+  element.addEventListener('click', (e) => {
+    globalThis.timeLastChoseUpgrade = Date.now();
+    // Prevent click from "falling through" upgrade and propagating to vote for overworld level
+    e.stopPropagation();
+    pie.sendData({
+      type: MESSAGE_TYPES.CHOOSE_PERK,
+      perk,
+    });
+  });
+  element.addEventListener('mouseenter', (e) => {
+    playSFXKey('click');
+  });
+  return element;
 }
 
 function perkWhenToString(when: WhenUpgrade): string {
-    if (when == 'everyLevel') {
-        return `🗺️ ${i18n('every level')}`;
-    } else if (when == 'everyTurn') {
-        return `🕰️ ${i18n('every turn️')}`;
-    } else if (when == 'immediately') {
-        return '';
-    }
+  if (when == 'everyLevel') {
+    return `🗺️ ${i18n('every level')}`;
+  } else if (when == 'everyTurn') {
+    return `🕰️ ${i18n('every turn️')}`;
+  } else if (when == 'immediately') {
     return '';
+  }
+  return '';
 }
 function perkAttributeToIcon(attr: string): string {
-    if (attr == 'manaMax') {
-        return `🔵`;
-    }
-    if (attr == 'healthMax') {
-        return `❤️`;
-    }
-    if (attr == 'staminaMax') {
-        return `🏃‍♂️`;
-    }
-    if (attr == 'mana') {
-        return `🔵`;
-    }
-    if (attr == 'health') {
-        return `❤️`;
-    }
-    if (attr == 'stamina') {
-        return `🏃‍♂️`;
-    }
-    if (attr == 'attackRange') {
-        return `🎯`;
+  if (attr == 'manaMax') {
+    return `🔵`;
+  }
+  if (attr == 'healthMax') {
+    return `❤️`;
+  }
+  if (attr == 'staminaMax') {
+    return `🏃‍♂️`;
+  }
+  if (attr == 'mana') {
+    return `🔵`;
+  }
+  if (attr == 'health') {
+    return `❤️`;
+  }
+  if (attr == 'stamina') {
+    return `🏃‍♂️`;
+  }
+  if (attr == 'attackRange') {
+    return `🎯`;
 
-    }
-    return '';
+  }
+  return '';
 }
 function perkAttributeToString(attr: string): string {
-    if (attr == 'manaMax') {
-        return `Mana Capacity`;
-    }
-    if (attr == 'healthMax') {
-        return `Health Capacity`;
-    }
-    if (attr == 'staminaMax') {
-        return `Stamina Capacity`;
-    }
-    if (attr == 'mana') {
-        return `single-turn Mana`;
-    }
-    if (attr == 'health') {
-        return `single-turn Health`;
-    }
-    if (attr == 'stamina') {
-        return `single-turn Stamina`;
-    }
-    if (attr == 'attackRange') {
-        return `Cast Range`;
+  if (attr == 'manaMax') {
+    return `Mana Capacity`;
+  }
+  if (attr == 'healthMax') {
+    return `Health Capacity`;
+  }
+  if (attr == 'staminaMax') {
+    return `Stamina Capacity`;
+  }
+  if (attr == 'mana') {
+    return `single-turn Mana`;
+  }
+  if (attr == 'health') {
+    return `single-turn Health`;
+  }
+  if (attr == 'stamina') {
+    return `single-turn Stamina`;
+  }
+  if (attr == 'attackRange') {
+    return `Cast Range`;
 
-    }
-    return attr;
+  }
+  return attr;
 }
 export type UpgradableAttribute = 'staminaMax' | 'stamina' | 'healthMax' | 'health' | 'manaMax' | 'mana' | 'attackRange'
 export type WhenUpgrade = 'immediately' | 'everyLevel' | 'everyTurn';
 export function generatePerks(number: number, underworld: Underworld): AttributePerk[] {
-    const perks: AttributePerk[] = [];
-    const preRolledCertainty = chooseOneOf([0.1, 0.2, 0.3]) || 0.2;
-    let failedDueToDuplicateCount = 0;
-    for (let i = 0; i < number; i++) {
+  const perks: AttributePerk[] = [];
+  const preRolledCertainty = chooseOneOf([0.1, 0.2, 0.3]) || 0.2;
+  let failedDueToDuplicateCount = 0;
+  for (let i = 0; i < number; i++) {
 
-        let when: WhenUpgrade = 'immediately';// Default, should never be used
-        let amount = 1.1;// Default, should never be used
-        // certainty is a preportion 0.0 - 1.0
-        let certainty: number = 1.0;// Default, should never be used
-        let attribute: UpgradableAttribute = 'stamina';//Default, should never be used
+    let when: WhenUpgrade = 'immediately';// Default, should never be used
+    let amount = 1.1;// Default, should never be used
+    // certainty is a preportion 0.0 - 1.0
+    let certainty: number = 1.0;// Default, should never be used
+    let attribute: UpgradableAttribute = 'stamina';//Default, should never be used
 
-        // Choose attribute type
-        const seed = seedrandom(getUniqueSeedString(underworld, globalThis.player) + `-${i}-${player?.reroll || 0}-${failedDueToDuplicateCount}-${player?.attributePerks.length || 0}`);
-        const choiceAttributeType = chooseObjectWithProbability([{ attr: 'maxStat', probability: 10 }, { attr: 'stat', probability: 3 }], seed)?.attr || 'maxStat';
-        if (choiceAttributeType == 'maxStat') {
-            attribute = chooseOneOfSeeded(['staminaMax', 'healthMax', 'manaMax', 'attackRange'], seed) || 'stamina';
-            when = chooseOneOfSeeded<WhenUpgrade>(['immediately', 'everyLevel'], seed) || 'immediately';
-            amount = 15;
-            if (attribute == 'healthMax') {
-                amount = 20;
-            } else if (attribute == 'staminaMax') {
-                amount = 30;
-            } else if (attribute == 'attackRange') {
-                amount = 30;
-            }
-            certainty = 1.0;
-            // Perks gotten every level should take 5 rounds to pay for themselves
-            if (when == 'everyLevel') {
-                amount = Math.round(amount / 5);
-            }
-        } else {
-            attribute = chooseOneOfSeeded(['stamina', 'health', 'mana'], seed) || 'stamina';
-            // Regular stats' when should be recurring because regular stats wouldn't do much good as an
-            // upgrade if they were only changed once
-            when = chooseOneOfSeeded<WhenUpgrade>(['everyLevel', 'everyTurn'], seed) || 'everyLevel';
-            if (when == 'everyLevel') {
-                amount = 40;
-                certainty = 1.0;
-            } else if (when == 'everyTurn') {
-                amount = 30;
-                certainty = preRolledCertainty;
-            } else {
-                console.error('Unexpected: Invalid when for regular stat perk');
-            }
+    // Choose attribute type
+    const seed = seedrandom(getUniqueSeedString(underworld, globalThis.player) + `-${i}-${player?.reroll || 0}-${failedDueToDuplicateCount}-${player?.attributePerks.length || 0}`);
+    const choiceAttributeType = chooseObjectWithProbability([{ attr: 'maxStat', probability: 10 }, { attr: 'stat', probability: 3 }], seed)?.attr || 'maxStat';
+    if (choiceAttributeType == 'maxStat') {
+      attribute = chooseOneOfSeeded(['staminaMax', 'healthMax', 'manaMax', 'attackRange'], seed) || 'stamina';
+      when = chooseOneOfSeeded<WhenUpgrade>(['immediately', 'everyLevel'], seed) || 'immediately';
+      amount = 15;
+      if (attribute == 'healthMax') {
+        amount = 20;
+      } else if (attribute == 'staminaMax') {
+        amount = 30;
+      } else if (attribute == 'attackRange') {
+        amount = 30;
+      }
+      certainty = 1.0;
+      // Perks gotten every level should take 5 rounds to pay for themselves
+      if (when == 'everyLevel') {
+        amount = Math.round(amount / 5);
+      }
+    } else {
+      attribute = chooseOneOfSeeded(['stamina', 'health', 'mana'], seed) || 'stamina';
+      // Regular stats' when should be recurring because regular stats wouldn't do much good as an
+      // upgrade if they were only changed once
+      when = chooseOneOfSeeded<WhenUpgrade>(['everyLevel', 'everyTurn'], seed) || 'everyLevel';
+      if (when == 'everyLevel') {
+        amount = 40;
+        certainty = 1.0;
+      } else if (when == 'everyTurn') {
+        amount = 30;
+        certainty = preRolledCertainty;
+      } else {
+        console.error('Unexpected: Invalid when for regular stat perk');
+      }
 
-        }
-        const newPerk = {
-            attribute,
-            when,
-            amount,
-            certainty
-        };
+    }
+    const newPerk = {
+      attribute,
+      when,
+      amount,
+      certainty
+    };
 
-        // Prevent duplicates
-        const duplicate = perks.find(p => JSON.stringify(p) == JSON.stringify(newPerk));
-        if (duplicate) {
-            i--;
-            failedDueToDuplicateCount++;
-            if (failedDueToDuplicateCount > 100) {
-                console.error('Infinite loop protection, could not generate unique perk');
-                return perks;
-            }
-            continue;
-        }
-
-        perks.push(newPerk);
+    // Prevent duplicates
+    const duplicate = perks.find(p => JSON.stringify(p) == JSON.stringify(newPerk));
+    if (duplicate) {
+      i--;
+      failedDueToDuplicateCount++;
+      if (failedDueToDuplicateCount > 100) {
+        console.error('Infinite loop protection, could not generate unique perk');
+        return perks;
+      }
+      continue;
     }
 
-    return perks;
+    perks.push(newPerk);
+  }
+
+  return perks;
 
 }
 export function choosePerk(perk: AttributePerk, player: IPlayer, underworld: Underworld) {
-    // Reset reroll counter now that player has chosen a perk 
-    player.reroll = 0;
-    // Ensure the player cannot pick more perks than they have available
-    if (underworld.perksLeftToChoose(player) <= 0) {
-        // if current player, manage the visibility of the upgrade screen
-        if (player == globalThis.player) {
-            console.log('Cannot choose another perk');
-            // Clear upgrades
-            document.body?.classList.toggle(showUpgradesClassName, false);
-            // There may be upgrades left to choose
-            underworld.showUpgrades();
-            return;
-        }
-    }
-    if (perk.when == 'immediately') {
-        // Note: random doesn't need to be seeded for 'immediate' perks because they
-        // are guarunteed to proc
-        tryTriggerPerk(perk, player, 'immediately', seedrandom(), underworld, 0);
-    }
-    player.attributePerks.push(perk);
+  // Reset reroll counter now that player has chosen a perk 
+  player.reroll = 0;
+  // Ensure the player cannot pick more perks than they have available
+  if (underworld.perksLeftToChoose(player) <= 0) {
+    // if current player, manage the visibility of the upgrade screen
     if (player == globalThis.player) {
-        // Clear upgrades when current player has picked one
-        document.body?.classList.toggle(showUpgradesClassName, false);
-        // Show next round of upgrades
-        underworld.showUpgrades();
+      console.log('Cannot choose another perk');
+      // Clear upgrades
+      document.body?.classList.toggle(showUpgradesClassName, false);
+      // There may be upgrades left to choose
+      underworld.showUpgrades();
+      return;
     }
+  }
+  if (perk.when == 'immediately') {
+    // Note: random doesn't need to be seeded for 'immediate' perks because they
+    // are guarunteed to proc
+    tryTriggerPerk(perk, player, 'immediately', seedrandom(), underworld, 0);
+  }
+  player.attributePerks.push(perk);
+  if (player == globalThis.player) {
+    // Clear upgrades when current player has picked one
+    document.body?.classList.toggle(showUpgradesClassName, false);
+    // Show next round of upgrades
+    underworld.showUpgrades();
+  }
 }
 export function hidePerkList() {
-    if (elPerkList) {
-        elPerkList.classList.toggle('visible', false);
-    }
+  if (elPerkList) {
+    elPerkList.classList.toggle('visible', false);
+  }
 }
 export function showPerkList(player: IPlayer) {
-    if (!globalThis.headless) {
-        if (elPerkList && elPerksEveryLevel && elPerksEveryTurn) {
-            if (player.attributePerks.length) {
-                elPerkList.classList.toggle('visible', true);
-                const everyLevel = player.attributePerks.filter(p => p.when == 'everyLevel');
-                const everyTurn = player.attributePerks.filter(p => p.when == 'everyTurn');
-                // Clear previous perks now that they will be replaced
-                elPerksEveryLevel.innerHTML = '';
-                elPerksEveryTurn.innerHTML = '';
-                everyLevel.forEach(p => perkToListItem(p, elPerksEveryLevel));
-                everyTurn.forEach(p => perkToListItem(p, elPerksEveryTurn));
-            } else {
-                console.log('PerkList: No perks to show.');
-                elPerkList.classList.toggle('visible', false);
-            }
-        } else {
-            console.error('Could not render perkList')
-        }
+  if (!globalThis.headless) {
+    if (elPerkList && elPerksEveryLevel && elPerksEveryTurn) {
+      if (player.attributePerks.length) {
+        elPerkList.classList.toggle('visible', true);
+        const everyLevel = player.attributePerks.filter(p => p.when == 'everyLevel');
+        const everyTurn = player.attributePerks.filter(p => p.when == 'everyTurn');
+        // Clear previous perks now that they will be replaced
+        elPerksEveryLevel.innerHTML = '';
+        elPerksEveryTurn.innerHTML = '';
+        everyLevel.forEach(p => perkToListItem(p, elPerksEveryLevel));
+        everyTurn.forEach(p => perkToListItem(p, elPerksEveryTurn));
+      } else {
+        console.log('PerkList: No perks to show.');
+        elPerkList.classList.toggle('visible', false);
+      }
+    } else {
+      console.error('Could not render perkList')
     }
+  }
 
 }
 function perkToListItem(perk: AttributePerk, container: HTMLElement) {
-    const el = document.createElement('div');
-    el.innerHTML = getPerkText(perk, true);
-    container.appendChild(el);
+  const el = document.createElement('div');
+  el.innerHTML = getPerkText(perk, true);
+  container.appendChild(el);
 }
 export interface AttributePerk {
-    attribute: UpgradableAttribute;
-    // certainty is a preportion 0.0 - 1.0
-    certainty: number;
-    when: WhenUpgrade;
-    // amount is a preportion 0.0 - 1.0
-    amount: number;
+  attribute: UpgradableAttribute;
+  // certainty is a preportion 0.0 - 1.0
+  certainty: number;
+  when: WhenUpgrade;
+  // amount is a preportion 0.0 - 1.0
+  amount: number;
 }
 export function tryTriggerPerk(perk: AttributePerk, player: IPlayer, when: WhenUpgrade, random: seedrandom.PRNG, underworld: Underworld, offsetNotifyByMs: number) {
-    if (perk.when == when) {
-        const pick = random.quick();
-        const doTriggerPerk = pick <= perk.certainty;
-        const oldAttributeAmount = player.unit[perk.attribute];
-        if (doTriggerPerk) {
-            if (perk.attribute == 'manaMax' || perk.attribute == 'healthMax' || perk.attribute == 'staminaMax') {
-                setPlayerAttributeMax(player.unit, perk.attribute, player.unit[perk.attribute] + perk.amount)
-            } else {
-                let maxAmount = player.unit[perk.attribute];
-                if (perk.attribute == 'mana') {
-                    maxAmount = player.unit['manaMax'];
-                } else if (perk.attribute == 'health') {
-                    maxAmount = player.unit['healthMax'];
-                } else if (perk.attribute == 'stamina') {
-                    maxAmount = player.unit['staminaMax'];
-                }
-                player.unit[perk.attribute] = perk.amount + maxAmount;
-                player.unit[perk.attribute] = Math.ceil(player.unit[perk.attribute]);
-            }
-            if (player === globalThis.player) {
-                setTimeout(() => {
-                    floatingText({ coords: player.unit, text: `+${Math.round(player.unit[perk.attribute] - oldAttributeAmount)} ${i18n(perkAttributeToString(perk.attribute))}` });
-                }, offsetNotifyByMs);
-            }
-            // Now that the player unit's properties have changed, sync the new
-            // state with the player's predictionUnit so it is properly
-            // refelcted in the bar
-            // (note: this would be auto corrected on the next mouse move anyway)
-            underworld.syncPlayerPredictionUnitOnly();
-            Unit.syncPlayerHealthManaUI(underworld);
+  if (perk.when == when) {
+    const pick = random.quick();
+    const doTriggerPerk = pick <= perk.certainty;
+    const oldAttributeAmount = player.unit[perk.attribute];
+    if (doTriggerPerk) {
+      if (perk.attribute == 'manaMax' || perk.attribute == 'healthMax' || perk.attribute == 'staminaMax') {
+        setPlayerAttributeMax(player.unit, perk.attribute, player.unit[perk.attribute] + perk.amount)
+      } else {
+        let maxAmount = player.unit[perk.attribute];
+        if (perk.attribute == 'mana') {
+          maxAmount = player.unit['manaMax'];
+        } else if (perk.attribute == 'health') {
+          maxAmount = player.unit['healthMax'];
+        } else if (perk.attribute == 'stamina') {
+          maxAmount = player.unit['staminaMax'];
         }
+        player.unit[perk.attribute] = perk.amount + maxAmount;
+        player.unit[perk.attribute] = Math.ceil(player.unit[perk.attribute]);
+      }
+      if (player === globalThis.player) {
+        setTimeout(() => {
+          floatingText({ coords: player.unit, text: `+${Math.round(player.unit[perk.attribute] - oldAttributeAmount)} ${i18n(perkAttributeToString(perk.attribute))}` });
+        }, offsetNotifyByMs);
+      }
+      // Now that the player unit's properties have changed, sync the new
+      // state with the player's predictionUnit so it is properly
+      // refelcted in the bar
+      // (note: this would be auto corrected on the next mouse move anyway)
+      underworld.syncPlayerPredictionUnitOnly();
+      Unit.syncPlayerHealthManaUI(underworld);
     }
+  }
 }

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2778,10 +2778,6 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
                 }
                 return '';
               }
-              if (stat == 'attackRange') {
-                // Display default attackRange as "100"
-                return Math.floor(100 * value / config.PLAYER_BASE_ATTACK_RANGE);
-              }
               return value;
             }
             const elStatUpgradeRow = (stat: string) => `<tr class="stat-row">

--- a/src/Upgrade.ts
+++ b/src/Upgrade.ts
@@ -75,7 +75,7 @@ export function generateUpgrades(player: IPlayer, numberOfUpgrades: number, mini
       // Prevent picking the same upgrade twice
       .filter(filterUpgrades)
       // Ensure they pick from only damage cards
-      .filter(c => (![bleedCardId, drownCardId].includes(c.title) && c.cardCategory == CardCategory.Damage) || [poisonCardId, suffocateCardId].includes(c.title));
+      .filter(c => (![bleedCardId, drownCardId].includes(c.title) && c.cardCategory == CardCategory.Damage) || [poisonCardId].includes(c.title));
   }
   if (isPickingClass(player)) {
     return upgradeMageClassSource;

--- a/src/entity/units/darkSummoner.ts
+++ b/src/entity/units/darkSummoner.ts
@@ -59,7 +59,7 @@ const unit: UnitSource = {
   },
   action: async (unit: Unit.IUnit, attackTargets, underworld: Underworld) => {
     // attackTargets has irregular usage for this unit, see explanation in this file's getUnitAttackTargets()
-    await summonerAction(unit, !!attackTargets.length, underworld, { closeUnit: allUnits[MANA_VAMPIRE_ID], farUnit: allUnits[DARK_PRIEST_ID] }, 3);
+    await summonerAction(unit, !!attackTargets.length, underworld, { closeUnit: allUnits[MANA_VAMPIRE_ID], farUnit: allUnits[DARK_PRIEST_ID] }, 2);
   },
   getUnitAttackTargets: summonerGetUnitAttackTargets
 };

--- a/src/entity/units/priest.ts
+++ b/src/entity/units/priest.ts
@@ -21,8 +21,9 @@ async function resurrectUnits(self: Unit.IUnit, units: Unit.IUnit[], underworld:
     return false;
   }
   playSFXKey('priestAttack');
-  let didResurrect = false;
   await Unit.playAnimation(self, unit.animations.attack);
+  let manaBeforeCast = self.mana;
+  let didResurrect = false;
   let promises = [];
   for (let ally of units) {
     promises.push(animatePriestProjectileAndHit(self, ally).then(async () => {
@@ -43,9 +44,9 @@ async function resurrectUnits(self: Unit.IUnit, units: Unit.IUnit[], underworld:
     didResurrect = true;
   }
   await Promise.all(promises);
-  // Ensure priest never goes below 0 mana
-  // This is a bandaid because a miniboss priest will cast multiple times drawing mana from each cast
-  self.mana = Math.max(0, self.mana);
+
+  // Fixes an issue where cast card resurrect would cause incorrect mana cost
+  self.mana = manaBeforeCast - self.manaCostToCast;
   return didResurrect;
 
 }

--- a/src/entity/units/priest.ts
+++ b/src/entity/units/priest.ts
@@ -60,11 +60,11 @@ const unit: UnitSource = {
   unitProps: {
     damage: 0,
     attackRange: 500,
-    healthMax: 20,
+    healthMax: 40,
     mana: 90,
     manaMax: 90,
-    manaPerTurn: 45,
-    manaCostToCast: 90,
+    manaPerTurn: 30,
+    manaCostToCast: 60,
   },
   spawnParams: {
     probability: 20,

--- a/src/entity/units/summoner.ts
+++ b/src/entity/units/summoner.ts
@@ -37,10 +37,10 @@ const unit: UnitSource = {
     damage: 0,
     attackRange: 550,
     healthMax: 120,
-    mana: 60,
-    manaMax: 90,
+    mana: 90,
+    manaMax: 120,
     manaPerTurn: 30,
-    manaCostToCast: 90,
+    manaCostToCast: 120,
   },
   spawnParams: {
     probability: 20,

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -877,7 +877,7 @@ export function updateTooltipContent(underworld: Underworld) {
           }
           const extraText = `
 ${modifiersToText(globalThis.selectedUnit.modifiers)}
-${unitSource.unitProps.manaCostToCast && unitSource.unitProps.manaCostToCast > 0 ? `${i18n('mana cost to cast')}: ${unitSource.unitProps.manaCostToCast}` : ''}
+${globalThis.selectedUnit.manaCostToCast && globalThis.selectedUnit.manaCostToCast > 0 ? `${i18n('mana cost to cast')}: ${globalThis.selectedUnit.manaCostToCast}` : ''}
           `.trim();
           // NOTE: globalThis.selectedUnit.name is NOT localized on purpose
           // because those are user provided names

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -423,9 +423,9 @@ export function drawHealthBarAboveHead(unitIndex: number, underworld: Underworld
 
         const manaBarMax = u.manaMax || 1;
 
+        //background for mana using units
         let manaBarProps = getFillRect(u, 0, manaBarMax, 0, manaBarMax, zoom);
         if (u.manaMax > 0) {
-          //background for mana using units
           globalThis.unitOverlayGraphics.lineStyle(0, 0x000000, 1.0);
           globalThis.unitOverlayGraphics.beginFill(0x111111, 0.8);
           globalThis.unitOverlayGraphics.drawRect(
@@ -435,7 +435,6 @@ export function drawHealthBarAboveHead(unitIndex: number, underworld: Underworld
             manaBarProps.height
           );
         }
-
         //current mana
         manaBarProps = getFillRect(u, 0, manaBarMax, 0, u.mana, zoom);
         globalThis.unitOverlayGraphics.lineStyle(0, 0x000000, 1.0);
@@ -447,27 +446,28 @@ export function drawHealthBarAboveHead(unitIndex: number, underworld: Underworld
           manaBarProps.height
         );
 
-        // Show mana bar prediction
-        if (predictionUnit) {
-          const manaAfterPrediction = predictionUnit.mana;
-          if (manaAfterPrediction < u.mana) {
-            globalThis.unitOverlayGraphics.beginFill(colors.manaDarkBlue, 1.0);
-          }
-          else {
-            globalThis.unitOverlayGraphics.beginFill(colors.manaBrightBlue, 1.0);
-          }
+        if (underworld.turn_phase == turn_phase.PlayerTurns && globalThis.unitOverlayGraphics) {
+          // Show mana bar prediction
+          if (predictionUnit) {
+            const manaAfterPrediction = predictionUnit.mana;
+            if (manaAfterPrediction < u.mana) {
+              globalThis.unitOverlayGraphics.beginFill(colors.manaDarkBlue, 1.0);
+            }
+            else {
+              globalThis.unitOverlayGraphics.beginFill(colors.manaBrightBlue, 1.0);
+            }
 
-          let fillRect = getFillRect(u, 0, manaBarMax, u.mana, manaAfterPrediction, zoom);
-          globalThis.unitOverlayGraphics.drawRect(
-            fillRect.x,
-            fillRect.y,
-            fillRect.width,
-            fillRect.height);
+            let fillRect = getFillRect(u, 0, manaBarMax, u.mana, manaAfterPrediction, zoom);
+            globalThis.unitOverlayGraphics.drawRect(
+              fillRect.x,
+              fillRect.y,
+              fillRect.width,
+              fillRect.height);
+          }
+          globalThis.unitOverlayGraphics.endFill();
         }
-        globalThis.unitOverlayGraphics.endFill();
       }
     }
-
   }
 }
 


### PR DESCRIPTION
Final PR for 1.26

- Fixes decoy sprite scale issue
- Fixed mana cost to cast display issue for minibosses
- Remove adjusted cast range display
- Summoners were a little strong after #162 , balances them back to normal
- Priest adjustment after 162
- Fixed a priest bug that caused it to spend all mana when casting resurrect
- Fixed prediction mana drawing on enemy turns
- Suffocate removed from guaranteed starting damage spells
