### PR TITLE
Impact Damage Fix

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -485,10 +485,10 @@ export default class Underworld {
       // Check to see if unit has falled out of lava via a forcemove
       Obstacle.tryFallInOutOfLiquid(forceMoveInst.pushedObject, this, prediction);
     } else if (isForceMoveProjectile(forceMoveInst)) {
-      const newPosition = Vec.add(pushedObject, velocity);
+      const newPosition = Vec.add(pushedObject, deltaPosition);
       pushedObject.x = newPosition.x;
       pushedObject.y = newPosition.y;
-      if (math.distance(forceMoveInst.pushedObject, forceMoveInst.startPoint) >= math.distance(forceMoveInst.endPoint, forceMoveInst.startPoint)) {
+      if (math.sqrDistance(forceMoveInst.pushedObject, forceMoveInst.startPoint) >= math.sqrDistance(forceMoveInst.endPoint, forceMoveInst.startPoint)) {
         // Projectile is done if it reaches or goes beyond its end point
         return true;
       }

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -427,36 +427,6 @@ export default class Underworld {
         pushedObject.x = newPosition.x;
         pushedObject.y = newPosition.y;
       }
-      for (let other of aliveUnits) {
-        if (other == forceMoveInst.pushedObject) {
-          // Don't collide with self
-          continue;
-        }
-        // The units' regular radius is for "crowding". It is much smaller than their actual size and it is used
-        // to ensure they can crowd together but not overlap perfect, so here we use a custom radius to detect
-        // forcePush collisions.
-        // Only allow instances that are flagged as able to create second order pushes create new pushes on collision or else you risk infinite
-        // recursion
-        if (forceMoveInst.canCreateSecondOrderPushes && isVecIntersectingVecWithCustomRadius(pushedObject, other, config.COLLISION_MESH_RADIUS)) {
-          // Don't collide with the same object more than once
-          if (forceMoveInst.alreadyCollided.includes(other)) {
-            continue;
-          }
-          forceMoveInst.alreadyCollided.push(other);
-          // If they collide transfer force:
-          // () => {}: No resolver needed for second order force pushes
-          // All pushable objects have the same mass so when a collision happens they'll split the distance
-          const fullDist = Vec.magnitude(forceMoveInst.velocity);
-          const halfDist = fullDist / 2;
-          // This is a second order push and second order pushes CANNOT create more pushes or else you risk infinite recursion in prediction mode
-          const canCreateSecondOrderPushes = false;
-          console.warn("Second order pushes may not work. Needs testing")
-          forcePushAwayFrom(other, forceMoveInst.pushedObject, halfDist, this, prediction);
-          // Reduce own velocity by half due to the transfer of force:
-          forceMoveInst.velocity = Vec.multiply(0.5, forceMoveInst.velocity);
-
-        }
-      }
       collideWithLineSegments(pushedObject, this.walls, this);
       forceMoveInst.velocity = Vec.multiply(Math.pow(velocity_falloff, deltaTime), velocity);
       if (Unit.isUnit(forceMoveInst.pushedObject)) {

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -407,10 +407,16 @@ export default class Underworld {
       const collision = predictWallCollision(forceMoveInst, this, deltaTime);
 
       if (collision.wall) {
+        // TODO - Due to different simulation speeds
+        // This will always have a very very small (<0.1%) margin of error
+        // which can cause a 1 damage difference between prediction/gameloop
+        // The fix would be to simulate forceMoves independent of deltaTime/fps
         const estimatedCollisionVelocity = Vec.multiply(Math.pow(velocity_falloff, collision.msUntilCollision), velocity);
         const magnitude = Vec.magnitude(estimatedCollisionVelocity);
 
-        let impactDamage = Math.floor((magnitude - 2) * 10);
+        // Requires at least 2 velocity for a heavy impact and
+        // smoothly deals 10 damage per velocity thereafter
+        const impactDamage = Math.floor((magnitude - 2) * 10);
         // console.log("Impact Damage: ", impactDamage, prediction);
 
         // If impact damage > 0, we hit the wall hard enough for

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -441,7 +441,7 @@ export default class Underworld {
           // We should calculate where the unit needs to move
           // This should prevent units going through walls and other weird behavior
 
-          // These examples would require modifications to
+          // These examples would require slight modifications to
           // predictWallCollision() to work correctly
 
           // Makes the unit bounce off of the wall
@@ -456,7 +456,7 @@ export default class Underworld {
           // velocity.y = newVelocity.y;
 
           // Moves the unit based off its velocity projection along the wall
-          // Units will moving parallel to the wall until passing it
+          // Units will move parallel to the wall until passing it
           // const projection = projectVelocityAlongWall(velocity, collision.wall);
           // const newPosition = Vec.add(pushedObject, Vec.multiply(deltaTime - collision.msUntilCollision, projection));
           // pushedObject.x = newPosition.x;

--- a/src/cards/arrow.ts
+++ b/src/cards/arrow.ts
@@ -69,7 +69,6 @@ export function arrowEffect(multiShotCount: number, collideFnKey: string, doesPi
           if (!prediction) {
             image = Image.create(casterPositionAtTimeOfCast, 'projectile/arrow', containerProjectiles)
             if (image) {
-
               image.sprite.rotation = Math.atan2(endPoint.y - casterPositionAtTimeOfCast.y, endPoint.x - casterPositionAtTimeOfCast.x);
             }
           }

--- a/src/effects/force_move.ts
+++ b/src/effects/force_move.ts
@@ -9,7 +9,7 @@ import { ForceMoveType, ForceMoveUnitOrPickup } from "../jmath/moveWithCollision
 
 export const defaultPushDistance = 140; // In game units
 const velocity_falloff = 0.992;
-const EXPECTED_MILLIS_PER_GAMELOOP = 0.15;
+export const EXPECTED_MILLIS_PER_GAMELOOP = 16;
 
 export async function forcePushDelta(pushedObject: HasSpace, deltaMovement: Vec2, underworld: Underworld, prediction: boolean): Promise<void> {
   // Calculate velocity needed to move object
@@ -56,7 +56,6 @@ export async function forcePushToDestination(pushedObject: HasSpace, destination
 
 // Find starting velocity based on the direction and distance we want to move
 function movementToVelocity(deltaMovement: Vec2): Vec2 {
-  let mult = (1 - velocity_falloff) / EXPECTED_MILLIS_PER_GAMELOOP;
-  mult /= 7; //correction for in game units
+  let mult = (1 - velocity_falloff);
   return multiply(mult, deltaMovement);
 }

--- a/src/jmath/Vec.ts
+++ b/src/jmath/Vec.ts
@@ -8,6 +8,8 @@ export interface Vec2 {
   y: number;
 }
 
+// TODO - Might fix them later. Not for 1.27.
+
 // Get the angle away from the x-axis from origin to point in radians
 // Note: This function returns the counter clockwise angle from the x-axis
 // of "origin" to "point".  This is tricky because I built Polygons to

--- a/src/jmath/Vec.ts
+++ b/src/jmath/Vec.ts
@@ -1,5 +1,6 @@
 
 import { clockwiseAngle } from "./Angle";
+import { LineSegment } from "./lineSegment";
 import { distance, similarTriangles, lerp } from "./math";
 import { prng, randInt } from "./rand";
 export interface Vec2 {
@@ -65,31 +66,53 @@ export function random(min: number, max: number, random?: prng): Vec2 {
   return { x: randInt(min, max, random), y: randInt(min, max, random) };
 }
 // Returns a scalar
-export function crossproduct(p1: Vec2, p2: Vec2): number {
-  return p1.x * p2.y - p1.y * p2.x;
+// Function to calculate the cross product of two 2D vectors
+export function crossProduct(v1: Vec2, v2: Vec2): number {
+  return v1.x * v2.y - v1.y * v2.x;
 }
 // Returns a scalar
+// Function to calculate the dot product of two 2D vectors
 // Source: https://www.cuemath.com/algebra/product-of-vectors/
-export function dotProduct(p1: Vec2, p2: Vec2): number {
-  const origin = { x: 0, y: 0 };
-  const angle = clockwiseAngle(getAngleBetweenVec2s(origin, p1), getAngleBetweenVec2s(origin, p2));
-  return magnitude(p1) * magnitude(p2) * Math.cos(angle);
+export function dotProduct(v1: Vec2, v2: Vec2): number {
+  return v1.x * v2.x + v1.y * v2.y;
 }
+// The direction a line moves from point 1 to point 2
+export function getDirectionVector(segment: LineSegment): Vec2 {
+  return { x: segment.p2.x - segment.p1.x, y: segment.p2.y - segment.p1.y }
+}
+// The line perpendicular to a wall, facing inward
+export function getNormalVector(segment: LineSegment): Vec2 {
+  const directionVector = getDirectionVector(segment);
+  const normalVector = { x: -directionVector.y, y: directionVector.x };
+  return normalized(normalVector);
+}
+// Like a laser against a mirror
+// Normal must be normalized before passing it here
+export function reflectOnNormal(v: Vec2, normal: Vec2): Vec2 {
+  const dotProd = dotProduct(v, normal);
+  const scaledNormal = multiply(2 * dotProd, normal);
+  return subtract(v, scaledNormal);
+}
+// Like a heavy box hitting a wall and continuing to slide parallel to it
+// Normal must be normalized before passing it here
+export function projectOnNormal(v: Vec2, normal: Vec2): Vec2 {
+  const scalar = dotProduct(v, normal) / dotProduct(normal, normal);
+  return multiply(scalar, normal);
+}
+// Magnitude Squared - Used for optimization
 export function sqrMagnitude(p: Vec2): number {
   return p.y * p.y + p.x * p.x;
 }
+// Magnitude of a vector
 export function magnitude(p: Vec2): number {
   return Math.sqrt(sqrMagnitude(p));
 }
-
 export function equal(p1: Vec2, p2: Vec2): boolean {
   return p1.x == p2.x && p1.y == p2.y;
 }
-
 export function clone(p: Vec2): Vec2 {
   return { x: p.x, y: p.y };
 }
-
 export function round(v: Vec2): Vec2 {
   return { x: Math.round(v.x), y: Math.round(v.y) };
 }
@@ -112,7 +135,6 @@ export function getEndpointOfMagnitudeAlongVector(pos: Vec2, angle: number, magn
   return add(pos, similarTriangles(nextPointDirection.x - pos.x, nextPointDirection.y - pos.y, dist, magnitude));
 
 }
-
 // Returns true if testPoint is within a bounding box drawn between the two bounding points
 export function isBetween(testPoint: Vec2, boundingPoint: Vec2, boundingPoint2: Vec2): boolean {
   const minY = Math.min(boundingPoint.y, boundingPoint2.y);

--- a/src/jmath/Vec.ts
+++ b/src/jmath/Vec.ts
@@ -75,8 +75,11 @@ export function dotProduct(p1: Vec2, p2: Vec2): number {
   const angle = clockwiseAngle(getAngleBetweenVec2s(origin, p1), getAngleBetweenVec2s(origin, p2));
   return magnitude(p1) * magnitude(p2) * Math.cos(angle);
 }
+export function sqrMagnitude(p: Vec2): number {
+  return p.y * p.y + p.x * p.x;
+}
 export function magnitude(p: Vec2): number {
-  return Math.sqrt(p.y * p.y + p.x * p.x);
+  return Math.sqrt(sqrMagnitude(p));
 }
 
 export function equal(p1: Vec2, p2: Vec2): boolean {

--- a/src/jmath/Vec.ts
+++ b/src/jmath/Vec.ts
@@ -74,7 +74,6 @@ export function crossProduct(v1: Vec2, v2: Vec2): number {
 }
 // Returns a scalar
 // Function to calculate the dot product of two 2D vectors
-// Source: https://www.cuemath.com/algebra/product-of-vectors/
 export function dotProduct(v1: Vec2, v2: Vec2): number {
   return v1.x * v2.x + v1.y * v2.y;
 }

--- a/src/jmath/Vec.ts
+++ b/src/jmath/Vec.ts
@@ -1,5 +1,4 @@
 
-import { clockwiseAngle } from "./Angle";
 import { LineSegment } from "./lineSegment";
 import { distance, similarTriangles, lerp } from "./math";
 import { prng, randInt } from "./rand";
@@ -8,7 +7,8 @@ export interface Vec2 {
   y: number;
 }
 
-// TODO - Might fix them later. Not for 1.27.
+// TODO - see comment below and getAngleBetween functions
+// would be good to fix after 1.27
 
 // Get the angle away from the x-axis from origin to point in radians
 // Note: This function returns the counter clockwise angle from the x-axis
@@ -100,9 +100,13 @@ export function projectOnNormal(v: Vec2, normal: Vec2): Vec2 {
   const scalar = dotProduct(v, normal) / dotProduct(normal, normal);
   return multiply(scalar, normal);
 }
-// Magnitude Squared - Used for optimization
+// Magnitude without the sqrt() function - Use when performance is a concern
+// When comparing the length of two vectors, compare sqrMagnitudes
+// When comparing to a distance, use (sqrMagnitude > sqrDistance)
+// *or to (distance * distance) where distance is a constant
+// ... instead of (magnitude to magnitude) or (magnitude to distance)
 export function sqrMagnitude(p: Vec2): number {
-  return p.y * p.y + p.x * p.x;
+  return p.x * p.x + p.y * p.y;
 }
 // Magnitude of a vector
 export function magnitude(p: Vec2): number {

--- a/src/jmath/__test__/Vec.test.ts
+++ b/src/jmath/__test__/Vec.test.ts
@@ -33,6 +33,14 @@ describe('vectorMath', () => {
             const expected = 21;
             expect(actual).toEqual(expected);
         });
+        it('should return 11 for [1,2] dot [3,4]', () => {
+            const v1 = { x: 1, y: 2 };
+            const v2 = { x: 3, y: 4 }
+            const actual = dotProduct(v1, v2);
+            const expected = 11;
+            expect(actual).toEqual(expected);
+        });
+
     });
     describe('isBetween', () => {
         [

--- a/src/jmath/lineSegment.ts
+++ b/src/jmath/lineSegment.ts
@@ -1,72 +1,72 @@
 import { distance } from "./math";
 import * as Vec from "./Vec";
 export interface LineSegment {
-    p1: Vec.Vec2;
-    p2: Vec.Vec2;
+  p1: Vec.Vec2;
+  p2: Vec.Vec2;
 }
 
 export function equal(line1: LineSegment, line2: LineSegment): boolean {
-    return Vec.equal(line1.p1, line2.p1) && Vec.equal(line1.p2, line2.p2);
+  return Vec.equal(line1.p1, line2.p1) && Vec.equal(line1.p2, line2.p2);
 }
 export function toString(line: LineSegment): string {
-    return `${line.p1.x},${line.p1.y} to ${line.p2.x},${line.p2.y}`;
+  return `${line.p1.x},${line.p1.y} to ${line.p2.x},${line.p2.y}`;
 }
 function slope(line: LineSegment): number | undefined {
-    const X = (line.p2.x - line.p1.x);
-    if (X == 0) {
-        return undefined
-    }
-    return (line.p2.y - line.p1.y) / X;
+  const X = (line.p2.x - line.p1.x);
+  if (X == 0) {
+    return undefined
+  }
+  return (line.p2.y - line.p1.y) / X;
 }
 // Standard Form: ax+by+c=0
 interface LineInStandardForm {
-    a: number,
-    x: number,
-    b: number,
-    y: number,
-    c: number
+  a: number,
+  x: number,
+  b: number,
+  y: number,
+  c: number
 }
 // Converts a LineSegment to a LineInStandardForm
 export function toStandardForm(line: LineSegment): LineInStandardForm | undefined {
-    const M = slope(line);
-    if (M !== undefined) {
-        const c = -(line.p1.y - M * line.p1.x)
-        return {
-            a: -M,
-            x: line.p1.x,
-            b: 1,
-            y: line.p1.y,
-            c
-        }
-    } else {
-        return undefined
+  const M = slope(line);
+  if (M !== undefined) {
+    const c = -(line.p1.y - M * line.p1.x)
+    return {
+      a: -M,
+      x: line.p1.x,
+      b: 1,
+      y: line.p1.y,
+      c
     }
+  } else {
+    return undefined
+  }
 }
 // TODO Doesn't account for edge cases such as vertical lines
 // OLD, do not use
 function intersectionOfLines(line: LineInStandardForm, line2: LineInStandardForm): Vec.Vec2 {
-    // https://www.cuemath.com/geometry/intersection-of-two-lines/
-    return {
-        x: (line.b * line2.c - line2.b * line.c) / (line.a * line2.b - line2.a * line.b),
-        y: (line.c * line2.a - line2.c * line.a) / (line.a * line2.b - line2.a * line.b),
-    }
+  // https://www.cuemath.com/geometry/intersection-of-two-lines/
+  return {
+    x: (line.b * line2.c - line2.b * line.c) / (line.a * line2.b - line2.a * line.b),
+    y: (line.c * line2.a - line2.c * line.a) / (line.a * line2.b - line2.a * line.b),
+  }
 }
 // Given a line and a point, find the intersection point of the line an a vector starting at "point",
 // moving twords line at a right angle to line
 // This is useful for determining if a circle intersects with a line
 function findWherePointIntersectLineAtRightAngle(point: Vec.Vec2, line: LineInStandardForm): Vec.Vec2 {
-    const inverseLine1Slope = line.a;
-    const line2 = { p1: point, p2: { x: point.x + inverseLine1Slope, y: point.y + 1 } }
-    const line2InStandardForm = toStandardForm(line2);
-    if (line2InStandardForm) {
-        return intersectionOfLines(line, line2InStandardForm);
-    } else {
-        // line2 is vertical (has an undefined slope)
-        return {
-            x: line2.p1.x,
-            y: line.y
-        }
+  const inverseLine1Slope = line.a;
+  const line2 = { p1: point, p2: { x: point.x + inverseLine1Slope, y: point.y + 1 } }
+  const line2InStandardForm = toStandardForm(line2);
+  if (line2InStandardForm) {
+    return intersectionOfLines(line, line2InStandardForm);
+  } else {
+    // line2 is vertical (has an undefined slope)
+    return {
+      x: line2.p1.x,
+      y: line.y
     }
+  }
 }
 // See comments for the similar function "findWherePointIntersectLineAtRightAngle"; this function differs
 // in that it considers a point and a lineSEGMENT.
@@ -76,229 +76,229 @@ function findWherePointIntersectLineAtRightAngle(point: Vec.Vec2, line: LineInSt
 // perfect right angle to the endpoint).  So this function should be used together with other functions to account
 // for the endpoints of the line segment
 export function findWherePointIntersectLineSegmentAtRightAngle(point: Vec.Vec2, line: LineSegment): Vec.Vec2 | undefined {
-    const lineInStandardForm = toStandardForm(line);
-    const largestX = Math.max(line.p1.x, line.p2.x);
-    const smallestX = Math.min(line.p1.x, line.p2.x);
-    const largestY = Math.max(line.p1.y, line.p2.y);
-    const smallestY = Math.min(line.p1.y, line.p2.y);
-    if (lineInStandardForm) {
-        const intersection = findWherePointIntersectLineAtRightAngle(point, lineInStandardForm);
-        // Return the intersection point IF it is between the endpoints of the line segment
-        if (intersection.y <= largestY && intersection.y >= smallestY && intersection.x <= largestX && intersection.x >= smallestX) {
-            return intersection
-        } else {
-            // Point is not on line segment
-            return undefined
-        }
+  const lineInStandardForm = toStandardForm(line);
+  const largestX = Math.max(line.p1.x, line.p2.x);
+  const smallestX = Math.min(line.p1.x, line.p2.x);
+  const largestY = Math.max(line.p1.y, line.p2.y);
+  const smallestY = Math.min(line.p1.y, line.p2.y);
+  if (lineInStandardForm) {
+    const intersection = findWherePointIntersectLineAtRightAngle(point, lineInStandardForm);
+    // Return the intersection point IF it is between the endpoints of the line segment
+    if (intersection.y <= largestY && intersection.y >= smallestY && intersection.x <= largestX && intersection.x >= smallestX) {
+      return intersection
     } else {
-        // line is vertical, so the intersection is any x on "line" and point.y
-        const intersection = {
-            x: line.p1.x,
-            y: point.y
-        }
-        // Return the intersection point IF it is between the endpoints of the line segment
-        if (intersection.y <= largestY && intersection.y >= smallestY && intersection.x <= largestX && intersection.x >= smallestX) {
-            return intersection
-        } else {
-            // Point is not on line segment
-            return undefined
-        }
+      // Point is not on line segment
+      return undefined
     }
+  } else {
+    // line is vertical, so the intersection is any x on "line" and point.y
+    const intersection = {
+      x: line.p1.x,
+      y: point.y
+    }
+    // Return the intersection point IF it is between the endpoints of the line segment
+    if (intersection.y <= largestY && intersection.y >= smallestY && intersection.x <= largestX && intersection.x >= smallestX) {
+      return intersection
+    } else {
+      // Point is not on line segment
+      return undefined
+    }
+  }
 
 }
 export function getCenterPoint(ls: LineSegment): Vec.Vec2 {
-    return Vec.add(ls.p1, Vec.multiply(0.5, Vec.subtract(ls.p2, ls.p1)));
+  return Vec.add(ls.p1, Vec.multiply(0.5, Vec.subtract(ls.p2, ls.p1)));
 
 }
 export function isPointOnLineSegment(point: Vec.Vec2, lineSegment: LineSegment): boolean {
-    const segmentSlope = slope(lineSegment);
-    const slopeFromPointToEndOfSegment = slope({ p1: point, p2: lineSegment.p2 })
-    if (segmentSlope == slopeFromPointToEndOfSegment) {
-        const pointIsInBoundingBoxOfSegment = point.x >= Math.min(lineSegment.p1.x, lineSegment.p2.x)
-            && point.x <= Math.max(lineSegment.p1.x, lineSegment.p2.x)
-            && point.y >= Math.min(lineSegment.p1.y, lineSegment.p2.y)
-            && point.y <= Math.max(lineSegment.p1.y, lineSegment.p2.y);
-        return pointIsInBoundingBoxOfSegment;
-    }
-    return false;
+  const segmentSlope = slope(lineSegment);
+  const slopeFromPointToEndOfSegment = slope({ p1: point, p2: lineSegment.p2 })
+  if (segmentSlope == slopeFromPointToEndOfSegment) {
+    const pointIsInBoundingBoxOfSegment = point.x >= Math.min(lineSegment.p1.x, lineSegment.p2.x)
+      && point.x <= Math.max(lineSegment.p1.x, lineSegment.p2.x)
+      && point.y >= Math.min(lineSegment.p1.y, lineSegment.p2.y)
+      && point.y <= Math.max(lineSegment.p1.y, lineSegment.p2.y);
+    return pointIsInBoundingBoxOfSegment;
+  }
+  return false;
 
 }
 // modified from https://stackoverflow.com/a/3461533/4418836
 export function isOnOutside(line: LineSegment, c: Vec.Vec2): boolean {
-    return ((line.p2.x - line.p1.x) * (c.y - line.p1.y) - (line.p2.y - line.p1.y) * (c.x - line.p1.x)) > 0;
+  return ((line.p2.x - line.p1.x) * (c.y - line.p1.y) - (line.p2.y - line.p1.y) * (c.x - line.p1.x)) > 0;
 }
 interface ParametricRelation {
-    p: Vec.Vec2;
-    r: Vec.Vec2;
-    q: Vec.Vec2;
-    s: Vec.Vec2;
-    qMinusP: Vec.Vec2;
-    rCrossS: number;
-    isCollinear: boolean;
-    pointInSameDirection: boolean;
-    isOverlapping: boolean;
-    l2p1Insidel1?: boolean;
-    l2p2Insidel1?: boolean;
-    l2FullyCoversl1?: boolean;
+  p: Vec.Vec2;
+  r: Vec.Vec2;
+  q: Vec.Vec2;
+  s: Vec.Vec2;
+  qMinusP: Vec.Vec2;
+  rCrossS: number;
+  isCollinear: boolean;
+  pointInSameDirection: boolean;
+  isOverlapping: boolean;
+  l2p1Insidel1?: boolean;
+  l2p2Insidel1?: boolean;
+  l2FullyCoversl1?: boolean;
 }
 export function getParametricRelation(l1: LineSegment, l2: LineSegment): ParametricRelation {
-    // l1 expressed as p to p+r
-    const p = l1.p1;
-    const r = Vec.subtract(l1.p2, l1.p1);
-    // l2 expressed as q to q+s
-    const q = l2.p1;
-    const s = Vec.subtract(l2.p2, l2.p1);
-    const qMinusP = Vec.subtract(q, p);
-    const rCrossS = Vec.crossproduct(r, s);
-    // If r × s = 0 and (q − p) × r = 0, then the two lines are collinear.
-    const isCollinear = rCrossS == 0 && Vec.crossproduct(qMinusP, r) == 0;
-    const pointInSameDirection = Vec.dotProduct(s, r) >= 0;
-    //     In this case, express the endpoints of the second segment (q and q + s) in terms of the equation of the first line segment (p + t r):
-    //     t0 = (q − p) · r / (r · r)
-    //     t1 = (q + s − p) · r / (r · r) = t0 + s · r / (r · r)
-    if (isCollinear) {
-        if (!pointInSameDirection) {
-            // If lines are collinear but do NOT point in the same direction, one of the lines
-            // must be reversed in order for the t0,t1 checks to work as intended.
-            const reversedRelation = getParametricRelation(l1, { p1: l2.p2, p2: l2.p1 })
-            return {
-                // Take l2FullyCoversl1, l2p1Insidel1, and l2p2Insidel1 from the reversed relation
-                // These are the properties that required the reversed relation to calculate correctly
-                l2FullyCoversl1: reversedRelation.l2FullyCoversl1,
-                // Flip these back since l2's points were reversed above
-                l2p1Insidel1: reversedRelation.l2p2Insidel1,
-                l2p2Insidel1: reversedRelation.l2p1Insidel1,
-                // Take isOverlapping from the reversed relation just so that it doesn't have to be recalculated
-                isOverlapping: reversedRelation.isOverlapping,
-                // Keep the original properties of the relation,
-                // so that they aren't changed with the abover reversal
-                p, r, q, s,
-                qMinusP,
-                rCrossS,
-                isCollinear,
-                pointInSameDirection
-            }
-        } else {
-            const dotRR = Vec.dotProduct(r, r);
-            const dotSR = Vec.dotProduct(s, r);
-            const t0 = Vec.dotProduct(Vec.subtract(q, p), r) / dotRR;
-            const t1 = t0 + dotSR / dotRR;
-            // If the interval between t0 and t1 intersects the interval [0, 1] then the line segments are collinear and overlapping; otherwise they are collinear and disjoint.
-            // Note that if s and r point in opposite directions, then s · r < 0 and so the interval to be checked is [t1, t0] rather than [t0, t1].
-            const l2p1Insidel1 = (0 <= t0 && t0 <= 1);
-            const l2p2Insidel1 = (0 <= t1 && t1 <= 1);
-            const l2FullyCoversl1 = (t0 <= 0 && t1 >= 1);
-            const l1FullyCoversl2 = (t1 <= 0 && t0 >= 1);
-            const isOverlapping = l2p1Insidel1 || l2p2Insidel1 || l2FullyCoversl1 || l1FullyCoversl2;
-            return {
-                p, r, q, s, qMinusP, rCrossS, isCollinear, pointInSameDirection, isOverlapping, l2p1Insidel1, l2p2Insidel1, l2FullyCoversl1
-            }
-        }
+  // l1 expressed as p to p+r
+  const p = l1.p1;
+  const r = Vec.subtract(l1.p2, l1.p1);
+  // l2 expressed as q to q+s
+  const q = l2.p1;
+  const s = Vec.subtract(l2.p2, l2.p1);
+  const qMinusP = Vec.subtract(q, p);
+  const rCrossS = Vec.crossProduct(r, s);
+  // If r × s = 0 and (q − p) × r = 0, then the two lines are collinear.
+  const isCollinear = rCrossS == 0 && Vec.crossProduct(qMinusP, r) == 0;
+  const pointInSameDirection = Vec.dotProduct(s, r) >= 0;
+  //     In this case, express the endpoints of the second segment (q and q + s) in terms of the equation of the first line segment (p + t r):
+  //     t0 = (q − p) · r / (r · r)
+  //     t1 = (q + s − p) · r / (r · r) = t0 + s · r / (r · r)
+  if (isCollinear) {
+    if (!pointInSameDirection) {
+      // If lines are collinear but do NOT point in the same direction, one of the lines
+      // must be reversed in order for the t0,t1 checks to work as intended.
+      const reversedRelation = getParametricRelation(l1, { p1: l2.p2, p2: l2.p1 })
+      return {
+        // Take l2FullyCoversl1, l2p1Insidel1, and l2p2Insidel1 from the reversed relation
+        // These are the properties that required the reversed relation to calculate correctly
+        l2FullyCoversl1: reversedRelation.l2FullyCoversl1,
+        // Flip these back since l2's points were reversed above
+        l2p1Insidel1: reversedRelation.l2p2Insidel1,
+        l2p2Insidel1: reversedRelation.l2p1Insidel1,
+        // Take isOverlapping from the reversed relation just so that it doesn't have to be recalculated
+        isOverlapping: reversedRelation.isOverlapping,
+        // Keep the original properties of the relation,
+        // so that they aren't changed with the abover reversal
+        p, r, q, s,
+        qMinusP,
+        rCrossS,
+        isCollinear,
+        pointInSameDirection
+      }
     } else {
-        return {
-            p, r, q, s, qMinusP, rCrossS, isCollinear, pointInSameDirection, isOverlapping: false
-        }
+      const dotRR = Vec.dotProduct(r, r);
+      const dotSR = Vec.dotProduct(s, r);
+      const t0 = Vec.dotProduct(Vec.subtract(q, p), r) / dotRR;
+      const t1 = t0 + dotSR / dotRR;
+      // If the interval between t0 and t1 intersects the interval [0, 1] then the line segments are collinear and overlapping; otherwise they are collinear and disjoint.
+      // Note that if s and r point in opposite directions, then s · r < 0 and so the interval to be checked is [t1, t0] rather than [t0, t1].
+      const l2p1Insidel1 = (0 <= t0 && t0 <= 1);
+      const l2p2Insidel1 = (0 <= t1 && t1 <= 1);
+      const l2FullyCoversl1 = (t0 <= 0 && t1 >= 1);
+      const l1FullyCoversl2 = (t1 <= 0 && t0 >= 1);
+      const isOverlapping = l2p1Insidel1 || l2p2Insidel1 || l2FullyCoversl1 || l1FullyCoversl2;
+      return {
+        p, r, q, s, qMinusP, rCrossS, isCollinear, pointInSameDirection, isOverlapping, l2p1Insidel1, l2p2Insidel1, l2FullyCoversl1
+      }
     }
+  } else {
+    return {
+      p, r, q, s, qMinusP, rCrossS, isCollinear, pointInSameDirection, isOverlapping: false
+    }
+  }
 }
 export function getRelation(l1: LineSegment, l2: LineSegment): { isCollinear: boolean, isOverlapping: boolean, pointInSameDirection: boolean } {
-    const { isCollinear, pointInSameDirection, isOverlapping } = getParametricRelation(l1, l2);
-    return { isCollinear, pointInSameDirection, isOverlapping };
+  const { isCollinear, pointInSameDirection, isOverlapping } = getParametricRelation(l1, l2);
+  return { isCollinear, pointInSameDirection, isOverlapping };
 }
 // A slice of logic from lineSegmentIntersection
 // returns true if two line segmenst are collinear and point in the same direction
 export function isCollinearAndPointInSameDirection(l1: LineSegment, l2: LineSegment): boolean {
-    const { isCollinear, pointInSameDirection } = getRelation(l1, l2);
-    return isCollinear && pointInSameDirection;
+  const { isCollinear, pointInSameDirection } = getRelation(l1, l2);
+  return isCollinear && pointInSameDirection;
 
 }
 // A slice of logic from lineSegmentIntersection
 // returns true if two line segmenst are both collinear and overlapping
 export function isCollinearAndOverlapping(l1: LineSegment, l2: LineSegment): boolean {
-    const { isCollinear, isOverlapping } = getRelation(l1, l2);
-    return isCollinear && isOverlapping;
+  const { isCollinear, isOverlapping } = getRelation(l1, l2);
+  return isCollinear && isOverlapping;
 }
 
 export function closestLineSegmentIntersectionWithLine(l1: LineSegment, otherLines: LineSegment[]): { intersection: Vec.Vec2, lineSegment: LineSegment } | undefined {
-    let shortestDistance = Number.MAX_SAFE_INTEGER;
-    let closestIntersection = undefined;
-    let lineThatIntersected = undefined;
-    for (let line of otherLines) {
-        // Don't test against self
-        if (line == l1) {
-            continue;
-        }
-        const intersection = lineSegmentIntersection(l1, line);
-        if (intersection) {
-            const distanceToIntersection = distance(l1.p1, intersection);
-            if (!closestIntersection || distanceToIntersection < shortestDistance) {
-                shortestDistance = distanceToIntersection;
-                closestIntersection = intersection;
-                lineThatIntersected = line;
-            }
-        }
+  let shortestDistance = Number.MAX_SAFE_INTEGER;
+  let closestIntersection = undefined;
+  let lineThatIntersected = undefined;
+  for (let line of otherLines) {
+    // Don't test against self
+    if (line == l1) {
+      continue;
     }
-    return closestIntersection && lineThatIntersected ? { intersection: closestIntersection, lineSegment: lineThatIntersected } : undefined;
+    const intersection = lineSegmentIntersection(l1, line);
+    if (intersection) {
+      const distanceToIntersection = distance(l1.p1, intersection);
+      if (!closestIntersection || distanceToIntersection < shortestDistance) {
+        shortestDistance = distanceToIntersection;
+        closestIntersection = intersection;
+        lineThatIntersected = line;
+      }
+    }
+  }
+  return closestIntersection && lineThatIntersected ? { intersection: closestIntersection, lineSegment: lineThatIntersected } : undefined;
 }
 // Test l1 for intersections with each of otherLines; of all the intersections return the closest intersection
 export function closestLineSegmentIntersection(l1: LineSegment, otherLines: LineSegment[]): Vec.Vec2 | undefined {
-    return closestLineSegmentIntersectionWithLine(l1, otherLines)?.intersection;
+  return closestLineSegmentIntersectionWithLine(l1, otherLines)?.intersection;
 }
 
 // Adapted from https://stackoverflow.com/a/565282
 // Resources https://www.math.usm.edu/lambers/mat169/fall09/lecture25.pdf
 // Example points: "Converting your example into my notation, I get p=(11,11), r=(-12,-12), q=(0,0), s=(0,10), r×s=-120, t=11/12, u=0. Since r×s is non-zero, the segments are not parallel."
 export function lineSegmentIntersection(l1: LineSegment, l2: LineSegment): Vec.Vec2 | undefined {
-    const { p, r, s, qMinusP, rCrossS, isCollinear, isOverlapping, l2p1Insidel1, l2p2Insidel1, l2FullyCoversl1 } = getParametricRelation(l1, l2);
-    if (isCollinear) {
-        if (isOverlapping) {
-            // Since the line segments are collinear and overlapping, there are infinite intersection points,
-            // but since this function only returns 1 intersection point, I, personally, am opting to prefer
-            // an endpoing on l1 over l2 and the p2 point over the p1 point
-            if (l2p1Insidel1 && l2p2Insidel1) {
-                // l1 fully covers l2
-                return l2.p2;
-            } else if (l2p1Insidel1) {
-                // Infinite intersections, pick arbitrary one
-                return l2.p1;
-            } else if (l2p2Insidel1) {
-                // Infinite intersections, pick arbitrary one
-                return l2.p2;
-            } else if (l2FullyCoversl1) {
-                return l1.p2;
-            } else {
-                console.error('lineSegmentIntersection: this line should be impossible to reach')
-                // This should never happen, if the line segments are overlapping, one of the above cases
-                // will be true
-                return l2.p2;
-            }
-        } else {
-            // No intersection
-            return undefined
-        }
+  const { p, r, s, qMinusP, rCrossS, isCollinear, isOverlapping, l2p1Insidel1, l2p2Insidel1, l2FullyCoversl1 } = getParametricRelation(l1, l2);
+  if (isCollinear) {
+    if (isOverlapping) {
+      // Since the line segments are collinear and overlapping, there are infinite intersection points,
+      // but since this function only returns 1 intersection point, I, personally, am opting to prefer
+      // an endpoing on l1 over l2 and the p2 point over the p1 point
+      if (l2p1Insidel1 && l2p2Insidel1) {
+        // l1 fully covers l2
+        return l2.p2;
+      } else if (l2p1Insidel1) {
+        // Infinite intersections, pick arbitrary one
+        return l2.p1;
+      } else if (l2p2Insidel1) {
+        // Infinite intersections, pick arbitrary one
+        return l2.p2;
+      } else if (l2FullyCoversl1) {
+        return l1.p2;
+      } else {
+        console.error('lineSegmentIntersection: this line should be impossible to reach')
+        // This should never happen, if the line segments are overlapping, one of the above cases
+        // will be true
+        return l2.p2;
+      }
+    } else {
+      // No intersection
+      return undefined
     }
-    // If r × s = 0 and (q − p) × r ≠ 0, then the two lines are parallel and non-intersecting.
-    if (rCrossS == 0 && Vec.crossproduct(qMinusP, r) != 0) {
-        // No intersection
-        return undefined
-    }
-    // The two lines intersect if we can find t and u such that: p + t r = q + u s
-    // And therefore, solving for t: t = (q − p) × s / (r × s)
-    // In the same way, we can solve for u: u = (q − p) × r / (r × s)
-    const t = Vec.crossproduct(qMinusP, s) / rCrossS;
-    const u = Vec.crossproduct(qMinusP, r) / rCrossS;
-
-    // If r × s ≠ 0 and 0 ≤ t ≤ 1 and 0 ≤ u ≤ 1, the two line segments meet at the point p + t r = q + u s.
-    if (rCrossS != 0 && 0 <= t && t <= 1 && 0 <= u && u <= 1) {
-        return Vec.add(p, Vec.multiply(t, r))
-    }
-
-    // Otherwise, the two line segments are not parallel but do not intersect.
+  }
+  // If r × s = 0 and (q − p) × r ≠ 0, then the two lines are parallel and non-intersecting.
+  if (rCrossS == 0 && Vec.crossProduct(qMinusP, r) != 0) {
+    // No intersection
     return undefined
+  }
+  // The two lines intersect if we can find t and u such that: p + t r = q + u s
+  // And therefore, solving for t: t = (q − p) × s / (r × s)
+  // In the same way, we can solve for u: u = (q − p) × r / (r × s)
+  const t = Vec.crossProduct(qMinusP, s) / rCrossS;
+  const u = Vec.crossProduct(qMinusP, r) / rCrossS;
+
+  // If r × s ≠ 0 and 0 ≤ t ≤ 1 and 0 ≤ u ≤ 1, the two line segments meet at the point p + t r = q + u s.
+  if (rCrossS != 0 && 0 <= t && t <= 1 && 0 <= u && u <= 1) {
+    return Vec.add(p, Vec.multiply(t, r))
+  }
+
+  // Otherwise, the two line segments are not parallel but do not intersect.
+  return undefined
 }
 
 export const testables = {
-    slope,
-    toStandardForm,
-    findWherePointIntersectLineAtRightAngle,
-    intersectionOfLines
+  slope,
+  toStandardForm,
+  findWherePointIntersectLineAtRightAngle,
+  intersectionOfLines
 }

--- a/src/jmath/math.ts
+++ b/src/jmath/math.ts
@@ -41,11 +41,17 @@ export function getCoordsAtDistanceTowardsTarget(start: Vec2, target: Vec2, trav
     y: start.y + result.y
   }
 }
-
-export function distance(coords1: Vec2, coords2: Vec2): number {
+// Distance without the sqrt() function - Use when performance is a concern
+// When comparing distances, compare sqrDistances
+// When comparing to a vector, use (sqrMagnitude to sqrDistance)
+// ... instead of (distance to distance) or (magnitude to distance)
+export function sqrDistance(coords1: Vec2, coords2: Vec2): number {
   const dx = coords1.x - coords2.x;
   const dy = coords1.y - coords2.y;
-  return Math.sqrt(dx * dx + dy * dy);
+  return dx * dx + dy * dy;
+}
+export function distance(coords1: Vec2, coords2: Vec2): number {
+  return Math.sqrt(sqrDistance(coords1, coords2));
 }
 
 // Returns a point distance away from origin in the direction of the angle radians

--- a/src/jmath/moveWithCollision.ts
+++ b/src/jmath/moveWithCollision.ts
@@ -48,7 +48,7 @@ interface ForceMoveProjectileArgs {
   ignoreUnitIds: number[];
   collideFnKey: string;
 }
-const START_VELOCITY = 10;
+const START_VELOCITY = 1.5;
 export function makeForceMoveProjectile(args: ForceMoveProjectileArgs, underworld: Underworld, prediction: boolean): ForceMove {
   const { pushedObject, startPoint, endPoint, doesPierce, ignoreUnitIds, collideFnKey } = args;
   const velocity = similarTriangles(endPoint.x - pushedObject.x, endPoint.y - pushedObject.y, distance(pushedObject, endPoint), START_VELOCITY);

--- a/src/jmath/moveWithCollision.ts
+++ b/src/jmath/moveWithCollision.ts
@@ -1,4 +1,4 @@
-import { add, magnitude, subtract, Vec2 } from './Vec';
+import { add, magnitude, multiply, subtract, Vec2 } from './Vec';
 import { distance, similarTriangles } from "./math";
 import { closestLineSegmentIntersection, findWherePointIntersectLineSegmentAtRightAngle, LineSegment, lineSegmentIntersection } from "./lineSegment";
 import * as config from '../config';
@@ -127,11 +127,11 @@ export function collideWithLineSegments(circle: Circle, lineSegments: LineSegmen
 // Handle super fast moving objects.  If an object is moving fast enough it *would* pass through
 // solid walls, this function prevents that and stops the unit where it would collide with the wall if it were 
 // moving slower
-export function forceMovePreventForceThroughWall(forceMoveInst: ForceMove, underworld: Underworld, trueVelocity: Vec2): boolean {
+export function forceMovePreventForceThroughWall(forceMoveInst: ForceMove, underworld: Underworld, deltaPosition: Vec2): boolean {
   const { pushedObject } = forceMoveInst;
-  if (magnitude(trueVelocity) >= pushedObject.radius) {
+  if (magnitude(deltaPosition) >= pushedObject.radius) {
     for (let wall of underworld.walls) {
-      const intersection = lineSegmentIntersection({ p1: pushedObject, p2: add(pushedObject, trueVelocity) }, wall);
+      const intersection = lineSegmentIntersection({ p1: pushedObject, p2: add(pushedObject, deltaPosition) }, wall);
       if (intersection) {
         const newPos = math.getCoordsAtDistanceTowardsTarget(intersection, pushedObject, pushedObject.radius)
         pushedObject.x = newPos.x;

--- a/src/jmath/moveWithCollision.ts
+++ b/src/jmath/moveWithCollision.ts
@@ -133,7 +133,8 @@ export function predictWallCollision(forceMoveInst: ForceMove, underworld: Under
   for (const wall of underworld.walls) {
     const intersection = lineSegmentIntersection({ p1: pushedObject, p2: farIntersection }, wall);
     if (intersection) {
-      // TODO - Should factor in sin(angleBetween(velocity, getNormalVector(wall))) or something like that.
+      // TODO - Should factor in sin(angleBetween(velocity, getNormalVector(wall))) or something like that
+      // if we want to remove collideWithLineSegments as talked about in Underworld.runForceMove
       const newPos = math.getCoordsAtDistanceTowardsTarget(intersection, pushedObject, config.COLLISION_MESH_RADIUS);
       const msUntilCollision = distance(pushedObject, newPos) / magnitude(velocity);
       pushedObject.x = newPos.x;

--- a/src/jmath/moveWithCollision.ts
+++ b/src/jmath/moveWithCollision.ts
@@ -128,6 +128,8 @@ export function collideWithLineSegments(circle: Circle, lineSegments: LineSegmen
 export function predictWallCollision(forceMoveInst: ForceMove, underworld: Underworld, deltaTime: number): { msUntilCollision: number, wall: LineSegment | undefined } {
   const { pushedObject, velocity } = forceMoveInst;
   const deltaPosition = multiply(deltaTime, velocity);
+  // TODO - I think this could be optimized with SimilarTriangles
+  // or removed entirely with the todo below?
   const farIntersection = add(pushedObject, multiply(magnitude(deltaPosition) + config.COLLISION_MESH_RADIUS, normalized(deltaPosition)));
 
   for (const wall of underworld.walls) {

--- a/src/jmath/moveWithCollision.ts
+++ b/src/jmath/moveWithCollision.ts
@@ -1,4 +1,4 @@
-import { add, magnitude, multiply, subtract, Vec2 } from './Vec';
+import { add, getDirectionVector, getNormalVector, magnitude, multiply, normalized, projectOnNormal, reflectOnNormal, subtract, Vec2 } from './Vec';
 import { distance, similarTriangles } from "./math";
 import { closestLineSegmentIntersection, findWherePointIntersectLineSegmentAtRightAngle, LineSegment, lineSegmentIntersection } from "./lineSegment";
 import * as config from '../config';
@@ -123,28 +123,47 @@ export function collideWithLineSegments(circle: Circle, lineSegments: LineSegmen
   return collisionDidOccur;
 }
 
-// Returns true if it prevented a movement through a wall
-// Handle super fast moving objects.  If an object is moving fast enough it *would* pass through
-// solid walls, this function prevents that and stops the unit where it would collide with the wall if it were 
-// moving slower
-export function forceMovePreventForceThroughWall(forceMoveInst: ForceMove, underworld: Underworld, deltaPosition: Vec2): boolean {
-  const { pushedObject } = forceMoveInst;
-  if (magnitude(deltaPosition) >= pushedObject.radius) {
-    for (let wall of underworld.walls) {
-      const intersection = lineSegmentIntersection({ p1: pushedObject, p2: add(pushedObject, deltaPosition) }, wall);
-      if (intersection) {
-        const newPos = math.getCoordsAtDistanceTowardsTarget(intersection, pushedObject, pushedObject.radius)
-        pushedObject.x = newPos.x;
-        pushedObject.y = newPos.y;
-        return true;
-      }
+// Prevents force move through walls and
+// returns some collision info
+export function predictWallCollision(forceMoveInst: ForceMove, underworld: Underworld, deltaTime: number): { msUntilCollision: number, wall: LineSegment | undefined } {
+  const { pushedObject, velocity } = forceMoveInst;
+  const deltaPosition = multiply(deltaTime, velocity);
+  const farIntersection = add(pushedObject, multiply(magnitude(deltaPosition) + config.COLLISION_MESH_RADIUS, normalized(deltaPosition)));
+
+  for (const wall of underworld.walls) {
+    const intersection = lineSegmentIntersection({ p1: pushedObject, p2: farIntersection }, wall);
+    if (intersection) {
+      // TODO - Should factor in sin(angleBetween(velocity, getNormalVector(wall))) or something like that.
+      const newPos = math.getCoordsAtDistanceTowardsTarget(intersection, pushedObject, config.COLLISION_MESH_RADIUS);
+      const msUntilCollision = distance(pushedObject, newPos) / magnitude(velocity);
+      pushedObject.x = newPos.x;
+      pushedObject.y = newPos.y;
+      return { msUntilCollision, wall };
     }
   }
-  return false;
-
+  // No collision
+  return { msUntilCollision: -1, wall: undefined };
 }
-
-
+export function projectVelocityAlongWall(velocity: Vec2, lineSegment: LineSegment): Vec2 {
+  // We want to use the direction vector instead of normal here
+  // that way the velocity is projected "along" the wall instead of away
+  const projection = projectOnNormal(velocity, getDirectionVector(lineSegment));
+  // projection factor is a number 0-1 that controls
+  // the magnitude of the projection relative to the velocity
+  //const projectionFactor = getAngleBetweenVec2s(velocity, projection) / (Math.PI);
+  const projectionFactor = 1;
+  return multiply(projectionFactor, projection);
+}
+export function reflectVelocityOnWall(velocity: Vec2, lineSegment: LineSegment): Vec2 {
+  // We want to use the normal vector here
+  // that way the velocity reflected away from the wall
+  const reflection = reflectOnNormal(velocity, getNormalVector(lineSegment));
+  // reflection factor is a number 0-1 that controls
+  // the magnitude of the reflection relative to the velocity
+  //const reflectionFactor = getAngleBetweenVec2s(velocity, reflection) / (Math.PI);
+  const reflectionFactor = 1;
+  return multiply(reflectionFactor, reflection);
+}
 // move moves a mover towards the destination but will consider
 // collisions with circles and eventaully lines.  Collisions may cause
 // both colliders to move


### PR DESCRIPTION
Closes #336 

Force Moves were using deltaPosition (previously true velocity), aka distance moved that frame, to calculate impact damage. This meant that if a prediction used 16ms delta time, and the game loop used 4ms, the game loop would have 1/4th the deltaPosition and thus way less impact damage. They now both use velocity.

The other half of the problem was that even though they're both using velocity now, the velocity itself can be different because of the different simulation time stamps. If a collision would happen at 24ms, the game loop simulates every 10ms, and the prediction loop simulates every 16ms, they are going to register the collision at 30ms and 32ms respectively, so they'll have different velocities at that point. The prediction velocity would have fallen off 2ms longer. I solved this by predicting when the collision would happen in advance, and then estimating the velocity at the time of collision.

estimatedCollisionVelocity has a very very small (<0.1%) margin of error left. I left a comment about it. It's technically possible that there's a 1 damage difference between prediction and game loop, but this is only going to happen once every 1000 high-velocity force moves and 1 damage is very rarely going to be noticeable or the difference between life and death, so I'm going to say it's fine for 1.27.

### TODO - More QA - Specifically Multiplayer