### PR TITLE
Safe cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ update/
 .vs/
 .vscode/
 public/spellmasons-mods/types
+.DS_Store

--- a/src/Syncronization.ts
+++ b/src/Syncronization.ts
@@ -1,0 +1,19 @@
+import * as Unit from "./entity/Unit"
+import { UnitType } from "./types/commonTypes";
+
+// syncUnits should:
+// NOT remove any existing player's units (even if there are discrepancies)
+// Sync the state of player units
+// Sync the state of identical non player units
+// Remove units not in the serialized units array (so long as they are not player units)
+// Create missing units from the serialized array (careful not to overwrite ids of existing units)
+interface UnitSubType {
+    id: number;
+    unitSourceId: string;
+    unitType: UnitType;
+}
+export function syncUnits(current: Unit.IUnit[], syncFrom: Unit.IUnitSerialized[]): Unit.IUnit[] {
+    // TODO maybe use a subtype so it's testable without constructing a whole underworld
+    return [];
+
+}

--- a/src/Syncronization.ts
+++ b/src/Syncronization.ts
@@ -3,17 +3,59 @@ import { UnitType } from "./types/commonTypes";
 
 // syncUnits should:
 // NOT remove any existing player's units (even if there are discrepancies)
-// Sync the state of player units
-// Sync the state of identical non player units
-// Remove units not in the serialized units array (so long as they are not player units)
+//   Note: Missing player unit's should be sent to the server from clients
+//   This should piggy back on CLIENT_SEND_PLAYER_TO_SERVER
+// Sync the state of identityMatched units (same id, same type, same sourceId)
+// Remove current units not in the serialized units array (so long as they are not player units)
 // Create missing units from the serialized array (careful not to overwrite ids of existing units)
-interface UnitSubType {
-    id: number;
-    unitSourceId: string;
-    unitType: UnitType;
+
+// TODO: INPROGRESS (replace `any`s) maybe use a subtype so it's testable without constructing a whole underworld
+interface syncFunctionReturn {
+    // Which objects should be synced,
+    // first is from `current`
+    // last is from `syncFrom`
+    sync: [any, any][];
+    //  current to remove
+    remove: any[];
+    //  Current objects to send to the server
+    syncToServer: any[];
+    // Objects of syncFrom to create new
+    create: any[];
+
 }
-export function syncUnits(current: Unit.IUnit[], syncFrom: Unit.IUnitSerialized[]): Unit.IUnit[] {
-    // TODO maybe use a subtype so it's testable without constructing a whole underworld
-    return [];
+// Identity match determines if the units are the same entity (and then it's okay to sync from syncFrom to current for that entity)
+export function getSyncActions(
+    current: any[],
+    syncFrom: any[],
+    findMatchIndex: (a: any, potentialMatches: any[]) => number,
+    ignoreSync: (a: any) => boolean): syncFunctionReturn {
+    const ret: syncFunctionReturn = {
+        sync: [],
+        remove: [],
+        syncToServer: [],
+        create: []
+    }
+    const matches: any[] = []
+    for (let i = 0; i < current.length; i++) {
+        const e = current[i];
+        const matchIndex = findMatchIndex(e, syncFrom);
+        const match = syncFrom[matchIndex]
+        if (match) {
+            // Keep track of what synced so we can create the extras in syncFrom as new
+            matches.push(match);
+            ret.sync.push([e, match]);
+        } else {
+            if (!ignoreSync(e)) {
+                ret.remove.push(e);
+            } else {
+                ret.syncToServer.push(e);
+            }
+        }
+    }
+    const toBeCreated = syncFrom.filter(x => !matches.includes(x));
+    for (let e of toBeCreated) {
+        ret.create.push(e);
+    }
+    return ret;
 
 }

--- a/src/Syncronization.ts
+++ b/src/Syncronization.ts
@@ -1,5 +1,3 @@
-import * as Unit from "./entity/Unit"
-import { UnitType } from "./types/commonTypes";
 
 // syncUnits should:
 // NOT remove any existing player's units (even if there are discrepancies)
@@ -9,35 +7,33 @@ import { UnitType } from "./types/commonTypes";
 // Remove current units not in the serialized units array (so long as they are not player units)
 // Create missing units from the serialized array (careful not to overwrite ids of existing units)
 
-// TODO: INPROGRESS (replace `any`s) maybe use a subtype so it's testable without constructing a whole underworld
-interface syncFunctionReturn {
+interface syncFunctionReturn<T> {
     // Which objects should be synced,
     // first is from `current`
     // last is from `syncFrom`
-    sync: [any, any][];
+    sync: [T, T][];
     //  current to remove
-    remove: any[];
+    remove: T[];
     //  Current objects to send to the server
-    syncToServer: any[];
+    syncToServer: T[];
     // Objects of syncFrom to create new
-    create: any[];
+    create: T[];
 
 }
 // Identity match determines if the units are the same entity (and then it's okay to sync from syncFrom to current for that entity)
-export function getSyncActions(
-    current: any[],
-    syncFrom: any[],
-    findMatchIndex: (a: any, potentialMatches: any[]) => number,
-    ignoreSync: (a: any) => boolean): syncFunctionReturn {
-    const ret: syncFunctionReturn = {
+export function getSyncActions<T>(
+    current: T[],
+    syncFrom: T[],
+    findMatchIndex: (a: T, potentialMatches: T[]) => number,
+    ignoreSync: (a: T) => boolean): syncFunctionReturn<T> {
+    const ret: syncFunctionReturn<T> = {
         sync: [],
         remove: [],
         syncToServer: [],
         create: []
     }
-    const matches: any[] = []
-    for (let i = 0; i < current.length; i++) {
-        const e = current[i];
+    const matches: T[] = []
+    for (let e of current) {
         const matchIndex = findMatchIndex(e, syncFrom);
         const match = syncFrom[matchIndex]
         if (match) {

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3801,6 +3801,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
     for (let sendToServer of actions.skippedRemoval) {
       // TODO send to server
+      console.error('TODO: player unit is missing on server, client should send player unit to server')
     }
 
     // Remove units that were just cleaned up

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -1159,7 +1159,7 @@ export default class Underworld {
       Pickup.removePickup(x, this, false);
     }
     this.players = [];
-    this.units.forEach(u => Unit.cleanup(u));
+    this.units.forEach(u => Unit.cleanup(u, false, true));
     globalThis.selectedPickup = undefined;
     globalThis.selectedUnit = undefined;
 

--- a/src/__test__/Syncronization.test.ts
+++ b/src/__test__/Syncronization.test.ts
@@ -10,8 +10,8 @@ interface testSyncObject {
     type: string;
     value: number;
 }
-function findMatchIndex(current: testSyncObject, potentialMatches: testSyncObject[]): number {
-    return potentialMatches.findIndex(x => x.id == current.id);
+function findMatch(current: testSyncObject, potentialMatches: testSyncObject[]): testSyncObject | undefined {
+    return potentialMatches.find(x => x.id == current.id);
 }
 function sync(current: testSyncObject, from: testSyncObject) {
     current.type = from.type;
@@ -39,7 +39,7 @@ describe('Syncronization', () => {
         const from = [
             makeTestSyncObject(unitCurrent.id, 'unit', 11),
         ];
-        const actual = getSyncActions(current, from, findMatchIndex, ignoreSync);
+        const actual = getSyncActions(current, from, findMatch, ignoreSync);
         expect(actual.remove).toEqual([]);
     });
     it('should sync the state of identity matched units', () => {
@@ -52,7 +52,7 @@ describe('Syncronization', () => {
         const from = [
             makeTestSyncObject(unitCurrent.id, 'unit', 11),
         ];
-        const actual = getSyncActions(current, from, findMatchIndex, ignoreSync);
+        const actual = getSyncActions(current, from, findMatch, ignoreSync);
         expect(actual.sync).toEqual([[unitCurrent, from[0]]]);
     });
     it('should remove current units not in the serialized array', () => {
@@ -67,7 +67,7 @@ describe('Syncronization', () => {
             player,
             fromUnit,
         ];
-        const actual = getSyncActions(current, from, findMatchIndex, ignoreSync);
+        const actual = getSyncActions(current, from, findMatch, ignoreSync);
         expect(actual.remove).toEqual([unitCurrent]);
     });
     it('should create missing units', () => {
@@ -82,7 +82,7 @@ describe('Syncronization', () => {
             player,
             fromUnit,
         ];
-        const actual = getSyncActions(current, from, findMatchIndex, ignoreSync);
+        const actual = getSyncActions(current, from, findMatch, ignoreSync);
         expect(actual.create).toEqual([fromUnit]);
     });
 });

--- a/src/__test__/Syncronization.test.ts
+++ b/src/__test__/Syncronization.test.ts
@@ -1,0 +1,52 @@
+import * as Unit from "../entity/Unit"
+import playerUnit from "../entity/units/playerUnit";
+import { Faction, UnitSubType, UnitType } from "../types/commonTypes";
+import golem from '../entity/units/golem';
+import { syncUnits } from '../Syncronization';
+import { registerUnit } from "../entity/units";
+function makePlayerUnit(): Unit.IUnit {
+    return Unit.create(
+        playerUnit.id,
+        // x,y of NaN denotes that the player unit is
+        // inPortal.  See the function inPortal for more
+        NaN,
+        NaN,
+        Faction.ALLY,
+        playerUnit.info.image,
+        UnitType.PLAYER_CONTROLLED,
+        playerUnit.info.subtype,
+        undefined,
+        // @ts-ignore no underworld in tests
+        undefined
+    );
+}
+function makeGolem(): Unit.IUnit {
+    const sourceUnit = golem;
+    return Unit.create(
+        sourceUnit.id,
+        0,
+        0,
+        Faction.ENEMY,
+        sourceUnit.info.image,
+        UnitType.AI,
+        sourceUnit.info.subtype,
+        sourceUnit.unitProps,
+        // @ts-ignore no underworld in tests
+        undefined
+    );
+
+}
+registerUnit(playerUnit);
+registerUnit(golem);
+describe('Syncronization', () => {
+    it('should NOT remove any existing player units', () => {
+        const playerUnit1 = makePlayerUnit();
+        const golem = makeGolem();
+        const golem2 = makeGolem();
+        golem2.id = 3;
+        const actual = syncUnits([playerUnit1, golem], [Unit.serialize(golem2)]);
+        expect(actual).toEqual([playerUnit1, golem2]);
+
+
+    });
+});

--- a/src/__test__/Syncronization.test.ts
+++ b/src/__test__/Syncronization.test.ts
@@ -2,51 +2,47 @@ import * as Unit from "../entity/Unit"
 import playerUnit from "../entity/units/playerUnit";
 import { Faction, UnitSubType, UnitType } from "../types/commonTypes";
 import golem from '../entity/units/golem';
-import { syncUnits } from '../Syncronization';
+import { getSyncActions } from '../Syncronization';
 import { registerUnit } from "../entity/units";
-function makePlayerUnit(): Unit.IUnit {
-    return Unit.create(
-        playerUnit.id,
-        // x,y of NaN denotes that the player unit is
-        // inPortal.  See the function inPortal for more
-        NaN,
-        NaN,
-        Faction.ALLY,
-        playerUnit.info.image,
-        UnitType.PLAYER_CONTROLLED,
-        playerUnit.info.subtype,
-        undefined,
-        // @ts-ignore no underworld in tests
-        undefined
-    );
-}
-function makeGolem(): Unit.IUnit {
-    const sourceUnit = golem;
-    return Unit.create(
-        sourceUnit.id,
-        0,
-        0,
-        Faction.ENEMY,
-        sourceUnit.info.image,
-        UnitType.AI,
-        sourceUnit.info.subtype,
-        sourceUnit.unitProps,
-        // @ts-ignore no underworld in tests
-        undefined
-    );
 
+interface testSyncObject {
+    id: number;
+    type: string;
+    value: number;
 }
-registerUnit(playerUnit);
-registerUnit(golem);
+function findMatchIndex(current: testSyncObject, potentialMatches: testSyncObject[]): number {
+    return potentialMatches.findIndex(x => x.id == current.id);
+}
+function sync(current: testSyncObject, from: testSyncObject) {
+    current.type = from.type;
+    current.value = from.value;
+}
+function ignoreSync(current: testSyncObject): boolean {
+    return current.type == 'player';
+}
+function makeTestSyncObject(id: number, type: string, value: number): testSyncObject {
+    return {
+        id,
+        type,
+        value
+    }
+}
+
 describe('Syncronization', () => {
     it('should NOT remove any existing player units', () => {
-        const playerUnit1 = makePlayerUnit();
-        const golem = makeGolem();
-        const golem2 = makeGolem();
-        golem2.id = 3;
-        const actual = syncUnits([playerUnit1, golem], [Unit.serialize(golem2)]);
-        expect(actual).toEqual([playerUnit1, golem2]);
-
-
+        const current = [
+            makeTestSyncObject(0, 'player', 1),
+            makeTestSyncObject(1, 'unit', 10),
+        ];
+        const from = [
+            makeTestSyncObject(1, 'unit', 11),
+        ];
+        const actual = getSyncActions(current, from, findMatchIndex, ignoreSync);
+        expect(actual).toEqual({
+            sync: [[current[1], from[0]]],
+            remove: [],
+            syncToServer: [current[0]],
+            create: []
+        });
     });
 });

--- a/src/__test__/Syncronization.test.ts
+++ b/src/__test__/Syncronization.test.ts
@@ -30,19 +30,59 @@ function makeTestSyncObject(id: number, type: string, value: number): testSyncOb
 
 describe('Syncronization', () => {
     it('should NOT remove any existing player units', () => {
+        const player = makeTestSyncObject(0, 'player', 1);
+        const unitCurrent = makeTestSyncObject(1, 'unit', 10);
         const current = [
-            makeTestSyncObject(0, 'player', 1),
-            makeTestSyncObject(1, 'unit', 10),
+            unitCurrent,
+            player,
         ];
         const from = [
-            makeTestSyncObject(1, 'unit', 11),
+            makeTestSyncObject(unitCurrent.id, 'unit', 11),
         ];
         const actual = getSyncActions(current, from, findMatchIndex, ignoreSync);
-        expect(actual).toEqual({
-            sync: [[current[1], from[0]]],
-            remove: [],
-            syncToServer: [current[0]],
-            create: []
-        });
+        expect(actual.remove).toEqual([]);
+    });
+    it('should sync the state of identity matched units', () => {
+        const player = makeTestSyncObject(0, 'player', 1);
+        const unitCurrent = makeTestSyncObject(1, 'unit', 10);
+        const current = [
+            unitCurrent,
+            player,
+        ];
+        const from = [
+            makeTestSyncObject(unitCurrent.id, 'unit', 11),
+        ];
+        const actual = getSyncActions(current, from, findMatchIndex, ignoreSync);
+        expect(actual.sync).toEqual([[unitCurrent, from[0]]]);
+    });
+    it('should remove current units not in the serialized array', () => {
+        const player = makeTestSyncObject(0, 'player', 1);
+        const unitCurrent = makeTestSyncObject(1, 'unit', 10);
+        const fromUnit = makeTestSyncObject(2, 'unit', 11);
+        const current = [
+            unitCurrent,
+            player,
+        ];
+        const from = [
+            player,
+            fromUnit,
+        ];
+        const actual = getSyncActions(current, from, findMatchIndex, ignoreSync);
+        expect(actual.remove).toEqual([unitCurrent]);
+    });
+    it('should create missing units', () => {
+        const player = makeTestSyncObject(0, 'player', 1);
+        const unitCurrent = makeTestSyncObject(1, 'unit', 10);
+        const fromUnit = makeTestSyncObject(2, 'unit', 11);
+        const current = [
+            unitCurrent,
+            player,
+        ];
+        const from = [
+            player,
+            fromUnit,
+        ];
+        const actual = getSyncActions(current, from, findMatchIndex, ignoreSync);
+        expect(actual.create).toEqual([fromUnit]);
     });
 });

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -397,13 +397,15 @@ export function removeModifier(unit: IUnit, key: string, underworld: Underworld)
 
 }
 
-export function cleanup(unit: IUnit, maintainPosition?: boolean) {
+export function cleanup(unit: IUnit, maintainPosition?: boolean, forceCleanPlayerUnit?: boolean) {
   // Resolve done moving on cleanup to ensure that there are no forever-blocking promises
   if (unit.resolveDoneMoving) {
     unit.resolveDoneMoving();
   }
-  // Prevent id conflicts with other existing units after cleanup
-  unit.id = -1;
+  if (unit.unitType == UnitType.PLAYER_CONTROLLED && !forceCleanPlayerUnit) {
+    console.log('Protection: Do not clean up player unit');
+    return;
+  }
   // Sometimes you will want to clean up a unit without NaN'ing it's position
   // because it's position may still be used in synchronous events such as
   // an urn exploding (being cleaned up), but there are still other onDeath

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -403,7 +403,11 @@ export function cleanup(unit: IUnit, maintainPosition?: boolean, forceCleanPlaye
     unit.resolveDoneMoving();
   }
   if (unit.unitType == UnitType.PLAYER_CONTROLLED && !forceCleanPlayerUnit) {
-    console.log('Protection: Do not clean up player unit');
+    console.log('Protection: Do not clean up player unit, instead move to portal');
+    // Instead of cleaning up the player unit, move it into the portal
+    // represented by (NaN, NaN)
+    unit.x = NaN;
+    unit.y = NaN
     return;
   }
   // Sometimes you will want to clean up a unit without NaN'ing it's position

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -984,7 +984,7 @@ async function handleLoadGameState(payload: {
   // Load units
   if (units) {
     // Clean up previous units:
-    underworld.units.forEach(u => Unit.cleanup(u));
+    underworld.units.forEach(u => Unit.cleanup(u, false, true));
     underworld.units = units.filter(u => !u.flaggedForRemoval).map(u => Unit.load(u, underworld, false));
   }
   // Note: Players should sync after units are loaded so


### PR DESCRIPTION
This PR reworks the sync functions.  Syncing is complicated because sometimes you need to add, remove, or overwrite.
Additionally, we never want to remove certain objects (such as the player unit).

This PR also protects against the player unit from getting cleaned up (for example, in Harvest or BoneShrapnel)

Fixes #306, #310