### PR TITLE
* Added ignoreRange flag to ICard

### DIFF
--- a/src/PlayerUtils.ts
+++ b/src/PlayerUtils.ts
@@ -1,6 +1,7 @@
 import * as math from './jmath/math';
 import throttle from 'lodash.throttle';
 import * as Player from './entity/Player';
+import * as Cards from './cards';
 import * as config from './config';
 import { round, Vec2 } from './jmath/Vec';
 import Underworld from './Underworld';
@@ -10,7 +11,7 @@ import { targetArrowCardId } from './cards/target_arrow';
 
 function isAllowedToCastOutOfRange(cardIds: string[]): boolean {
     // Exception, if all of the cards cast are arrow cards, let them cast out of range
-    return cardIds[0] == targetArrowCardId || cardIds.every(id => id.toLowerCase().includes('arrow'));
+    return cardIds[0] == targetArrowCardId || cardIds.every(id => Cards.allCards[id]?.ignoreRange);
 }
 export function isOutOfRange(caster: Player.IPlayer, target: Vec2, underworld: Underworld, cardIds?: string[]): boolean {
     if (cardIds && cardIds.length && isAllowedToCastOutOfRange(cardIds)) {

--- a/src/cards/arrow.ts
+++ b/src/cards/arrow.ts
@@ -25,6 +25,7 @@ const spell: Spell = {
     thumbnail: 'spellIconArrow.png',
     // so that you can fire the arrow at targets out of range
     allowNonUnitTarget: true,
+    ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
     description: ['spell_arrow', damage.toString()],

--- a/src/cards/arrow2.ts
+++ b/src/cards/arrow2.ts
@@ -18,6 +18,7 @@ const spell: Spell = {
     thumbnail: 'spellIconArrow2.png',
     // so that you can fire the arrow at targets out of range
     allowNonUnitTarget: true,
+    ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
     description: ['spell_arrow', damageDone.toString()],

--- a/src/cards/arrow3.ts
+++ b/src/cards/arrow3.ts
@@ -19,6 +19,7 @@ const spell: Spell = {
     thumbnail: 'spellIconArrow3.png',
     // so that you can fire the arrow at targets out of range
     allowNonUnitTarget: true,
+    ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
     description: ['spell_arrow', damageDone.toString()],

--- a/src/cards/arrow_far.ts
+++ b/src/cards/arrow_far.ts
@@ -32,6 +32,7 @@ const spell: Spell = {
     thumbnail: 'spellIconArrowLong.png',
     // so that you can fire the arrow at targets out of range
     allowNonUnitTarget: true,
+    ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
     description: ['spell_arrow_far', maxDamage.toString()],

--- a/src/cards/arrow_fork.ts
+++ b/src/cards/arrow_fork.ts
@@ -23,6 +23,7 @@ const spell: Spell = {
     thumbnail: 'spellIconArrowFork.png',
     // so that you can fire the arrow at targets out of range
     allowNonUnitTarget: true,
+    ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
     description: ['spell_arrow_fork', damageDone.toString()],

--- a/src/cards/arrow_multi.ts
+++ b/src/cards/arrow_multi.ts
@@ -20,6 +20,7 @@ const spell: Spell = {
     thumbnail: 'spellIconArrowMulti.png',
     // so that you can fire the arrow at targets out of range
     allowNonUnitTarget: true,
+    ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
     description: ['spell_arrow_many', arrowCount.toString(), damageDone.toString()],

--- a/src/cards/arrow_triple.ts
+++ b/src/cards/arrow_triple.ts
@@ -20,6 +20,7 @@ const spell: Spell = {
     thumbnail: 'spellIconArrowTriple.png',
     // so that you can fire the arrow at targets out of range
     allowNonUnitTarget: true,
+    ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
     description: ['spell_arrow_many', arrowCount.toString(), damageDone.toString()],

--- a/src/cards/explosive_arrow.ts
+++ b/src/cards/explosive_arrow.ts
@@ -26,6 +26,7 @@ const spell: Spell = {
     thumbnail: 'spellIconExplosiveArrow.png',
     // so that you can fire the arrow at targets out of range
     allowNonUnitTarget: true,
+    ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
     description: ['spell_arrow_explosive', damageDone.toString(), explodeDamage.toString()],

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -477,6 +477,8 @@ export interface ICard {
   supportQuantity?: boolean;
   // used to assist with targeting for spells that only affect dead units
   onlySelectDeadUnits?: boolean;
+  // if true, character range will be ignored for this spell
+  ignoreRange?: boolean;
   sfx?: string;
 }
 

--- a/src/cards/phantom_arrow.ts
+++ b/src/cards/phantom_arrow.ts
@@ -22,6 +22,7 @@ const spell: Spell = {
     thumbnail: 'spellIconArrowRed.png',
     // so that you can fire the arrow at targets out of range
     allowNonUnitTarget: true,
+    ignoreRange: true,
     animationPath: '',
     sfx: 'phantomArrow',
     description: ['spell_phantom_arrow', damageDone.toString()],

--- a/src/cards/target_arrow.ts
+++ b/src/cards/target_arrow.ts
@@ -21,6 +21,7 @@ const spell: Spell = {
     thumbnail: 'spellIconArrowGreen.png',
     // so that you can fire the arrow at targets out of range
     allowNonUnitTarget: true,
+    ignoreRange: true,
     // This ensures that "target scamming" doesn't work with target arrow
     // due to it being able to fire out of range
     noInitialTarget: true,


### PR DESCRIPTION
* Added ignoreRange flag to ICard
* Set to true for arrow spells
* Updated check in isAllowedToCastOutOfRange to use ignoreRange

This should allow new cards to be added that can also ignore range restrictions without having to include 'arrow' in that card's id.

This will need an accompanying PR into the mods repo to update the ICard interface, so that it also includes ignoreRange.