### PR TITLE
1.26 bug fixes 1

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3284,7 +3284,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       case UnitSubType.RANGED_LOS:
         return u.alive && this.hasLineOfSight(u, attackTarget) && Unit.inRange(u, attackTarget);
       case UnitSubType.RANGED_RADIUS:
-        return u.alive && Unit.inRange(u, attackTarget) && u.mana > u.manaCostToCast;
+        return u.alive && Unit.inRange(u, attackTarget) && u.mana >= u.manaCostToCast;
       case UnitSubType.SUPPORT_CLASS:
         // Support classes (such as priests and summoners) dont attack targets
         return false;

--- a/src/Upgrade.ts
+++ b/src/Upgrade.ts
@@ -177,7 +177,7 @@ export function createUpgradeElement(upgrade: IUpgrade, player: IPlayer, underwo
   desc.classList.add('card-description');
   const descriptionText = document.createElement('div');
   if (upgrade.replaces || upgrade.requires) {
-    const replacesEl = getReplacesCardText(upgrade.requires || [], upgrade.replaces || []);
+    const replacesEl = getReplacesCardText(upgrade.replaces || [], upgrade.requires || []);
     descriptionText.appendChild(replacesEl)
   }
   const label = document.createElement('span');

--- a/src/cards/purify.ts
+++ b/src/cards/purify.ts
@@ -1,5 +1,5 @@
 import * as Unit from '../entity/Unit';
-import { Spell } from './index';
+import { Spell, refundLastSpell } from './index';
 import Underworld from '../Underworld';
 import { CardCategory } from '../types/commonTypes';
 import { playDefaultSpellAnimation, playDefaultSpellSFX } from './cardUtils';
@@ -20,14 +20,16 @@ const spell: Spell = {
     animationPath: 'spell-effects/spellPurify',
     description: 'spell_purify',
     effect: async (state, card, quantity, underworld, prediction) => {
-      // .filter: only target living units
-      const targets = state.targetedUnits.filter(u => u.alive);
+      const targets = state.targetedUnits;
       if (targets.length) {
         playDefaultSpellSFX(card, prediction);
         await playDefaultSpellAnimation(card, targets, prediction);
         for (let unit of targets) {
           apply(unit, underworld)
         }
+      }
+      else {
+        refundLastSpell(state, prediction, 'No valid targets. Cost refunded.')
       }
       return state;
     },

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -30,7 +30,7 @@ function remove(unit: Unit.IUnit, underworld: Underworld) {
     return;
   }
   // Safely restore unit's original properties
-  const { scaleX, scaleY, healthMax, manaMax, staminaMax, damage, moveSpeed } = unit.modifiers[id].originalStats;
+  const { scaleX, scaleY, healthMax, manaMax, manaPerTurn, staminaMax, damage, moveSpeed } = unit.modifiers[id].originalStats;
   if (unit.image) {
     unit.image.sprite.scale.x = scaleX;
     unit.image.sprite.scale.y = scaleY;
@@ -49,6 +49,7 @@ function remove(unit: Unit.IUnit, underworld: Underworld) {
   unit.manaMax = manaMax;
   // Prevent unexpected overflow
   unit.mana = Math.min(manaMax, unit.mana);
+  unit.manaPerTurn = manaPerTurn;
 
   const staminaChange = staminaMax / unit.staminaMax;
   unit.stamina *= staminaChange;
@@ -61,7 +62,7 @@ function remove(unit: Unit.IUnit, underworld: Underworld) {
   unit.moveSpeed = moveSpeed;
 }
 function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) {
-  const { healthMax, manaMax, staminaMax, damage, moveSpeed } = unit;
+  const { healthMax, manaMax, manaPerTurn, staminaMax, damage, moveSpeed } = unit;
   const modifier = getOrInitModifier(unit, id, {
     isCurse: true,
     quantity,
@@ -71,6 +72,7 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
       scaleY: unit.image && unit.image.sprite.scale.y || 1,
       healthMax,
       manaMax,
+      manaPerTurn,
       staminaMax,
       damage,
       moveSpeed

--- a/src/cards/suffocate.ts
+++ b/src/cards/suffocate.ts
@@ -84,7 +84,7 @@ export function updateTooltip(unit: Unit.IUnit) {
     const turnsUntilSuffocation = Math.ceil(2 * Math.log2(unit.health / 10) + 1) - modifier.quantity;
 
     // Set tooltip:
-    modifier.tooltip = i18n(['turns until suffocation', turnsUntilSuffocation.toString()]);
+    modifier.tooltip = `${turnsUntilSuffocation} ${i18n('turns until suffocation')}`;
   }
 }
 

--- a/src/cards/summon_generic.ts
+++ b/src/cards/summon_generic.ts
@@ -27,181 +27,195 @@ import { DARK_PRIEST_ID } from '../entity/units/darkPriest';
 
 
 const overrides: { [unitId: string]: { exclude: boolean, properties: { manaCost?: number } } } = {
-    'decoy': {
-        exclude: true,
-        properties: {}
-    },
-    [golem_unit_id]: {
-        exclude: false,
-        properties: { manaCost: 60 }
-    },
-    [ARCHER_ID]: {
-        exclude: false,
-        properties: { manaCost: 60 }
-    },
-    [ANCIENT_UNIT_ID]: {
-        exclude: false,
-        properties: { manaCost: 50 }
-    },
-    [GLOP_UNIT_ID]: {
-        exclude: false,
-        properties: { manaCost: 80 }
-    },
-    [gripthulu_id]: {
-        exclude: false,
-        properties: { manaCost: 80 }
-    },
-    [BLOOD_GOLEM_ID]: {
-        exclude: false,
-        properties: { manaCost: 100 }
-    },
-    [POISONER_ID]: {
-        exclude: false,
-        properties: { manaCost: 100 }
-    },
-    [VAMPIRE_ID]: {
-        exclude: false,
-        properties: { manaCost: 150 }
-    },
-    [BLOOD_ARCHER_ID]: {
-        exclude: false,
-        properties: { manaCost: 130 }
-    },
-    [PRIEST_ID]: {
-        exclude: false,
-        properties: { manaCost: 130 }
-    },
-    [SUMMONER_ID]: {
-        exclude: false,
-        properties: { manaCost: 150 }
-    },
-    [GHOST_ARCHER_ID]: {
-        exclude: false,
-        properties: { manaCost: 180 }
-    },
-    [MANA_VAMPIRE_ID]: {
-        exclude: false,
-        properties: { manaCost: 180 }
-    },
-    [DARK_SUMMONER_ID]: {
-        exclude: false,
-        properties: { manaCost: 210 }
-    },
-    [DARK_PRIEST_ID]: {
-        exclude: false,
-        properties: { manaCost: 210 }
-    },
-    [bossmasonUnitId]: {
-        exclude: false,
-        properties: { manaCost: 400 }
-    },
-    'Spellmason': {
-        exclude: false,
-        properties: {}
-    },
+  'decoy': {
+    exclude: true,
+    properties: {}
+  },
+  [golem_unit_id]: {
+    exclude: false,
+    properties: { manaCost: 60 }
+  },
+  [ARCHER_ID]: {
+    exclude: false,
+    properties: { manaCost: 60 }
+  },
+  [ANCIENT_UNIT_ID]: {
+    exclude: false,
+    properties: { manaCost: 50 }
+  },
+  [GLOP_UNIT_ID]: {
+    exclude: false,
+    properties: { manaCost: 80 }
+  },
+  [gripthulu_id]: {
+    exclude: false,
+    properties: { manaCost: 80 }
+  },
+  [BLOOD_GOLEM_ID]: {
+    exclude: false,
+    properties: { manaCost: 100 }
+  },
+  [POISONER_ID]: {
+    exclude: false,
+    properties: { manaCost: 100 }
+  },
+  [VAMPIRE_ID]: {
+    exclude: false,
+    properties: { manaCost: 150 }
+  },
+  [BLOOD_ARCHER_ID]: {
+    exclude: false,
+    properties: { manaCost: 130 }
+  },
+  [PRIEST_ID]: {
+    exclude: false,
+    properties: { manaCost: 130 }
+  },
+  [SUMMONER_ID]: {
+    exclude: false,
+    properties: { manaCost: 150 }
+  },
+  [GHOST_ARCHER_ID]: {
+    exclude: false,
+    properties: { manaCost: 180 }
+  },
+  [MANA_VAMPIRE_ID]: {
+    exclude: false,
+    properties: { manaCost: 180 }
+  },
+  [DARK_SUMMONER_ID]: {
+    exclude: false,
+    properties: { manaCost: 210 }
+  },
+  [DARK_PRIEST_ID]: {
+    exclude: false,
+    properties: { manaCost: 210 }
+  },
+  [bossmasonUnitId]: {
+    exclude: false,
+    properties: { manaCost: 400 }
+  },
+  'Spellmason': {
+    exclude: false,
+    properties: {}
+  },
 }
 export default function makeSpellForUnitId(unitId: string, asMiniboss: boolean, difficulty?: number): Spell | undefined {
-    const override = overrides[unitId];
-    const sourceUnit = allUnits[unitId];
-    if (!sourceUnit) {
-        console.error('Could not find source unit for ', unitId);
-        return undefined;
-    }
-    if (override && override.exclude) {
-        return undefined;
-    }
-    const unitAppearsAtLevelIndex = sourceUnit.spawnParams?.unavailableUntilLevelIndex || 1;
-    let rarity = CardRarity.COMMON;
-    if (unitAppearsAtLevelIndex < 4) {
-        rarity = CardRarity.COMMON
-    } else if (unitAppearsAtLevelIndex < 6) {
-        rarity = CardRarity.SPECIAL;
-    } else if (unitAppearsAtLevelIndex < 8) {
-        rarity = CardRarity.UNCOMMON;
-    } else if (unitAppearsAtLevelIndex < 10) {
-        rarity = CardRarity.RARE;
-    } else {
-        rarity = CardRarity.FORBIDDEN;
-    }
+  const override = overrides[unitId];
+  const sourceUnit = allUnits[unitId];
+  if (!sourceUnit) {
+    console.error('Could not find source unit for ', unitId);
+    return undefined;
+  }
+  if (override && override.exclude) {
+    return undefined;
+  }
+  const unitAppearsAtLevelIndex = sourceUnit.spawnParams?.unavailableUntilLevelIndex || 1;
+  let rarity = CardRarity.COMMON;
+  if (unitAppearsAtLevelIndex < 4) {
+    rarity = CardRarity.COMMON
+  } else if (unitAppearsAtLevelIndex < 6) {
+    rarity = CardRarity.SPECIAL;
+  } else if (unitAppearsAtLevelIndex < 8) {
+    rarity = CardRarity.UNCOMMON;
+  } else if (unitAppearsAtLevelIndex < 10) {
+    rarity = CardRarity.RARE;
+  } else {
+    rarity = CardRarity.FORBIDDEN;
+  }
 
-    const expenseScaling = 2;
-    const manaCost = override?.properties.manaCost ? (override.properties.manaCost * (asMiniboss ? 1.5 : 1)) : Math.max(1, Math.round(2 * Math.log2((sourceUnit.spawnParams?.budgetCost || 1)))) * 30 * (asMiniboss ? 2 : 1);
-    const id = unitId + (asMiniboss ? ' Miniboss' : '');
-    const unitSource = allUnits[unitId];
-    let healthMax = unitSource?.unitProps.healthMax || config.UNIT_BASE_HEALTH;
-    let manaMax = unitSource?.unitProps.manaMax || 0;
+  const expenseScaling = 2;
+  const manaCost = override?.properties.manaCost ? (override.properties.manaCost * (asMiniboss ? 1.5 : 1)) : Math.max(1, Math.round(2 * Math.log2((sourceUnit.spawnParams?.budgetCost || 1)))) * 30 * (asMiniboss ? 1.5 : 1);
+  const id = unitId + (asMiniboss ? ' Miniboss' : '');
+  const unitSource = allUnits[unitId];
+  let unitStats = '';
+
+  if (unitSource) {
+    let damage = unitSource.unitProps.damage || 0;
+    let healthMax = unitSource.unitProps.healthMax || config.UNIT_BASE_HEALTH;
+    let manaMax = unitSource.unitProps.manaMax || 0;
+    let manaPerTurn = unitSource.unitProps.manaPerTurn || 0;
     if (difficulty && unitSource) {
-        const adjustedUnitProps = Unit.adjustUnitPropsDueToDifficulty(unitSource, difficulty);
-        healthMax = adjustedUnitProps.healthMax;
-        manaMax = adjustedUnitProps.manaMax;
+      const adjustedUnitProps = Unit.adjustUnitPropsDueToDifficulty(unitSource, difficulty);
+      healthMax = adjustedUnitProps.healthMax;
+      manaMax = adjustedUnitProps.manaMax;
     }
-    const unitStats = !unitSource ? '' : `${!!unitSource.unitProps.damage ? `
-🗡️ ${unitSource.unitProps.damage} ${i18n(['damage'])}` : ''}${!!unitSource.unitProps.attackRange ? `
+
+    if (asMiniboss) {
+      damage *= config.UNIT_MINIBOSS_DAMAGE_MULTIPLIER;
+      healthMax *= config.UNIT_MINIBOSS_HEALTH_MULTIPLIER;
+      manaMax *= config.UNIT_MINIBOSS_MANA_MULTIPLIER;
+      manaPerTurn *= config.UNIT_MINIBOSS_MANA_MULTIPLIER;
+    }
+
+    unitStats = `${!!unitSource.unitProps.damage ? `
+🗡️ ${damage} ${i18n(['damage'])}` : ''}${!!unitSource.unitProps.attackRange ? `
 🎯 ${unitSource.unitProps.attackRange} ${i18n(['attack range'])}` : ''}
-❤️ ${healthMax} ${i18n(['health capacity'])}
-${manaMax ? `🔵 ${manaMax} + ${unitSource.unitProps.manaPerTurn} ${i18n('Mana')} ${i18n('per turn')}` : ''}`;
+❤️ ${healthMax} ${i18n(['health capacity'])}${manaMax ? `
+🔵 ${manaMax} + ${manaPerTurn} ${i18n('Mana')} ${i18n('per turn')}` : ''}`;
+  }
 
-    return {
-        card: {
-            id,
-            category: CardCategory.Soul,
-            sfx: 'summonDecoy',
-            supportQuantity: true,
-            // Make mana cost dependent on how late they show up in the game
-            manaCost,
-            healthCost: 0,
-            expenseScaling,
-            cooldown: 0,
-            // These cards are not available as upgrades and must be accessed through capture_soul
-            probability: 0,
-            thumbnail: `spellIconSummon_${unitId.split(' ').join('').toLowerCase()}.png`,
-            description: i18n([`spell_summon_generic`, unitId, expenseScaling.toString()]) + '\n' + unitStats,
-            allowNonUnitTarget: true,
-            effect: async (state, card, quantity, underworld, prediction) => {
-                const sourceUnit = allUnits[unitId];
-                if (sourceUnit) {
-                    const summonLocation = {
-                        x: state.castLocation.x,
-                        y: state.castLocation.y
-                    }
-                    if (underworld.isCoordOnWallTile(summonLocation)) {
-                        if (prediction) {
-                            const WARNING = "Invalid Summon Location";
-                            addWarningAtMouse(WARNING);
-                        } else {
-                            refundLastSpell(state, prediction, 'Invalid summon location, mana refunded.')
-                        }
-                        return state;
-                    }
-                    playDefaultSpellSFX(card, prediction);
-                    const unit = Unit.create(
-                        sourceUnit.id,
-                        summonLocation.x,
-                        summonLocation.y,
-                        Faction.ALLY,
-                        sourceUnit.info.image,
-                        UnitType.AI,
-                        sourceUnit.info.subtype,
-                        {
-                            ...sourceUnit.unitProps,
-                            isMiniboss: asMiniboss,
-                            strength: quantity,
-                        },
-                        underworld,
-                        prediction
-                    );
-
-                    addUnitTarget(unit, state);
-
-                    if (!prediction) {
-                        // Animate effect of unit spawning from the sky
-                        skyBeam(unit);
-                    }
-                } else {
-                    console.error(`Source unit ${unitId} is missing`);
-                }
-                return state;
+  return {
+    card: {
+      id,
+      category: CardCategory.Soul,
+      sfx: 'summonDecoy',
+      supportQuantity: true,
+      // Make mana cost dependent on how late they show up in the game
+      manaCost,
+      healthCost: 0,
+      expenseScaling,
+      cooldown: 0,
+      // These cards are not available as upgrades and must be accessed through capture_soul
+      probability: 0,
+      thumbnail: `spellIconSummon_${unitId.split(' ').join('').toLowerCase()}.png`,
+      description: i18n([`spell_summon_generic`, unitId, expenseScaling.toString()]) + '\n' + unitStats,
+      allowNonUnitTarget: true,
+      effect: async (state, card, quantity, underworld, prediction) => {
+        const sourceUnit = allUnits[unitId];
+        if (sourceUnit) {
+          const summonLocation = {
+            x: state.castLocation.x,
+            y: state.castLocation.y
+          }
+          if (underworld.isCoordOnWallTile(summonLocation)) {
+            if (prediction) {
+              const WARNING = "Invalid Summon Location";
+              addWarningAtMouse(WARNING);
+            } else {
+              refundLastSpell(state, prediction, 'Invalid summon location, mana refunded.')
+            }
+            return state;
+          }
+          playDefaultSpellSFX(card, prediction);
+          const unit = Unit.create(
+            sourceUnit.id,
+            summonLocation.x,
+            summonLocation.y,
+            Faction.ALLY,
+            sourceUnit.info.image,
+            UnitType.AI,
+            sourceUnit.info.subtype,
+            {
+              ...sourceUnit.unitProps,
+              isMiniboss: asMiniboss,
+              strength: quantity,
             },
-        },
-    };
+            underworld,
+            prediction
+          );
+
+          addUnitTarget(unit, state);
+
+          if (!prediction) {
+            // Animate effect of unit spawning from the sky
+            skyBeam(unit);
+          }
+        } else {
+          console.error(`Source unit ${unitId} is missing`);
+        }
+        return state;
+      },
+    },
+  };
 }

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -24,6 +24,7 @@ import { getPerkText } from '../Perk';
 import { View } from '../views';
 import { gripthulu_id } from '../entity/units/gripthulu';
 import { getSuffocateBuildup, suffocateCardId } from '../cards/suffocate';
+import * as Cards from '../cards';
 
 const TEXT_OUT_OF_RANGE = 'Out of Range';
 // Graphics for rendering above board and walls but beneath units and doodads,
@@ -817,6 +818,11 @@ export function updateTooltipContent(underworld: Underworld) {
         if (globalThis.selectedUnit.unitType === UnitType.PLAYER_CONTROLLED) {
           const player = underworld.players.find((p) => p.unit === globalThis.selectedUnit);
           if (player) {
+            const replacedCards = Cards.getCardsFromIds(player.inventory).flatMap(card => card.replaces || []);
+            const inventory = player.inventory
+              // .filter: Hide replaced cards in inventory
+              .filter(cardId => !replacedCards.includes(cardId));
+
             playerSpecificInfo = '';
             if (player.mageType) {
               playerSpecificInfo += `<br/>${player.mageType}</div>`;
@@ -852,7 +858,7 @@ export function updateTooltipContent(underworld: Underworld) {
             // }
             playerSpecificInfo +=
               '<h3>Spells</h3>' +
-              player.inventory.filter(x => x !== '').join(', ');
+              inventory.filter(x => x !== '').join(', ');
 
           } else {
             console.error('Tooltip: globalThis.selectedUnit is player controlled but does not exist in underworld.players array.');

--- a/src/graphics/ui/CardUI.ts
+++ b/src/graphics/ui/CardUI.ts
@@ -969,9 +969,7 @@ export function updateCardBadges(underworld: Underworld) {
         const elBadgesH = document.querySelectorAll(`#selected-cards .card[data-card-id="${card.id}"] .card-health-badge`);
         const elBadgeH = Array.from(elBadgesH)[sliceOfCardsOfSameIdUntilCurrent.length];
         if (elBadgeH) {
-          // onDamageEvents alter the healthCost of cards that cost health to cast
-          // such as 'bite', 'vulnerable', or 'shield'
-          updateHealthBadge(elBadgeH, composeOnDamageEvents(predictionPlayerUnit, cost.healthCost, underworld, true), card);
+          updateHealthBadge(elBadgeH, cost.healthCost, card);
         }
       }
     }
@@ -1008,10 +1006,8 @@ export function updateCardBadges(underworld: Underworld) {
         for (let elBadge of badgeRecord.mana) {
           updateManaBadge(elBadge, cost.manaCost, card);
         }
-        // onDamageEvents alter the healthCost of cards that cost health to cast
-        // such as 'bite', 'vulnerable', or 'shield'
         for (let elBadgeHealth of badgeRecord.health) {
-          updateHealthBadge(elBadgeHealth, composeOnDamageEvents(predictionPlayerUnit, cost.healthCost, underworld, true), card);
+          updateHealthBadge(elBadgeHealth, cost.healthCost, card);
         }
       }
     }


### PR DESCRIPTION
Closes #72 
- Summon stats now account for miniboss modifiers

Closes #250
- Replaced spells no longer appear in the player tooltip

Closes #251
- Fixed an issue with Dark Priest attack prediction

Closes #252
- Spells display their unadjusted health cost while shielded/fortified

Closes #253
- Mana Regen is restored upon split removal

Closes #254
- Purify can now target corpses

Closes #213
- Fixed suffocate tooltip

Also fixed an issue that caused some cards to say "upgrade" when they actually only "require" the following pre-requisite.