### PR TITLE
Resurrect requires a valid corpse

### DIFF
--- a/src/cards/resurrect.ts
+++ b/src/cards/resurrect.ts
@@ -30,7 +30,7 @@ const spell: Spell = {
       const targets = state.targetedUnits;
       let resurrectedUnitCount = 0;
       for (let unit of targets) {
-        if (unit && !unit.alive) {
+        if (unit && !unit.alive && !unit.flaggedForRemoval) {
           let colorOverlayFilter: ColorOverlayFilter;
           if (unit.image && unit.image.sprite.filters) {
             // Overlay with white

--- a/src/cards/resurrect_toxic.ts
+++ b/src/cards/resurrect_toxic.ts
@@ -31,7 +31,7 @@ const spell: Spell = {
       const targets = state.targetedUnits;
       let resurrectedUnitCount = 0;
       for (let unit of targets) {
-        if (unit && !unit.alive) {
+        if (unit && !unit.alive && !unit.flaggedForRemoval) {
           let colorOverlayFilter: ColorOverlayFilter;
           if (unit.image && unit.image.sprite.filters) {
             // Overlay with white

--- a/src/cards/resurrect_weak.ts
+++ b/src/cards/resurrect_weak.ts
@@ -29,7 +29,7 @@ const spell: Spell = {
       const targets = state.targetedUnits;
       let resurrectedUnitCount = 0;
       for (let unit of targets) {
-        if (unit && !unit.alive) {
+        if (unit && !unit.alive && !unit.flaggedForRemoval) {
           let colorOverlayFilter: ColorOverlayFilter;
           if (unit.image && unit.image.sprite.filters) {
             // Overlay with white


### PR DESCRIPTION
Fixed an issue where you could resurrect a unit after using bone shrapnel on them, which could lock the game in the case of a player character and cause lots of visual/targeting issues in the case of other units.