### PR TITLE
Send Mana Id (i18n)

### DIFF
--- a/src/cards/send_mana.ts
+++ b/src/cards/send_mana.ts
@@ -12,7 +12,7 @@ import { MultiColorReplaceFilter } from '@pixi/filter-multi-color-replace';
 import * as config from '../config';
 import { explain, EXPLAIN_OVERFILL } from '../graphics/Explain';
 
-export const id = 'send_mana';
+export const id = 'Send Mana';
 const amount = 20;
 
 const spell: Spell = {


### PR DESCRIPTION
Closes #224 

Upgrade.ts was searching for localization id "send_mana" but in the sheet it is called "Send Mana". I went ahead and just changed the spell id to match the localization.

@jdoleary 
There doesn't seem to be any standard naming convention for spell ids. Do you want me to clean this up? Also, should we sort the localization sheet alphabetically to group similar things together/prevent duplicates? It would only take a few clicks, but I wasn't sure if it was left the way it is for a specific reason.