### PR TITLE
ref: Give hotseat players different client ids

### DIFF
--- a/src/HeadlessServer.ts
+++ b/src/HeadlessServer.ts
@@ -79,8 +79,11 @@ class HostApp implements IHostApp {
     // Automatically overridden when passed into pie.startServer
     sendData: (msg: string) => void = () => { };
     overworld: Overworld;
+    soloMode: boolean;
     constructor() {
         this.overworld = makeOverworld(this);
+        // HostApp is run on a server for multiplayer and therefore is never in soloMode.
+        this.soloMode = false;
         new Underworld(this.overworld, this.overworld.pie, Math.random().toString());
     }
     onData(data: any) {

--- a/src/Overworld.ts
+++ b/src/Overworld.ts
@@ -100,7 +100,12 @@ export function ensureAllClientsHaveAssociatedPlayers(overworld: Overworld, clie
             console.log(`Setup: Create a Player instance for ${clientId}`)
             for (let i = 0; i < globalThis.numberOfHotseatPlayers; i++) {
                 const config = globalThis.hotseatPlayerConfig?.[i];
-                const player = Player.create(clientId, underworld);
+                let nextClientId = clientId;
+                // Hotseat players should not share the same client id
+                if (globalThis.numberOfHotseatPlayers > 1 && i > 0) {
+                    nextClientId = `${clientId}_${i}`;
+                }
+                const player = Player.create(nextClientId, underworld);
                 player.lobbyReady = !!defaultLobbyReady;
                 if (config) {
                     player.name = config.name;

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -353,13 +353,11 @@ export function resetPlayerForNextLevel(player: IPlayer, underworld: Underworld)
 }
 // Keep a global reference to the current client's player
 export function updateGlobalRefToCurrentClientPlayer(player: IPlayer, underworld: Underworld) {
-  if (globalThis.clientId === player.clientId) {
-    if (numberOfHotseatPlayers > 1) {
-      globalThis.player = underworld.players[underworld.hotseatCurrentPlayerIndex];
-      if (!globalThis.player) {
-        console.error('Unexpected: Hotseat player is undefined');
-      }
-    } else {
+  if (numberOfHotseatPlayers > 1) {
+    globalThis.player = player;
+    globalThis.clientId = player.clientId;
+  } else {
+    if (globalThis.clientId === player.clientId) {
       globalThis.player = player;
     }
   }
@@ -468,6 +466,10 @@ export function load(player: IPlayerSerialized, index: number, underworld: Under
 
 // Sets boolean and substring denoting if the player has a @websocketpie/client client associated with it
 export function setClientConnected(player: IPlayer, connected: boolean, underworld: Underworld) {
+  // Override: If in hotseat multiplayer than all clients are considered connected
+  if (globalThis.numberOfHotseatPlayers > 1) {
+    connected = true;
+  }
   player.clientConnected = connected;
   if (connected) {
     Image.removeSubSprite(player.unit.image, 'disconnected.png');

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -1315,6 +1315,20 @@ export function setupNetworkHandlerGlobalFunctions(overworld: Overworld) {
       const { underworld: savedUnderworld, phase, units, players, pickups, version, numberOfHotseatPlayers } = fileSaveObj as SaveFile;
       if (numberOfHotseatPlayers !== undefined) {
         globalThis.numberOfHotseatPlayers = numberOfHotseatPlayers;
+        if (!overworld.pie.soloMode) {
+          console.log('Loading a hotseat multiplayer game into an online multiplayer server: so reset numberOfHotseatPlayers to 1 so that other players can assume control of hotseat players.');
+          globalThis.numberOfHotseatPlayers = 1;
+          for (let i = 1; i < players.length; i++) {
+            const player = players[i];
+            // Ensure players have different client ids when loading a hotseat game
+            // in a multiplayer lobby
+            if (player && player.clientId == players[0]?.clientId) {
+              player.clientId += `_${i}`;
+            }
+
+          }
+
+        }
       }
       if (version !== globalThis.SPELLMASONS_PACKAGE_VERSION) {
         Jprompt({

--- a/src/network/networkUtil.ts
+++ b/src/network/networkUtil.ts
@@ -54,6 +54,7 @@ export interface IHostApp {
     // Copied from PieClient.d.ts
     sendData(payload: any, extras?: any): void;
     isHostApp: boolean;
+    soloMode: boolean;
 }
 export function typeGuardHostApp(x: PieClient | IHostApp): x is IHostApp {
     // @ts-ignore: PieClient does not have isHostApp property but this typeguard will


### PR DESCRIPTION
This is important because sometimes players are looked up by their client ids (like in freeze's add()).

Also this will allow saved hotseat games to be loaded in an only multiplayer lobby.

Fixes #269