### PR TITLE
Jan 10 Fixes

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -398,7 +398,7 @@ export default class Underworld {
     // Represents the positional offset for this simulation loop
     // AKA the Vec2 distance to travel
     const deltaPosition = Vec.multiply(deltaTime, velocity)
-    if (Vec.sqrMagnitude(deltaPosition) < 0.01) {
+    if (Vec.magnitude(deltaPosition) < 0.1) {
       // It's close enough, return true to signify complete 
       return true;
     }
@@ -489,7 +489,7 @@ export default class Underworld {
       const newPosition = Vec.add(pushedObject, deltaPosition);
       pushedObject.x = newPosition.x;
       pushedObject.y = newPosition.y;
-      if (math.sqrDistance(forceMoveInst.pushedObject, forceMoveInst.startPoint) >= math.sqrDistance(forceMoveInst.endPoint, forceMoveInst.startPoint)) {
+      if (math.distance(forceMoveInst.pushedObject, forceMoveInst.startPoint) >= math.distance(forceMoveInst.endPoint, forceMoveInst.startPoint)) {
         // Projectile is done if it reaches or goes beyond its end point
         return true;
       }
@@ -3425,7 +3425,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     const withinDistance: HasSpace[] = [];
     const potentialTargets = this.getPotentialTargets(prediction);
     for (let entity of potentialTargets) {
-      if (math.sqrDistance(entity, target) <= distance * distance) {
+      if (math.distance(entity, target) <= distance) {
         withinDistance.push(entity);
       }
     }
@@ -3440,7 +3440,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     const withinDistance: Pickup.IPickup[] = [];
     const pickups = (prediction && this.pickupsPrediction) ? this.pickupsPrediction : this.pickups;
     for (let pickup of pickups) {
-      if (math.sqrDistance(pickup, target) <= distance * distance) {
+      if (math.distance(pickup, target) <= distance) {
         withinDistance.push(pickup);
       }
     }
@@ -3454,7 +3454,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     const withinDistance: Unit.IUnit[] = [];
     const units = (prediction && this.unitsPrediction) ? this.unitsPrediction : this.units;
     for (let unit of units) {
-      if (math.sqrDistance(unit, target) <= distance * distance) {
+      if (math.distance(unit, target) <= distance) {
         withinDistance.push(unit);
       }
     }

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3467,7 +3467,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       // Filter for units within SELECTABLE_RADIUS of coordinates
       .filter(u => math.distance(u, coords) <= (u.isMiniboss ? config.SELECTABLE_RADIUS * config.UNIT_MINIBOSS_SCALE_MULTIPLIER : config.SELECTABLE_RADIUS))
       // Order by closest to coords
-      .sort((a, b) => math.distance(a, coords) - math.distance(b, coords))
+      .sort((a, b) => math.sqrDistance(a, coords) - math.sqrDistance(b, coords))
       // Sort dead units to the back, prefer selecting living units
       // TODO: This should be opposite if the spell is ressurect
       .sort((a, b) => a.alive && b.alive ? 0 : a.alive ? -1 : 1);
@@ -3479,7 +3479,8 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
   getPickupAt(coords: Vec2, prediction?: boolean): Pickup.IPickup | undefined {
     const sortedByProximityToCoords = (prediction && this.pickupsPrediction ? this.pickupsPrediction : this.pickups)
       .filter(p => !p.flaggedForRemoval && !isNaN(p.x) && !isNaN(p.y))
-      .filter(p => !isNaN(p.x) && !isNaN(p.y) && math.distance(coords, p) <= p.radius).sort((a, b) => math.distance(a, coords) - math.distance(b, coords));
+      .filter(p => !isNaN(p.x) && !isNaN(p.y) && math.distance(coords, p) <= p.radius)
+      .sort((a, b) => math.sqrDistance(a, coords) - math.sqrDistance(b, coords));
     const closest = sortedByProximityToCoords[0]
     return closest;
   }

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3425,7 +3425,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     const withinDistance: HasSpace[] = [];
     const potentialTargets = this.getPotentialTargets(prediction);
     for (let entity of potentialTargets) {
-      if (math.distance(entity, target) <= distance) {
+      if (math.sqrDistance(entity, target) <= distance * distance) {
         withinDistance.push(entity);
       }
     }
@@ -3440,7 +3440,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     const withinDistance: Pickup.IPickup[] = [];
     const pickups = (prediction && this.pickupsPrediction) ? this.pickupsPrediction : this.pickups;
     for (let pickup of pickups) {
-      if (math.distance(pickup, target) <= distance) {
+      if (math.sqrDistance(pickup, target) <= distance * distance) {
         withinDistance.push(pickup);
       }
     }
@@ -3454,7 +3454,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     const withinDistance: Unit.IUnit[] = [];
     const units = (prediction && this.unitsPrediction) ? this.unitsPrediction : this.units;
     for (let unit of units) {
-      if (math.distance(unit, target) <= distance) {
+      if (math.sqrDistance(unit, target) <= distance * distance) {
         withinDistance.push(unit);
       }
     }

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3467,7 +3467,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       // Filter for units within SELECTABLE_RADIUS of coordinates
       .filter(u => math.distance(u, coords) <= (u.isMiniboss ? config.SELECTABLE_RADIUS * config.UNIT_MINIBOSS_SCALE_MULTIPLIER : config.SELECTABLE_RADIUS))
       // Order by closest to coords
-      .sort((a, b) => math.sqrDistance(a, coords) - math.sqrDistance(b, coords))
+      .sort(math.sortCosestTo(coords))
       // Sort dead units to the back, prefer selecting living units
       // TODO: This should be opposite if the spell is ressurect
       .sort((a, b) => a.alive && b.alive ? 0 : a.alive ? -1 : 1);
@@ -3480,7 +3480,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     const sortedByProximityToCoords = (prediction && this.pickupsPrediction ? this.pickupsPrediction : this.pickups)
       .filter(p => !p.flaggedForRemoval && !isNaN(p.x) && !isNaN(p.y))
       .filter(p => !isNaN(p.x) && !isNaN(p.y) && math.distance(coords, p) <= p.radius)
-      .sort((a, b) => math.sqrDistance(a, coords) - math.sqrDistance(b, coords));
+      .sort(math.sortCosestTo(coords));
     const closest = sortedByProximityToCoords[0]
     return closest;
   }

--- a/src/cards/burst.ts
+++ b/src/cards/burst.ts
@@ -10,9 +10,9 @@ import { makeBurstParticles } from '../graphics/ParticleCollection';
 
 export const burstCardId = 'Burst';
 const maxDamage = 50;
-function calculateDamage(stack: number, casterPositionAtTimeOfCast: Vec2, casterAttackRange: number, target: Vec2): number {
-    const dist = distance(casterPositionAtTimeOfCast, target)
-    return Math.ceil(lerp(maxDamage, 0, (dist - config.COLLISION_MESH_RADIUS) / casterAttackRange) * stack);
+function calculateDamage(stack: number, caster: Vec2, casterAttackRange: number, target: Vec2): number {
+  const dist = distance(caster, target)
+  return Math.ceil(lerp(maxDamage, 0, (dist - config.COLLISION_MESH_RADIUS) / casterAttackRange) * stack);
 }
 export interface UnitDamage {
   id: number;
@@ -44,9 +44,11 @@ const spell: Spell = {
             playDefaultSpellSFX(card, prediction);
             for (let unit of targets) {
               const damage = calculateDamage(quantity, state.casterUnit, state.casterUnit.attackRange, unit);
-              Unit.takeDamage(unit, damage, state.casterUnit, underworld, prediction, state);
-              // Animate:
-              makeBurstParticles(unit, lerp(0.1, 1, damage / maxDamage), prediction, resolve);
+              if (damage > 0) {
+                Unit.takeDamage(unit, damage, state.casterUnit, underworld, prediction, state);
+                // Animate:
+                makeBurstParticles(unit, lerp(0.1, 1, damage / maxDamage), prediction, resolve);
+              }
             }
           } else {
             // Prevent timeout if burst is cast on no living units

--- a/src/cards/connect.ts
+++ b/src/cards/connect.ts
@@ -135,13 +135,13 @@ export async function getNextConnectingEntities(
 
   let connected: { chainSource: HasSpace, entity: HasSpace }[] = [];
   do {
-    let closestSqrDist = radius * radius;
+    let closestDist = radius;
     let closestTarget: HasSpace | undefined = undefined;
 
     for (let t of potentialTargets) {
-      const dist = math.sqrDistance(t, source);
-      if (dist <= closestSqrDist) {
-        closestSqrDist = dist;
+      const dist = math.distance(t, source);
+      if (dist <= closestDist) {
+        closestDist = dist;
         closestTarget = t;
       }
     }

--- a/src/cards/connect.ts
+++ b/src/cards/connect.ts
@@ -135,13 +135,13 @@ export async function getNextConnectingEntities(
 
   let connected: { chainSource: HasSpace, entity: HasSpace }[] = [];
   do {
-    let closestDist = radius;
+    let closestSqrDist = radius * radius;
     let closestTarget: HasSpace | undefined = undefined;
 
     for (let t of potentialTargets) {
-      const dist = math.distance(t, source);
-      if (dist < closestDist) {
-        closestDist = dist;
+      const dist = math.sqrDistance(t, source);
+      if (dist <= closestSqrDist) {
+        closestSqrDist = dist;
         closestTarget = t;
       }
     }

--- a/src/cards/swap.ts
+++ b/src/cards/swap.ts
@@ -30,8 +30,8 @@ const spell: Spell = {
       const swaps: [HasSpace, Vec2][] = [];
       const swapLocation = { x: casterUnit.x, y: casterUnit.y };
       const targets = getCurrentTargets(state);
-      // Swap the casterUnit
-      const casterSwapTarget = targets[0];
+      // Swap the casterUnit with the last target
+      const casterSwapTarget = targets[targets.length - 1];
       if (casterSwapTarget) {
         swaps.push([casterUnit, casterSwapTarget]);
       }

--- a/src/cards/target_all.ts
+++ b/src/cards/target_all.ts
@@ -60,7 +60,7 @@ const spell: Spell = {
               return false;
             }
           })
-          .sort((a, b) => math.sqrDistance(a, target) - math.sqrDistance(b, target));
+          .sort(math.sortCosestTo(target));
 
         const newTargets = potentialTargets.slice(0, NUMBER_OF_TARGETS_PER_STACK * quantity);
         if (!prediction) {

--- a/src/cards/target_all.ts
+++ b/src/cards/target_all.ts
@@ -1,6 +1,7 @@
 import { addTarget, getCurrentTargets, Spell } from './index';
 import { CardCategory } from '../types/commonTypes';
 import { Vec2 } from '../jmath/Vec';
+import * as math from '../jmath/math';
 import * as Unit from '../entity/Unit';
 import { isUnit } from '../entity/Unit';
 import { isPickup } from '../entity/Pickup';
@@ -26,65 +27,55 @@ const spell: Spell = {
     description: ['spell_target_kind', NUMBER_OF_TARGETS_PER_STACK.toString()],
     allowNonUnitTarget: true,
     effect: async (state, card, quantity, underworld, prediction, outOfRange) => {
-      // Note: This loop must NOT be a for..of and it must cache the length because it
-      // mutates state.targetedUnits as it iterates.  Otherwise it will continue to loop as it grows
+      // We store the initial targets because target similar mutates state.targetedUnits
       let targets: Vec2[] = getCurrentTargets(state);
       targets = targets.length ? targets : [state.castLocation];
-      const length = targets.length;
+      const initialTargets = targets;
       const animators = [];
-      const newTargets: HasSpace[] = [];
-      for (let i = 0; i < length; i++) {
-        // Refresh the targets array so it excludes reselecting a target that was selected by the last iteration
+      for (let i = 0; i < initialTargets.length; i++) {
         targets = getCurrentTargets(state);
-        const target = targets[i];
+        const target = initialTargets[i];
         if (!target) {
           continue;
         }
-        const filterFn = (x: any) => {
-          if (Unit.isUnit(x) && Unit.isUnit(target)) {
-            if (target.alive) {
-              // Match living units of the same faction
-              return x.faction == target.faction && x.alive;
-            } else {
-              // Match any dead unit
-              return !x.alive;
-            }
-          } else if (!Unit.isUnit(x) && !Unit.isUnit(target)) {
-            // Match both non units to each other
-            return true;
-          } else {
-            // Do not match unit and non unit
-            return false;
-          }
-        }
-        const tempNewTargets = underworld.getPotentialTargets(prediction)
+
+        const potentialTargets = underworld.getPotentialTargets(prediction)
           // Filter out current targets
           .filter(t => !targets.includes(t))
           // Filter out dissimilar types
-          // @ts-ignore Find similar units by unitSourceId, find similar pickups by name
+          // For "Target All", we only filter by units and pickups
+          // Rather than filtering by unit species and pickup type
           .filter(t => {
-            if (isUnit(target)) {
-              return isUnit(t) && t.alive == target.alive;
-            } else if (isPickup(target)) {
-              return isPickup(t);
+            if (isUnit(target) && isUnit(t)) {
+              if (target.alive) {
+                // Match living units of the same faction
+                return t.alive && t.faction == target.faction;
+              } else {
+                // Match any dead unit
+                return !t.alive;
+              }
+            } else if (isPickup(target) && isPickup(t)) {
+              return true;
+            } else {
+              return false;
             }
           })
-          .filter(filterFn)
-          .slice(0, NUMBER_OF_TARGETS_PER_STACK * quantity);
-        tempNewTargets.forEach(t => newTargets.push(t));
+          .sort((a, b) => math.sqrDistance(a, target) - math.sqrDistance(b, target));
+
+        const newTargets = potentialTargets.slice(0, NUMBER_OF_TARGETS_PER_STACK * quantity);
         if (!prediction) {
           playSFXKey('targeting');
-          animators.push({ pos: target, newTargets: tempNewTargets });
+          animators.push({ pos: target, newTargets: newTargets });
+        }
+        for (let newTarget of newTargets) {
+          addTarget(newTarget, state);
         }
       }
-      for (let newTarget of newTargets) {
-        addTarget(newTarget, state);
-      }
+
       await animateTargetSimilar(animators);
 
       return state;
     },
   },
 };
-
 export default spell;

--- a/src/cards/target_arrow.ts
+++ b/src/cards/target_arrow.ts
@@ -9,7 +9,7 @@ import { clone, Vec2 } from '../jmath/Vec';
 import { findWherePointIntersectLineSegmentAtRightAngle } from '../jmath/lineSegment';
 import { findArrowPath } from './arrow';
 import Underworld from '../Underworld';
-import { distance } from '../jmath/math';
+import { distance, sqrDistance } from '../jmath/math';
 
 export const targetArrowCardId = 'Target Arrow';
 const spell: Spell = {
@@ -116,11 +116,11 @@ export function findArrowCollisions(casterPositionAtTimeOfCast: Vec2, casterId: 
       }
       const pointAtRightAngleToArrowPath = findWherePointIntersectLineSegmentAtRightAngle(u, arrowShootPath);
       // TODO: Validate: Will this hit miniboss since their radius is larger?
-      const willBeStruckByArrow = !pointAtRightAngleToArrowPath ? false : distance(u, pointAtRightAngleToArrowPath) <= config.COLLISION_MESH_RADIUS
+      const willBeStruckByArrow = !pointAtRightAngleToArrowPath ? false : sqrDistance(u, pointAtRightAngleToArrowPath) <= config.COLLISION_MESH_RADIUS * config.COLLISION_MESH_RADIUS;
       return willBeStruckByArrow;
     },
   ).sort((a, b) => {
-    return distance(a, arrowShootPath.p1) - distance(b, arrowShootPath.p1);
+    return sqrDistance(a, arrowShootPath.p1) - sqrDistance(b, arrowShootPath.p1);
   })
   // Return the endPoint so the arrow will fly and hit a wall even if it doesn't hit a unit
   return hitTargets.length ? hitTargets : [arrowShootPath.p2];

--- a/src/cards/target_arrow.ts
+++ b/src/cards/target_arrow.ts
@@ -9,7 +9,7 @@ import { clone, Vec2 } from '../jmath/Vec';
 import { findWherePointIntersectLineSegmentAtRightAngle } from '../jmath/lineSegment';
 import { findArrowPath } from './arrow';
 import Underworld from '../Underworld';
-import { sortCosestTo, sqrDistance } from '../jmath/math';
+import { distance, sortCosestTo } from '../jmath/math';
 
 export const targetArrowCardId = 'Target Arrow';
 const spell: Spell = {
@@ -116,7 +116,7 @@ export function findArrowCollisions(casterPositionAtTimeOfCast: Vec2, casterId: 
       }
       const pointAtRightAngleToArrowPath = findWherePointIntersectLineSegmentAtRightAngle(u, arrowShootPath);
       // TODO: Validate: Will this hit miniboss since their radius is larger?
-      const willBeStruckByArrow = !pointAtRightAngleToArrowPath ? false : sqrDistance(u, pointAtRightAngleToArrowPath) <= config.COLLISION_MESH_RADIUS * config.COLLISION_MESH_RADIUS;
+      const willBeStruckByArrow = !pointAtRightAngleToArrowPath ? false : distance(u, pointAtRightAngleToArrowPath) <= config.COLLISION_MESH_RADIUS;
       return willBeStruckByArrow;
     },
   ).sort(sortCosestTo(arrowShootPath.p1))

--- a/src/cards/target_arrow.ts
+++ b/src/cards/target_arrow.ts
@@ -9,7 +9,7 @@ import { clone, Vec2 } from '../jmath/Vec';
 import { findWherePointIntersectLineSegmentAtRightAngle } from '../jmath/lineSegment';
 import { findArrowPath } from './arrow';
 import Underworld from '../Underworld';
-import { distance, sqrDistance } from '../jmath/math';
+import { sortCosestTo, sqrDistance } from '../jmath/math';
 
 export const targetArrowCardId = 'Target Arrow';
 const spell: Spell = {
@@ -119,9 +119,8 @@ export function findArrowCollisions(casterPositionAtTimeOfCast: Vec2, casterId: 
       const willBeStruckByArrow = !pointAtRightAngleToArrowPath ? false : sqrDistance(u, pointAtRightAngleToArrowPath) <= config.COLLISION_MESH_RADIUS * config.COLLISION_MESH_RADIUS;
       return willBeStruckByArrow;
     },
-  ).sort((a, b) => {
-    return sqrDistance(a, arrowShootPath.p1) - sqrDistance(b, arrowShootPath.p1);
-  })
+  ).sort(sortCosestTo(arrowShootPath.p1))
+
   // Return the endPoint so the arrow will fly and hit a wall even if it doesn't hit a unit
   return hitTargets.length ? hitTargets : [arrowShootPath.p2];
 }

--- a/src/cards/target_circle.ts
+++ b/src/cards/target_circle.ts
@@ -9,6 +9,7 @@ import * as config from '../config';
 import { easeOutCubic } from '../jmath/Easing';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { HasSpace } from '../entity/Type';
+import { sqrDistance } from '../jmath/math';
 
 const id = 'Target Circle';
 const baseRadius = 100;
@@ -53,6 +54,8 @@ const spell: Spell = {
           adjustedRange,
           prediction
         );
+        // Sort by distance to circle center
+        withinRadius.sort((a, b) => sqrDistance(a, target) - sqrDistance(b, target));
         // Add entities to target
         withinRadius.forEach(e => addTarget(e, state));
       }

--- a/src/cards/target_circle.ts
+++ b/src/cards/target_circle.ts
@@ -9,7 +9,7 @@ import * as config from '../config';
 import { easeOutCubic } from '../jmath/Easing';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { HasSpace } from '../entity/Type';
-import { sqrDistance } from '../jmath/math';
+import { sortCosestTo, sqrDistance } from '../jmath/math';
 
 const id = 'Target Circle';
 const baseRadius = 100;
@@ -55,7 +55,7 @@ const spell: Spell = {
           prediction
         );
         // Sort by distance to circle center
-        withinRadius.sort((a, b) => sqrDistance(a, target) - sqrDistance(b, target));
+        withinRadius.sort(sortCosestTo(target));
         // Add entities to target
         withinRadius.forEach(e => addTarget(e, state));
       }

--- a/src/cards/target_circle.ts
+++ b/src/cards/target_circle.ts
@@ -9,7 +9,7 @@ import * as config from '../config';
 import { easeOutCubic } from '../jmath/Easing';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { HasSpace } from '../entity/Type';
-import { sortCosestTo, sqrDistance } from '../jmath/math';
+import { sortCosestTo, } from '../jmath/math';
 
 const id = 'Target Circle';
 const baseRadius = 100;

--- a/src/cards/target_column.ts
+++ b/src/cards/target_column.ts
@@ -3,6 +3,7 @@ import { addTarget, defaultTargetsForAllowNonUnitTargetTargetingSpell, getCurren
 import { drawUIPolyPrediction } from '../graphics/PlanningView';
 import { CardCategory } from '../types/commonTypes';
 import * as colors from '../graphics/ui/colors';
+import * as Vec from '../jmath/Vec';
 import { invert, Vec2 } from '../jmath/Vec';
 import { moveAlongVector, normalizedVector } from '../jmath/moveWithCollision';
 import { isVec2InsidePolygon } from '../jmath/Polygon2';
@@ -60,6 +61,10 @@ const spell: Spell = {
         ).filter(t => {
           return isVec2InsidePolygon(t, targetingColumn);
         });
+        // Sort by distance along column
+        withinColumn.sort((a, b) =>
+          sqrDistanceAlongColumn(a, target, vector)
+          - sqrDistanceAlongColumn(b, target, vector));
         // Add entities to target
         withinColumn.forEach(e => addTarget(e, state));
       }
@@ -134,5 +139,27 @@ async function animate(columns: { castLocation: Vec2, vector: Vec2, width: numbe
   })).then(() => {
     globalThis.predictionGraphics?.clear();
   });
+}
+function sqrDistanceAlongColumn(point: Vec2, columnOrigin: Vec2, vector: Vec2): number {
+  const vectorToPoint = Vec.subtract(point, columnOrigin);
+  // Vector is the direction the column extends
+  // Vector is already normalized in effect, so no need to normalize it again here
+  const projection = Vec.projectOnNormal(vectorToPoint, vector);
+
+  // if (predictionGraphics) {
+  //   const projectionEnd = Vec.add(columnOrigin, projection);
+  //   predictionGraphics.lineStyle(4, colors.trueBlue, 1.0)
+  //   predictionGraphics.moveTo(columnOrigin.x, columnOrigin.y);
+  //   predictionGraphics.lineTo(projectionEnd.x, projectionEnd.y);
+  //   predictionGraphics.endFill();
+
+  //   const columnEnd = Vec.add(columnOrigin, vector);
+  //   predictionGraphics.lineStyle(2, colors.trueRed, 1.0)
+  //   predictionGraphics.moveTo(columnOrigin.x, columnOrigin.y);
+  //   predictionGraphics.lineTo(columnEnd.x, columnEnd.y);
+  //   predictionGraphics.endFill();
+  // }
+
+  return Vec.sqrMagnitude(projection);
 }
 export default spell;

--- a/src/cards/target_column.ts
+++ b/src/cards/target_column.ts
@@ -63,8 +63,8 @@ const spell: Spell = {
         });
         // Sort by distance along column
         withinColumn.sort((a, b) =>
-          sqrDistanceAlongColumn(a, target, vector)
-          - sqrDistanceAlongColumn(b, target, vector));
+          distanceAlongColumn(a, target, vector)
+          - distanceAlongColumn(b, target, vector));
         // Add entities to target
         withinColumn.forEach(e => addTarget(e, state));
       }
@@ -140,7 +140,7 @@ async function animate(columns: { castLocation: Vec2, vector: Vec2, width: numbe
     globalThis.predictionGraphics?.clear();
   });
 }
-function sqrDistanceAlongColumn(point: Vec2, columnOrigin: Vec2, vector: Vec2): number {
+function distanceAlongColumn(point: Vec2, columnOrigin: Vec2, vector: Vec2): number {
   const vectorToPoint = Vec.subtract(point, columnOrigin);
   // Vector is the direction the column extends
   // Vector is already normalized in effect, so no need to normalize it again here
@@ -160,6 +160,6 @@ function sqrDistanceAlongColumn(point: Vec2, columnOrigin: Vec2, vector: Vec2): 
   //   predictionGraphics.endFill();
   // }
 
-  return Vec.sqrMagnitude(projection);
+  return Vec.magnitude(projection);
 }
 export default spell;

--- a/src/cards/target_cone.ts
+++ b/src/cards/target_cone.ts
@@ -4,7 +4,7 @@ import { CardCategory } from '../types/commonTypes';
 import * as colors from '../graphics/ui/colors';
 import { getAngleBetweenVec2s, Vec2 } from '../jmath/Vec';
 import { isAngleBetweenAngles } from '../jmath/Angle';
-import { distance, sqrDistance } from '../jmath/math';
+import { sortCosestTo, sqrDistance } from '../jmath/math';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import type Underworld from '../Underworld';
 import { raceTimeout } from '../Promise';
@@ -61,7 +61,7 @@ const spell: Spell = {
           return withinCone(state.casterUnit, target, adjustedRange, startAngle, endAngle, t);
         });
         // Sort by distance to cone start
-        withinRadiusAndAngle.sort((a, b) => sqrDistance(a, target) - sqrDistance(b, target));
+        withinRadiusAndAngle.sort(sortCosestTo(target));
         // Add entities to target
         withinRadiusAndAngle.forEach(e => addTarget(e, state));
       }

--- a/src/cards/target_cone.ts
+++ b/src/cards/target_cone.ts
@@ -4,7 +4,7 @@ import { CardCategory } from '../types/commonTypes';
 import * as colors from '../graphics/ui/colors';
 import { getAngleBetweenVec2s, Vec2 } from '../jmath/Vec';
 import { isAngleBetweenAngles } from '../jmath/Angle';
-import { sortCosestTo, sqrDistance } from '../jmath/math';
+import { distance, sortCosestTo } from '../jmath/math';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import type Underworld from '../Underworld';
 import { raceTimeout } from '../Promise';
@@ -75,11 +75,11 @@ const spell: Spell = {
 function withinCone(origin: Vec2, coneStartPoint: Vec2, radius: number, startAngle: number, endAngle: number, target: Vec2): boolean {
   // and within angle:
   const targetAngle = getAngleBetweenVec2s(coneStartPoint, target);
-  const distanceToConeStart = sqrDistance(target, coneStartPoint);
+  const distanceToConeStart = distance(target, coneStartPoint);
 
   //TODO - Investigate isAngleBetweenAngles
   //temp fix for cone inversion: if angle is whole circle, just check distance.
-  return distanceToConeStart <= radius * radius
+  return distanceToConeStart <= radius
     && (isAngleBetweenAngles(targetAngle, startAngle, endAngle) || Math.abs(endAngle - startAngle) >= 2 * Math.PI);
 }
 

--- a/src/cards/target_cone.ts
+++ b/src/cards/target_cone.ts
@@ -4,7 +4,7 @@ import { CardCategory } from '../types/commonTypes';
 import * as colors from '../graphics/ui/colors';
 import { getAngleBetweenVec2s, Vec2 } from '../jmath/Vec';
 import { isAngleBetweenAngles } from '../jmath/Angle';
-import { distance } from '../jmath/math';
+import { distance, sqrDistance } from '../jmath/math';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import type Underworld from '../Underworld';
 import { raceTimeout } from '../Promise';
@@ -60,6 +60,8 @@ const spell: Spell = {
         ).filter(t => {
           return withinCone(state.casterUnit, target, adjustedRange, startAngle, endAngle, t);
         });
+        // Sort by distance to cone start
+        withinRadiusAndAngle.sort((a, b) => sqrDistance(a, target) - sqrDistance(b, target));
         // Add entities to target
         withinRadiusAndAngle.forEach(e => addTarget(e, state));
       }

--- a/src/cards/target_cone.ts
+++ b/src/cards/target_cone.ts
@@ -75,13 +75,12 @@ const spell: Spell = {
 function withinCone(origin: Vec2, coneStartPoint: Vec2, radius: number, startAngle: number, endAngle: number, target: Vec2): boolean {
   // and within angle:
   const targetAngle = getAngleBetweenVec2s(coneStartPoint, target);
-  const distanceToConeStart = distance(target, coneStartPoint);
+  const distanceToConeStart = sqrDistance(target, coneStartPoint);
 
   //TODO - Investigate isAngleBetweenAngles
   //temp fix for cone inversion: if angle is whole circle, just check distance.
-  return distanceToConeStart <= radius
+  return distanceToConeStart <= radius * radius
     && (isAngleBetweenAngles(targetAngle, startAngle, endAngle) || Math.abs(endAngle - startAngle) >= 2 * Math.PI);
-
 }
 
 async function animate(cones: { origin: Vec2, coneStartPoint: Vec2, radius: number, startAngle: number, endAngle: number }[], underworld: Underworld) {

--- a/src/cards/target_similar.ts
+++ b/src/cards/target_similar.ts
@@ -56,7 +56,7 @@ export function targetSimilarEffect(numberOfTargets: number) {
             return isPickup(t) && t.name == target.name;
           }
         })
-        .sort((a, b) => math.distance(a, target) - math.distance(b, target));
+        .sort((a, b) => math.sqrDistance(a, target) - math.sqrDistance(b, target));
 
       const newTargets = potentialTargets.slice(0, numberOfTargets * quantity);
       if (!prediction) {

--- a/src/cards/target_similar.ts
+++ b/src/cards/target_similar.ts
@@ -63,7 +63,7 @@ export function targetSimilarEffect(numberOfTargets: number) {
             return false;
           }
         })
-        .sort((a, b) => math.sqrDistance(a, target) - math.sqrDistance(b, target));
+        .sort(math.sortCosestTo(target));
 
       const newTargets = potentialTargets.slice(0, numberOfTargets * quantity);
       if (!prediction) {

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1186,15 +1186,15 @@ export function livingUnitsInSameFaction(unit: IUnit, underworld: Underworld) {
   );
 }
 export function closestInListOfUnits(source: Vec2, units: IUnit[]): IUnit | undefined {
-  return units.reduce<{ closest: IUnit | undefined; sqrDistance: number }>(
+  return units.reduce<{ closest: IUnit | undefined; distance: number }>(
     (acc, currentUnitConsidered) => {
-      const sqrDist = math.sqrDistance(currentUnitConsidered, source);
-      if (sqrDist <= acc.sqrDistance) {
-        return { closest: currentUnitConsidered, sqrDistance: sqrDist };
+      const dist = math.distance(currentUnitConsidered, source);
+      if (dist <= acc.distance) {
+        return { closest: currentUnitConsidered, distance: dist };
       }
       return acc;
     },
-    { closest: undefined, sqrDistance: Number.MAX_SAFE_INTEGER },
+    { closest: undefined, distance: Number.MAX_SAFE_INTEGER },
   ).closest;
 }
 export function findClosestUnitInDifferentFaction(
@@ -1333,7 +1333,7 @@ export function getExplainPathForUnitId(id: string): string {
   return "images/explain/units/" + id.split(' ').join('') + ".gif";
 }
 export function inRange(unit: IUnit, target: Vec2): boolean {
-  return math.sqrDistance(unit, target) <= unit.attackRange * unit.attackRange;
+  return math.distance(unit, target) <= unit.attackRange;
 }
 
 // return boolean signifies if unit should abort their turn

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1185,19 +1185,16 @@ export function livingUnitsInSameFaction(unit: IUnit, underworld: Underworld) {
     (u) => u !== unit && u.faction == unit.faction && u.alive && u.unitSubType !== UnitSubType.DOODAD,
   );
 }
-export function closestInListOfUnits(
-  sourceUnit: IUnit,
-  units: IUnit[],
-): IUnit | undefined {
-  return units.reduce<{ closest: IUnit | undefined; distance: number }>(
+export function closestInListOfUnits(source: Vec2, units: IUnit[]): IUnit | undefined {
+  return units.reduce<{ closest: IUnit | undefined; sqrDistance: number }>(
     (acc, currentUnitConsidered) => {
-      const dist = distance(currentUnitConsidered, sourceUnit);
-      if (dist <= acc.distance) {
-        return { closest: currentUnitConsidered, distance: dist };
+      const sqrDist = math.sqrDistance(currentUnitConsidered, source);
+      if (sqrDist <= acc.sqrDistance) {
+        return { closest: currentUnitConsidered, sqrDistance: sqrDist };
       }
       return acc;
     },
-    { closest: undefined, distance: Number.MAX_SAFE_INTEGER },
+    { closest: undefined, sqrDistance: Number.MAX_SAFE_INTEGER },
   ).closest;
 }
 export function findClosestUnitInDifferentFaction(
@@ -1335,8 +1332,8 @@ export function syncImage(unit: IUnit) {
 export function getExplainPathForUnitId(id: string): string {
   return "images/explain/units/" + id.split(' ').join('') + ".gif";
 }
-export function inRange(unit: IUnit, coords: Vec2): boolean {
-  return math.distance(unit, coords) <= unit.attackRange;
+export function inRange(unit: IUnit, target: Vec2): boolean {
+  return math.sqrDistance(unit, target) <= unit.attackRange * unit.attackRange;
 }
 
 // return boolean signifies if unit should abort their turn

--- a/src/entity/units/ancient.ts
+++ b/src/entity/units/ancient.ts
@@ -68,7 +68,7 @@ const unit: UnitSource = {
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
     return Unit.livingUnitsInDifferentFaction(unit, underworld)
       .filter(u => Unit.inRange(unit, u))
-      .sort((a, b) => math.sqrDistance(a, unit) - math.sqrDistance(b, unit))
+      .sort(math.sortCosestTo(unit))
       .slice(0, numberOfTargets);
   }
 };

--- a/src/entity/units/ancient.ts
+++ b/src/entity/units/ancient.ts
@@ -67,12 +67,8 @@ const unit: UnitSource = {
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
     return Unit.livingUnitsInDifferentFaction(unit, underworld)
-      .filter(u => math.distance(unit, u) <= unit.attackRange)
-      .map(u => ({ unit: u, dist: math.distance(unit, u) }))
-      .sort((a, b) => {
-        return a.dist - b.dist;
-      })
-      .map(x => x.unit)
+      .filter(u => Unit.inRange(unit, u))
+      .sort((a, b) => math.sqrDistance(a, unit) - math.sqrDistance(b, unit))
       .slice(0, numberOfTargets);
   }
 };

--- a/src/entity/units/darkPriest.ts
+++ b/src/entity/units/darkPriest.ts
@@ -98,7 +98,7 @@ const unit: UnitSource = {
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
     return Unit.livingUnitsInDifferentFaction(unit, underworld)
       .filter(u => Unit.inRange(unit, u))
-      .sort((a, b) => math.sqrDistance(a, unit) - math.sqrDistance(b, unit))
+      .sort(math.sortCosestTo(unit))
       .slice(0, NUMBER_OF_GEYSERS);
   }
 };

--- a/src/entity/units/darkPriest.ts
+++ b/src/entity/units/darkPriest.ts
@@ -97,12 +97,8 @@ const unit: UnitSource = {
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
     return Unit.livingUnitsInDifferentFaction(unit, underworld)
-      .filter(u => math.distance(unit, u) <= unit.attackRange)
-      .map(u => ({ unit: u, dist: math.distance(unit, u) }))
-      .sort((a, b) => {
-        return a.dist - b.dist;
-      })
-      .map(x => x.unit)
+      .filter(u => Unit.inRange(unit, u))
+      .sort((a, b) => math.sqrDistance(a, unit) - math.sqrDistance(b, unit))
       .slice(0, NUMBER_OF_GEYSERS);
   }
 };

--- a/src/entity/units/greenGlop.ts
+++ b/src/entity/units/greenGlop.ts
@@ -114,7 +114,7 @@ const unit: UnitSource = {
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
     return Unit.livingUnitsInDifferentFaction(unit, underworld)
       .filter(u => Unit.inRange(unit, u))
-      .sort((a, b) => math.sqrDistance(a, unit) - math.sqrDistance(b, unit))
+      .sort(math.sortCosestTo(unit))
       .slice(0, numberOfTargets);
   }
 };

--- a/src/entity/units/greenGlop.ts
+++ b/src/entity/units/greenGlop.ts
@@ -113,12 +113,8 @@ const unit: UnitSource = {
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
     return Unit.livingUnitsInDifferentFaction(unit, underworld)
-      .filter(u => math.distance(unit, u) <= unit.attackRange)
-      .map(u => ({ unit: u, dist: math.distance(unit, u) }))
-      .sort((a, b) => {
-        return a.dist - b.dist;
-      })
-      .map(x => x.unit)
+      .filter(u => Unit.inRange(unit, u))
+      .sort((a, b) => math.sqrDistance(a, unit) - math.sqrDistance(b, unit))
       .slice(0, numberOfTargets);
   }
 };

--- a/src/entity/units/priest.ts
+++ b/src/entity/units/priest.ts
@@ -107,7 +107,7 @@ const unit: UnitSource = {
     const numberOfAlliesToRez = unit.isMiniboss ? 3 : 1;
     return resurrectableUnits(unit, underworld)
       .filter(u => Unit.inRange(unit, u))
-      .sort((a, b) => math.sqrDistance(a, unit) - math.sqrDistance(b, unit))
+      .sort(math.sortCosestTo(unit))
       .slice(0, numberOfAlliesToRez);
   }
 };

--- a/src/entity/units/priest.ts
+++ b/src/entity/units/priest.ts
@@ -105,9 +105,10 @@ const unit: UnitSource = {
       return [];
     }
     const numberOfAlliesToRez = unit.isMiniboss ? 3 : 1;
-    return resurrectableUnits(unit, underworld).filter(u => {
-      return Unit.inRange(unit, u)
-    }).slice(0, numberOfAlliesToRez);
+    return resurrectableUnits(unit, underworld)
+      .filter(u => Unit.inRange(unit, u))
+      .sort((a, b) => math.sqrDistance(a, unit) - math.sqrDistance(b, unit))
+      .slice(0, numberOfAlliesToRez);
   }
 };
 export function resurrectableUnits(resurrector: Unit.IUnit, underworld: Underworld): Unit.IUnit[] {
@@ -123,7 +124,6 @@ export function resurrectableUnits(resurrector: Unit.IUnit, underworld: Underwor
     // Do not allow priest to rez each other.
     // That would be super annoying for players
     && u.unitSourceId !== resurrector.unitSourceId);
-
 }
 
 export default unit;

--- a/src/jmath/Pathfinding.ts
+++ b/src/jmath/Pathfinding.ts
@@ -516,7 +516,7 @@ function getLastLineInPath(path: Path): LineSegment {
 function getClosestIntersectionWithWalls(line: LineSegment, walls: Polygon2LineSegment[], includeStartPoint: boolean = false): { intersectingWall?: Polygon2LineSegment, closestIntersection?: Vec2 } {
   let intersectingWall;
   let closestIntersection;
-  let closestIntersectionSqrDistance;
+  let closestIntersectionDistance;
   // Check for collisions between the last line in the path and pathing walls
   for (let wall of walls) {
     const intersection = lineSegmentIntersection(line, wall);
@@ -542,12 +542,12 @@ function getClosestIntersectionWithWalls(line: LineSegment, walls: Polygon2LineS
           }
         }
       }
-      const sqrDist = math.sqrDistance(line.p1, intersection);
+      const dist = math.distance(line.p1, intersection);
       // If there is no closest intersection, make this intersection the closest intersection
       // If there is and this intersection is closer, make it the closest
-      if (!closestIntersection || (closestIntersection && closestIntersectionSqrDistance && closestIntersectionSqrDistance > sqrDist)) {
+      if (!closestIntersection || (closestIntersection && closestIntersectionDistance && closestIntersectionDistance > dist)) {
         closestIntersection = intersection;
-        closestIntersectionSqrDistance = sqrDist;
+        closestIntersectionDistance = dist;
         intersectingWall = wall
       }
 

--- a/src/jmath/Pathfinding.ts
+++ b/src/jmath/Pathfinding.ts
@@ -9,498 +9,498 @@ import { isVec2InsidePolygon, Polygon2, Polygon2LineSegment, doesVertexBelongToP
 // Will return either an array with 1 normal polygon or an array with 1 or more 
 // inverted polygons 
 export function findPolygonsThatVec2IsInsideOf(point: Vec2, testPolygons: Polygon2[]): Polygon2[] {
-    let insideOfPolys: Polygon2[] = [];
-    for (let poly of testPolygons) {
-        // Exclude inverted polygons because if there is more than 1
-        // inverted polygon, and since inverted polygons' "insides"
-        // are actually on the outside; there'll be a false positive
-        // where a target in a valid location, will get flagged as
-        // "inside" an inverted polygon.  Maybe this calls for the concept
-        // of inverted polygons to be rethought, since it really only works
-        // when there is only one single inverted polygon
-        if (isVec2InsidePolygon(point, poly)) {
-            insideOfPolys = [poly];
-            // Exit immediately if the point is inside a non-inverted polygon
-            // since overlapping polygons should be merged, we can assume it
-            // is only inide this one polygon
-            break;
-        }
-
+  let insideOfPolys: Polygon2[] = [];
+  for (let poly of testPolygons) {
+    // Exclude inverted polygons because if there is more than 1
+    // inverted polygon, and since inverted polygons' "insides"
+    // are actually on the outside; there'll be a false positive
+    // where a target in a valid location, will get flagged as
+    // "inside" an inverted polygon.  Maybe this calls for the concept
+    // of inverted polygons to be rethought, since it really only works
+    // when there is only one single inverted polygon
+    if (isVec2InsidePolygon(point, poly)) {
+      insideOfPolys = [poly];
+      // Exit immediately if the point is inside a non-inverted polygon
+      // since overlapping polygons should be merged, we can assume it
+      // is only inide this one polygon
+      break;
     }
-    return insideOfPolys;
+
+  }
+  return insideOfPolys;
 }
 interface Path {
-    // done represents that the path should no longer be processing;
-    // it gives no guaruntee as to the validity of the path
-    done: boolean;
-    // Represents if the path reached the destination
-    complete: boolean;
-    // A invalid path does not path to the target and can be ignored
-    invalid: boolean;
-    points: Vec2[];
-    // The end of the path
-    target: Vec2;
-    // The distance that the full path traverses
-    distance: number;
-    walkAroundPolyInfo?: {
-        // A mutatable array of verticies that the pathing process with shift()
-        // one at a time to walk around the polygon
-        verticies: Vec2[];
-        // The original polygon
-        poly: Polygon2;
-    };
+  // done represents that the path should no longer be processing;
+  // it gives no guaruntee as to the validity of the path
+  done: boolean;
+  // Represents if the path reached the destination
+  complete: boolean;
+  // A invalid path does not path to the target and can be ignored
+  invalid: boolean;
+  points: Vec2[];
+  // The end of the path
+  target: Vec2;
+  // The distance that the full path traverses
+  distance: number;
+  walkAroundPolyInfo?: {
+    // A mutatable array of verticies that the pathing process with shift()
+    // one at a time to walk around the polygon
+    verticies: Vec2[];
+    // The original polygon
+    poly: Polygon2;
+  };
 }
 export function findPath(startPoint: Vec2, target: Vec2, pathingLineSegments: Polygon2LineSegment[]): Vec2[] {
-    // Ensure that startPoint and target are ONLY Vec2s and are not duck-typed
-    // This is important for serialization to prevent circular references
-    startPoint = clone(startPoint);
-    target = clone(target)
+  // Ensure that startPoint and target are ONLY Vec2s and are not duck-typed
+  // This is important for serialization to prevent circular references
+  startPoint = clone(startPoint);
+  target = clone(target)
 
 
 
-    let paths: Path[] = [
-        // Start with the first idea path from start to target
-        // Note, the distance is calculated inside of processPaths even if 
-        // there are no interruptions to the path and it just goes from startPoint
-        // to target.
-        { done: false, complete: false, invalid: false, points: [startPoint], target, distance: 0 }
-    ];
+  let paths: Path[] = [
+    // Start with the first idea path from start to target
+    // Note, the distance is calculated inside of processPaths even if 
+    // there are no interruptions to the path and it just goes from startPoint
+    // to target.
+    { done: false, complete: false, invalid: false, points: [startPoint], target, distance: 0 }
+  ];
 
-    // There is a processingLimit to prevent infinite processing.
-    // But this particular number is arbitrary.
-    const processingLimit = 30;
-    // Allow processing up to "processingLimit" times.
-    // Paths often need to be processed multiple times since
-    // one invokation of processPaths only changes the paths slightly
-    // as they get closer and closer to finding their way to the target.
-    for (let i = 0; i < processingLimit; i++) {
-        // Takes 1 step closer to finishing paths
-        paths = processPaths(paths, pathingLineSegments);
+  // There is a processingLimit to prevent infinite processing.
+  // But this particular number is arbitrary.
+  const processingLimit = 30;
+  // Allow processing up to "processingLimit" times.
+  // Paths often need to be processed multiple times since
+  // one invokation of processPaths only changes the paths slightly
+  // as they get closer and closer to finding their way to the target.
+  for (let i = 0; i < processingLimit; i++) {
+    // Takes 1 step closer to finishing paths
+    paths = processPaths(paths, pathingLineSegments);
 
-        // Optimization
-        calculateDistanceOfPaths(paths);
-        const shortestFinishedPaths = paths.filter(p => p.done && !p.invalid).sort((a, b) => a.distance - b.distance);
-        if (shortestFinishedPaths[0]) {
-            const shortestFinishedDistance = shortestFinishedPaths[0].distance;
-            // Make all paths that are already longer than the shortest, finished path invalid.
-            // even if they are not done processing, because even if they'd be valid, they would be
-            // longer than the current shortest, valid path; and thus, not a path we'd choose
-            for (let path of paths) {
-                if (!path.done && path.distance > shortestFinishedDistance) {
-                    path.invalid = true;
-                    path.done = true;
-                }
-
-            }
+    // Optimization
+    calculateDistanceOfPaths(paths);
+    const shortestFinishedPaths = paths.filter(p => p.done && !p.invalid).sort((a, b) => a.distance - b.distance);
+    if (shortestFinishedPaths[0]) {
+      const shortestFinishedDistance = shortestFinishedPaths[0].distance;
+      // Make all paths that are already longer than the shortest, finished path invalid.
+      // even if they are not done processing, because even if they'd be valid, they would be
+      // longer than the current shortest, valid path; and thus, not a path we'd choose
+      for (let path of paths) {
+        if (!path.done && path.distance > shortestFinishedDistance) {
+          path.invalid = true;
+          path.done = true;
         }
 
-        // Once all paths are "done", stop processing
-        if (paths.every(p => p.done)) {
-            break;
-        }
+      }
     }
 
-    // Now that processing is over, mark all paths as done:
-    paths.forEach(path => {
-        if (!path.done) {
-            path.done = true;
-        }
-    })
+    // Once all paths are "done", stop processing
+    if (paths.every(p => p.done)) {
+      break;
+    }
+  }
 
-    // // Debug: Draw the paths:
-    // for (let i = 0; i < paths.length; i++) {
-    //     // Visual offset is useful for representing overlapping paths in a way where you can see
-    //     // all of them
-    //     const visualOffset = i * 5;
-    //     const path = paths[i];
-    //     if (path && path.points[0]) {
+  // Now that processing is over, mark all paths as done:
+  paths.forEach(path => {
+    if (!path.done) {
+      path.done = true;
+    }
+  })
 
-    //         if (path.invalid) {
-    //             globalThis.debugGraphics.lineStyle(4, 0xff0000, 0.3);
-    //         } else {
-    //             globalThis.debugGraphics.lineStyle(4, 0x00ff00, 0.4);
-    //         }
-    //         globalThis.debugGraphics.moveTo(path.points[0].x + visualOffset, path.points[0].y + visualOffset);
-    //         for (let point of path.points) {
-    //             if (path.invalid && point == path.points[path.points.length - 1]) {
-    //                 // Don't draw last point since the path didn't finish
-    //                 break;
-    //             }
-    //             globalThis.debugGraphics.lineTo(point.x + visualOffset, point.y + visualOffset);
-    //         }
+  // // Debug: Draw the paths:
+  // for (let i = 0; i < paths.length; i++) {
+  //     // Visual offset is useful for representing overlapping paths in a way where you can see
+  //     // all of them
+  //     const visualOffset = i * 5;
+  //     const path = paths[i];
+  //     if (path && path.points[0]) {
 
-    //         // Finally, draw to the target, unless the path is invalid (in which case it didn't make
-    //         // it to the target); 
-    //         if (!path.invalid) {
-    //             globalThis.debugGraphics.lineTo(path.target.x + visualOffset, path.target.y + visualOffset);
-    //         }
-    //     }
-    // }
-    // console.log('paths', paths.filter(p => !p.invalid).length, '/', paths.length);
+  //         if (path.invalid) {
+  //             globalThis.debugGraphics.lineStyle(4, 0xff0000, 0.3);
+  //         } else {
+  //             globalThis.debugGraphics.lineStyle(4, 0x00ff00, 0.4);
+  //         }
+  //         globalThis.debugGraphics.moveTo(path.points[0].x + visualOffset, path.points[0].y + visualOffset);
+  //         for (let point of path.points) {
+  //             if (path.invalid && point == path.points[path.points.length - 1]) {
+  //                 // Don't draw last point since the path didn't finish
+  //                 break;
+  //             }
+  //             globalThis.debugGraphics.lineTo(point.x + visualOffset, point.y + visualOffset);
+  //         }
 
-    // Remove invalid paths
-    const firstIntersection = paths[0]?.points[1];
-    paths = paths.filter(p => !p.invalid);
-    paths = paths.filter(p => p.complete);
+  //         // Finally, draw to the target, unless the path is invalid (in which case it didn't make
+  //         // it to the target); 
+  //         if (!path.invalid) {
+  //             globalThis.debugGraphics.lineTo(path.target.x + visualOffset, path.target.y + visualOffset);
+  //         }
+  //     }
+  // }
+  // console.log('paths', paths.filter(p => !p.invalid).length, '/', paths.length);
 
-    // Find the shortest Path
-    // --
-    // Note: Must recalculate the distance of the paths
-    // before finding the shortest path.  This currently happens
-    // right after processPaths is invoked
-    const shortestPath = paths.reduce<Path | undefined>((shortest, contender) => {
-        if (shortest === undefined) {
-            return contender
-        } else {
-            if (shortest.distance > contender.distance) {
-                return contender;
+  // Remove invalid paths
+  const firstIntersection = paths[0]?.points[1];
+  paths = paths.filter(p => !p.invalid);
+  paths = paths.filter(p => p.complete);
+
+  // Find the shortest Path
+  // --
+  // Note: Must recalculate the distance of the paths
+  // before finding the shortest path.  This currently happens
+  // right after processPaths is invoked
+  const shortestPath = paths.reduce<Path | undefined>((shortest, contender) => {
+    if (shortest === undefined) {
+      return contender
+    } else {
+      if (shortest.distance > contender.distance) {
+        return contender;
+      } else {
+        return shortest
+      }
+    }
+  }, undefined);
+
+  // Optimize path by removing unnecessary points
+  // If there is an unobstructed straight line between two points, you can remove all the points in-between
+  if (shortestPath) {
+    // returns true if fully optimized
+    function tryOptimizePath(path: Path): boolean {
+      for (let i = 0; i < path.points.length; i++) {
+        for (let j = path.points.length - 1; j > i + 1; j--) {
+          const p1 = path.points[i];
+          const p2 = path.points[j];
+          if (!(p1 && p2)) {
+            console.error('Loop malformed. p1 or p2 is undefined')
+            continue;
+          }
+          const nextLine = { p1, p2 }
+          let { intersectingWall, closestIntersection } = getClosestIntersectionWithWalls(nextLine, pathingLineSegments);
+          if (intersectingWall) {
+            const intersectingPoly = intersectingWall.polygon;
+
+            const indexIfP2IsOnVertex = intersectingPoly.findIndex(p => Vec.equal(p, nextLine.p2));
+            if (indexIfP2IsOnVertex !== -1) {
+              const lineToTargetDoesNotPassThroughOwnPolygon =
+                doesLineFromPointToTargetProjectAwayFromOwnPolygon(intersectingPoly, indexIfP2IsOnVertex, nextLine.p1);
+              if (!lineToTargetDoesNotPassThroughOwnPolygon) {
+                // Skip, this optimization is invalid because it would cut through a polygon
+                continue;
+              }
             } else {
-                return shortest
+              // Then p2 is on a wall
+              const insideAngleOfWall = getInsideAnglesOfWall(intersectingWall);
+              const lineIsCastIntoNoWalkZone = isAngleBetweenAngles(
+                Vec.getAngleBetweenVec2s(nextLine.p2, nextLine.p1), insideAngleOfWall.start, insideAngleOfWall.end
+              );
+              if (lineIsCastIntoNoWalkZone) {
+                // Skip, this optimization is invalid because it would cut through a polygon
+                continue;
+              }
             }
-        }
-    }, undefined);
-
-    // Optimize path by removing unnecessary points
-    // If there is an unobstructed straight line between two points, you can remove all the points in-between
-    if (shortestPath) {
-        // returns true if fully optimized
-        function tryOptimizePath(path: Path): boolean {
-            for (let i = 0; i < path.points.length; i++) {
-                for (let j = path.points.length - 1; j > i + 1; j--) {
-                    const p1 = path.points[i];
-                    const p2 = path.points[j];
-                    if (!(p1 && p2)) {
-                        console.error('Loop malformed. p1 or p2 is undefined')
-                        continue;
-                    }
-                    const nextLine = { p1, p2 }
-                    let { intersectingWall, closestIntersection } = getClosestIntersectionWithWalls(nextLine, pathingLineSegments);
-                    if (intersectingWall) {
-                        const intersectingPoly = intersectingWall.polygon;
-
-                        const indexIfP2IsOnVertex = intersectingPoly.findIndex(p => Vec.equal(p, nextLine.p2));
-                        if (indexIfP2IsOnVertex !== -1) {
-                            const lineToTargetDoesNotPassThroughOwnPolygon =
-                                doesLineFromPointToTargetProjectAwayFromOwnPolygon(intersectingPoly, indexIfP2IsOnVertex, nextLine.p1);
-                            if (!lineToTargetDoesNotPassThroughOwnPolygon) {
-                                // Skip, this optimization is invalid because it would cut through a polygon
-                                continue;
-                            }
-                        } else {
-                            // Then p2 is on a wall
-                            const insideAngleOfWall = getInsideAnglesOfWall(intersectingWall);
-                            const lineIsCastIntoNoWalkZone = isAngleBetweenAngles(
-                                Vec.getAngleBetweenVec2s(nextLine.p2, nextLine.p1), insideAngleOfWall.start, insideAngleOfWall.end
-                            );
-                            if (lineIsCastIntoNoWalkZone) {
-                                // Skip, this optimization is invalid because it would cut through a polygon
-                                continue;
-                            }
-                        }
-                        if (!closestIntersection || Vec.equal(closestIntersection, p2)) {
-                            // globalThis.debugGraphics.lineStyle(1, 0xff0000, 1);
-                            // globalThis.debugGraphics.drawCircle(path.points[i].x, path.points[i].y, 4);
-                            // globalThis.debugGraphics.lineStyle(1, 0x0000ff, 1);
-                            // globalThis.debugGraphics.drawCircle(path.points[j].x, path.points[j].y, 4);
-                            path.points = removeBetweenIndexAtoB(path.points, i, j);
-                            return false
-                        }
-                    }
-                }
+            if (!closestIntersection || Vec.equal(closestIntersection, p2)) {
+              // globalThis.debugGraphics.lineStyle(1, 0xff0000, 1);
+              // globalThis.debugGraphics.drawCircle(path.points[i].x, path.points[i].y, 4);
+              // globalThis.debugGraphics.lineStyle(1, 0x0000ff, 1);
+              // globalThis.debugGraphics.drawCircle(path.points[j].x, path.points[j].y, 4);
+              path.points = removeBetweenIndexAtoB(path.points, i, j);
+              return false
             }
-            return true;
+          }
         }
-        // Run optimization twice
-        tryOptimizePath(shortestPath);
-        tryOptimizePath(shortestPath);
-        // let fullyOptimized = false;
-        // do {
-        //     fullyOptimized = tryOptimizePath(shortestPath);
-        // } while (!fullyOptimized);
+      }
+      return true;
     }
+    // Run optimization twice
+    tryOptimizePath(shortestPath);
+    tryOptimizePath(shortestPath);
+    // let fullyOptimized = false;
+    // do {
+    //     fullyOptimized = tryOptimizePath(shortestPath);
+    // } while (!fullyOptimized);
+  }
 
-    if (shortestPath) {
-        // Remove the start point, since the unit doing the pathing is already at the start point:
-        shortestPath.points.shift();
-    }
-    // Prevent returning a path that consists of the same 2 points
-    // If there is no shortestPath and the firstIntersection is the same
-    // as the startPoint then there is no path
-    if (!shortestPath && firstIntersection && Vec.equal(startPoint, firstIntersection)) {
-        return [];
-    }
-    return shortestPath
-        ? [...shortestPath.points, shortestPath.target]
-        // If no path is found, move to the first intersection which will always be a valid path.
-        : firstIntersection ? [firstIntersection] : [];
+  if (shortestPath) {
+    // Remove the start point, since the unit doing the pathing is already at the start point:
+    shortestPath.points.shift();
+  }
+  // Prevent returning a path that consists of the same 2 points
+  // If there is no shortestPath and the firstIntersection is the same
+  // as the startPoint then there is no path
+  if (!shortestPath && firstIntersection && Vec.equal(startPoint, firstIntersection)) {
+    return [];
+  }
+  return shortestPath
+    ? [...shortestPath.points, shortestPath.target]
+    // If no path is found, move to the first intersection which will always be a valid path.
+    : firstIntersection ? [firstIntersection] : [];
 }
 // Note: Mutates Path
 function addWalkAroundPolyInfoToPath(path: Path, direction: 'prev' | 'next', startVertex: Vec2, poly: Polygon2) {
-    // Walk all the way around a poly in "direction" (clockwise/next or counterclockwise/prev) until you have 
-    // a straight line path to the target, or until the straight line path
-    // to the target intersects another Polygon2LineSegment
-    // --
-    // Note: walkAroundAPoly adds "target" to the end of the path when it is finished
-    // --
-    // Now keep iterative in the "direction" until we have a path that doesn't intersect with this polygon
-    // and heads right for the target or intersects with another polygon:
-    const _verticies = getPointsFromPolygonStartingAt(poly, startVertex);
-    // If the direction is 'prev', walk in the opposite direction
-    const verticies = direction == 'prev' ? _verticies.reverse() : _verticies;
-    path.walkAroundPolyInfo = {
-        verticies,
-        poly
-    }
+  // Walk all the way around a poly in "direction" (clockwise/next or counterclockwise/prev) until you have 
+  // a straight line path to the target, or until the straight line path
+  // to the target intersects another Polygon2LineSegment
+  // --
+  // Note: walkAroundAPoly adds "target" to the end of the path when it is finished
+  // --
+  // Now keep iterative in the "direction" until we have a path that doesn't intersect with this polygon
+  // and heads right for the target or intersects with another polygon:
+  const _verticies = getPointsFromPolygonStartingAt(poly, startVertex);
+  // If the direction is 'prev', walk in the opposite direction
+  const verticies = direction == 'prev' ? _verticies.reverse() : _verticies;
+  path.walkAroundPolyInfo = {
+    verticies,
+    poly
+  }
 
 }
 function walkAroundAPoly(path: Path, pathingWalls: Polygon2LineSegment[]) {
-    if (!path.walkAroundPolyInfo) {
-        // Cannot walk if there is no walk info
-        return;
-    }
-    const vertex = path.walkAroundPolyInfo.verticies.shift();
-    if (!vertex) {
-        // No verticies left to be processed
-        return;
-    }
-    // If the target point is on the line between the last point and this point, we've found the path and can exit.
-    // This occurs if the target point lies directly on an edge of the current polygon
-    const endPoint = path.points[path.points.length - 1]
-    if (endPoint && isPointOnLineSegment(path.target, { p1: endPoint, p2: vertex })) {
-        path.complete = true;
-        path.done = true
-        return;
-    }
+  if (!path.walkAroundPolyInfo) {
+    // Cannot walk if there is no walk info
+    return;
+  }
+  const vertex = path.walkAroundPolyInfo.verticies.shift();
+  if (!vertex) {
+    // No verticies left to be processed
+    return;
+  }
+  // If the target point is on the line between the last point and this point, we've found the path and can exit.
+  // This occurs if the target point lies directly on an edge of the current polygon
+  const endPoint = path.points[path.points.length - 1]
+  if (endPoint && isPointOnLineSegment(path.target, { p1: endPoint, p2: vertex })) {
+    path.complete = true;
+    path.done = true
+    return;
+  }
 
-    path.points.push(vertex);
-    // Check if a straight line between the new vertex and the target passes through the current polygon
-    const indexOfVertex = path.walkAroundPolyInfo.poly.findIndex(p => Vec.equal(p, vertex));
-    // true if line to target doesn't pass through own polygon
-    let lineToTargetDoesNotPassThroughOwnPolygon = false;
-    if (indexOfVertex >= 0) {
-        lineToTargetDoesNotPassThroughOwnPolygon = doesLineFromPointToTargetProjectAwayFromOwnPolygon(path.walkAroundPolyInfo.poly, indexOfVertex, path.target);
-    }
-    // if !lineToTargetDoesNotPassThroughOwnPolygon then
-    // line cast to target DOES pass through the inside of this vertex's angle so it is invalid to branch.
-    // Thus, keep walking around the polygon
-    // Continue to check the next or previous (depending on direction) vertex for this poly
-    // we need to keep walking around it to continue the path
+  path.points.push(vertex);
+  // Check if a straight line between the new vertex and the target passes through the current polygon
+  const indexOfVertex = path.walkAroundPolyInfo.poly.findIndex(p => Vec.equal(p, vertex));
+  // true if line to target doesn't pass through own polygon
+  let lineToTargetDoesNotPassThroughOwnPolygon = false;
+  if (indexOfVertex >= 0) {
+    lineToTargetDoesNotPassThroughOwnPolygon = doesLineFromPointToTargetProjectAwayFromOwnPolygon(path.walkAroundPolyInfo.poly, indexOfVertex, path.target);
+  }
+  // if !lineToTargetDoesNotPassThroughOwnPolygon then
+  // line cast to target DOES pass through the inside of this vertex's angle so it is invalid to branch.
+  // Thus, keep walking around the polygon
+  // Continue to check the next or previous (depending on direction) vertex for this poly
+  // we need to keep walking around it to continue the path
 
-    // otherwise, line from vertex to the target is not cast through the inside angle of vertex and thus it MAY
-    // be valid to jump of the poly / branch
-    if (lineToTargetDoesNotPassThroughOwnPolygon) {
-        // Check if a straight line between the new vertex and the target collides with any walls
-        const { intersectingWall, closestIntersection } = getClosestIntersectionWithWalls({ p1: vertex, p2: path.target }, pathingWalls);
-        // If it does
-        if (intersectingWall && closestIntersection) {
-            // and the wall belongs to the current poly
-            if (doesVertexBelongToPolygon(vertex, intersectingWall.polygon) && doesVertexBelongToPolygon(intersectingWall.p1, intersectingWall.polygon)) {
-                // A straight line from vertex to target intersects the same polygon again but is probably closer,
-                // so we'll branch off the new intersection point
+  // otherwise, line from vertex to the target is not cast through the inside angle of vertex and thus it MAY
+  // be valid to jump of the poly / branch
+  if (lineToTargetDoesNotPassThroughOwnPolygon) {
+    // Check if a straight line between the new vertex and the target collides with any walls
+    const { intersectingWall, closestIntersection } = getClosestIntersectionWithWalls({ p1: vertex, p2: path.target }, pathingWalls);
+    // If it does
+    if (intersectingWall && closestIntersection) {
+      // and the wall belongs to the current poly
+      if (doesVertexBelongToPolygon(vertex, intersectingWall.polygon) && doesVertexBelongToPolygon(intersectingWall.p1, intersectingWall.polygon)) {
+        // A straight line from vertex to target intersects the same polygon again but is probably closer,
+        // so we'll branch off the new intersection point
 
-                // Exception: Don't branch off if it's branching into a polygonlinesegment that THIS path already contains
-                if (path.points.find(p => p == intersectingWall.p1) && path.points.find(p => p == intersectingWall.p2)) {
-                    // Continue walking polygon
-                } else {
-                    // Allowing jumping to intersecting wall
-                    // so, clear walking info so it will stop walking and jump
-                    path.walkAroundPolyInfo = undefined;
-                }
-            } else {
-                // If it belongs to a different poly, then we can stop walking because
-                // we've walked the path as far around the current poly as we need to in order
-                // to continue pathing towards the target by walking a different poly
-                // so, clear walking info so it will stop walking and jump
-                path.walkAroundPolyInfo = undefined;
-            }
+        // Exception: Don't branch off if it's branching into a polygonlinesegment that THIS path already contains
+        if (path.points.find(p => p == intersectingWall.p1) && path.points.find(p => p == intersectingWall.p2)) {
+          // Continue walking polygon
         } else {
-            // Stop if there is no intersecting wall, the path is complete because it has reached the poly
-            // so, clear walking info because it is done
-            path.walkAroundPolyInfo = undefined;
-            path.complete = true;
-            path.done = true;
+          // Allowing jumping to intersecting wall
+          // so, clear walking info so it will stop walking and jump
+          path.walkAroundPolyInfo = undefined;
         }
+      } else {
+        // If it belongs to a different poly, then we can stop walking because
+        // we've walked the path as far around the current poly as we need to in order
+        // to continue pathing towards the target by walking a different poly
+        // so, clear walking info so it will stop walking and jump
+        path.walkAroundPolyInfo = undefined;
+      }
+    } else {
+      // Stop if there is no intersecting wall, the path is complete because it has reached the poly
+      // so, clear walking info because it is done
+      path.walkAroundPolyInfo = undefined;
+      path.complete = true;
+      path.done = true;
     }
+  }
 }
 // Processes each path by ensuring that there is a valid line between each of the paths points,
 // and if there is not it will add points until either the path is invalid or the path is complete
 // --
 // Note: Mutates the paths array's objects
 function processPaths(paths: Path[], pathingWalls: Polygon2LineSegment[]): Path[] {
-    // Continue to process paths that are incomplete
-    tryAllPaths:
-    for (let path of paths) {
-        // Do not continue to process paths that are complete
-        if (path.done) {
-            continue;
-        }
-        // A path must have at least 1 point (a start and path.target is the end) to be processed
-        if (path.points.length < 1) {
-            console.error("Path is too short to process");
-            path.invalid = true;
-            path.done = true;
-            continue;
-        }
-
-        // There are 2 main ways to process a path, if the path has "walkAroundPolyInfo",
-        // that means it is currently in the process of walking around a polygon's verticies,
-        // one by one, so it should be processed with walkAroundAPoly()
-        // Otherwise, it drops into the "else" below and tests the last line in the path
-        // to see if it's a valid line, if not, that means it intersected at least 1 polygonLineSegment
-        // which means the path has to branch into two paths in order to "walkAround" the polygon that
-        // it intersected with, and so it will assign walkAroundPolyInfo so that next time the path is
-        // processed it will walk around.
-        if (path.walkAroundPolyInfo) {
-            walkAroundAPoly(path, pathingWalls);
-        } else {
-            const nextStraightLine: LineSegment = getLastLineInPath(path);
-
-            // Check for collisions between the last line in the path and pathing walls
-            // path.points.length === 1 because includeStartPoint should be true if this is the very beginning of the path in case
-            // the unit is already on an edge of a polygon
-            let { intersectingWall, closestIntersection } = getClosestIntersectionWithWalls(nextStraightLine, pathingWalls, path.points.length == 1);
-            // If there is an intersection between a straight line path and a pathing wall
-            // we have to branch the path to the corners of the wall and try again
-            if (intersectingWall && closestIntersection) {
-                if (Vec.equal(closestIntersection, nextStraightLine.p2)) {
-                    // This is the "happy path", a straight line without collisions has been found to the target
-                    // and the path is complete
-
-                    // Mark the path as "done"
-                    path.done = true;
-                    path.complete = true;
-
-                } else {
-                    path.points.push(closestIntersection);
-                    // globalThis.debugGraphics.lineStyle(2, 0xff00ff, 1);
-                    // globalThis.debugGraphics.drawCircle(closestIntersection.x, closestIntersection.y, 10);
-
-                    // Prevent paths from overlapping already existing paths:
-                    // This is very important because it prevents infinitely
-                    // spawning new paths in the event that a path enters a loop where
-                    // it hits a branch that another path has already processed.
-                    checkPaths:
-                    for (let otherPath of paths) {
-                        // Don't compare a currently processing path to an invalid path
-                        if (otherPath.invalid) {
-                            continue;
-                        }
-                        // Don't check a path for overlap against itself
-                        if (otherPath !== path) {
-                            for (let i = 0; i < otherPath.points.length; i++) {
-                                const point = otherPath.points[i];
-                                // If the closestIntersection is the same as a point from another path
-                                // invalidate the longer path, since whichever path is shorter is
-                                // a quicker route to that point
-                                if (point && Vec.equal(closestIntersection, point)) {
-                                    const lengthOfCurrentPathToThisVertex = calculateDistanceOfVec2Array([...path.points, closestIntersection]);
-                                    const lengthOfOtherPathToThisVertex = calculateDistanceOfVec2Array(otherPath.points.slice(0, i + 1));
-                                    if (lengthOfCurrentPathToThisVertex < lengthOfOtherPathToThisVertex) {
-                                        // Stop the other path, it is invalid since the current path
-                                        // has a shorter route to this intersection
-                                        // Note: This might be a misuse of invalid since the path technically isn't
-                                        // invalid, but I will allow it since we want to exclude this path
-                                        // because the shorter path will certainly be a better route
-                                        otherPath.invalid = true;
-                                        otherPath.done = true;
-                                        continue checkPaths;
-
-                                    } else {
-                                        // Stop the current path, it is invalid since the other path has
-                                        // a shorter route to this vertex
-
-                                        // Draw where path stopped
-                                        // globalThis.debugGraphics.lineStyle(1, 0x00ffff, 1);
-                                        // globalThis.debugGraphics.drawCircle(vertex.x, vertex.y, 10);
-
-                                        path.invalid = true;
-                                        path.done = true;
-                                        // Since the current path is found to be invalid, don't
-                                        // let it branch into new paths
-                                        continue tryAllPaths;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    let { next } = polygonLineSegmentToPrevAndNext(intersectingWall);
-
-                    // Branch the path.  The original path will try navigating around p1
-                    // and the branchedPath will try navigating around p2.
-                    // Note: branchedPath must be cloned before path's p2 is modified
-                    const branchedPath = { ...path, points: path.points.map(p => Vec.clone(p)) };
-                    paths.push(branchedPath);
-
-                    const nextWalkPoint = next;
-
-
-                    // Starting from the "prev" corner, walk around the poly until you can make a 
-                    // straight line to the target that doesn't intersect with this same poly
-                    // Note: It is INTENTIONAL that "next" is passed into this function because the ordered verticies
-                    // will be reversed when 'prev' is the direction
-                    addWalkAroundPolyInfoToPath(path, 'prev', nextWalkPoint, intersectingWall.polygon);
-                    // Starting from the "next" corner, walk around the poly until you can make a 
-                    // straight line to the target that doesn't intersect with this same poly
-                    addWalkAroundPolyInfoToPath(branchedPath, 'next', nextWalkPoint, intersectingWall.polygon);
-                }
-
-            } else {
-                // If no intersections were found then we have a path to the target, so stop processing this path.
-                // This is the "happy path", a straight line without collisions has been found to the target
-                // and the path is complete
-
-                // Mark the path as "done"
-                path.done = true;
-                path.complete = true;
-            }
-        }
+  // Continue to process paths that are incomplete
+  tryAllPaths:
+  for (let path of paths) {
+    // Do not continue to process paths that are complete
+    if (path.done) {
+      continue;
+    }
+    // A path must have at least 1 point (a start and path.target is the end) to be processed
+    if (path.points.length < 1) {
+      console.error("Path is too short to process");
+      path.invalid = true;
+      path.done = true;
+      continue;
     }
 
-    return paths
+    // There are 2 main ways to process a path, if the path has "walkAroundPolyInfo",
+    // that means it is currently in the process of walking around a polygon's verticies,
+    // one by one, so it should be processed with walkAroundAPoly()
+    // Otherwise, it drops into the "else" below and tests the last line in the path
+    // to see if it's a valid line, if not, that means it intersected at least 1 polygonLineSegment
+    // which means the path has to branch into two paths in order to "walkAround" the polygon that
+    // it intersected with, and so it will assign walkAroundPolyInfo so that next time the path is
+    // processed it will walk around.
+    if (path.walkAroundPolyInfo) {
+      walkAroundAPoly(path, pathingWalls);
+    } else {
+      const nextStraightLine: LineSegment = getLastLineInPath(path);
+
+      // Check for collisions between the last line in the path and pathing walls
+      // path.points.length === 1 because includeStartPoint should be true if this is the very beginning of the path in case
+      // the unit is already on an edge of a polygon
+      let { intersectingWall, closestIntersection } = getClosestIntersectionWithWalls(nextStraightLine, pathingWalls, path.points.length == 1);
+      // If there is an intersection between a straight line path and a pathing wall
+      // we have to branch the path to the corners of the wall and try again
+      if (intersectingWall && closestIntersection) {
+        if (Vec.equal(closestIntersection, nextStraightLine.p2)) {
+          // This is the "happy path", a straight line without collisions has been found to the target
+          // and the path is complete
+
+          // Mark the path as "done"
+          path.done = true;
+          path.complete = true;
+
+        } else {
+          path.points.push(closestIntersection);
+          // globalThis.debugGraphics.lineStyle(2, 0xff00ff, 1);
+          // globalThis.debugGraphics.drawCircle(closestIntersection.x, closestIntersection.y, 10);
+
+          // Prevent paths from overlapping already existing paths:
+          // This is very important because it prevents infinitely
+          // spawning new paths in the event that a path enters a loop where
+          // it hits a branch that another path has already processed.
+          checkPaths:
+          for (let otherPath of paths) {
+            // Don't compare a currently processing path to an invalid path
+            if (otherPath.invalid) {
+              continue;
+            }
+            // Don't check a path for overlap against itself
+            if (otherPath !== path) {
+              for (let i = 0; i < otherPath.points.length; i++) {
+                const point = otherPath.points[i];
+                // If the closestIntersection is the same as a point from another path
+                // invalidate the longer path, since whichever path is shorter is
+                // a quicker route to that point
+                if (point && Vec.equal(closestIntersection, point)) {
+                  const lengthOfCurrentPathToThisVertex = calculateDistanceOfVec2Array([...path.points, closestIntersection]);
+                  const lengthOfOtherPathToThisVertex = calculateDistanceOfVec2Array(otherPath.points.slice(0, i + 1));
+                  if (lengthOfCurrentPathToThisVertex < lengthOfOtherPathToThisVertex) {
+                    // Stop the other path, it is invalid since the current path
+                    // has a shorter route to this intersection
+                    // Note: This might be a misuse of invalid since the path technically isn't
+                    // invalid, but I will allow it since we want to exclude this path
+                    // because the shorter path will certainly be a better route
+                    otherPath.invalid = true;
+                    otherPath.done = true;
+                    continue checkPaths;
+
+                  } else {
+                    // Stop the current path, it is invalid since the other path has
+                    // a shorter route to this vertex
+
+                    // Draw where path stopped
+                    // globalThis.debugGraphics.lineStyle(1, 0x00ffff, 1);
+                    // globalThis.debugGraphics.drawCircle(vertex.x, vertex.y, 10);
+
+                    path.invalid = true;
+                    path.done = true;
+                    // Since the current path is found to be invalid, don't
+                    // let it branch into new paths
+                    continue tryAllPaths;
+                  }
+                }
+              }
+            }
+          }
+
+          let { next } = polygonLineSegmentToPrevAndNext(intersectingWall);
+
+          // Branch the path.  The original path will try navigating around p1
+          // and the branchedPath will try navigating around p2.
+          // Note: branchedPath must be cloned before path's p2 is modified
+          const branchedPath = { ...path, points: path.points.map(p => Vec.clone(p)) };
+          paths.push(branchedPath);
+
+          const nextWalkPoint = next;
+
+
+          // Starting from the "prev" corner, walk around the poly until you can make a 
+          // straight line to the target that doesn't intersect with this same poly
+          // Note: It is INTENTIONAL that "next" is passed into this function because the ordered verticies
+          // will be reversed when 'prev' is the direction
+          addWalkAroundPolyInfoToPath(path, 'prev', nextWalkPoint, intersectingWall.polygon);
+          // Starting from the "next" corner, walk around the poly until you can make a 
+          // straight line to the target that doesn't intersect with this same poly
+          addWalkAroundPolyInfoToPath(branchedPath, 'next', nextWalkPoint, intersectingWall.polygon);
+        }
+
+      } else {
+        // If no intersections were found then we have a path to the target, so stop processing this path.
+        // This is the "happy path", a straight line without collisions has been found to the target
+        // and the path is complete
+
+        // Mark the path as "done"
+        path.done = true;
+        path.complete = true;
+      }
+    }
+  }
+
+  return paths
 }
 export function removeBetweenIndexAtoB(array: any[], indexA: number, indexB: number): any[] {
-    // indexA must be < indexB, if invalid args are passed in, return the values of the array
-    if (indexA >= indexB) {
-        return [...array];
-    }
-    return [...array.slice(0, indexA + 1), ...array.slice(indexB)]
+  // indexA must be < indexB, if invalid args are passed in, return the values of the array
+  if (indexA >= indexB) {
+    return [...array];
+  }
+  return [...array.slice(0, indexA + 1), ...array.slice(indexB)]
 }
 function calculateDistanceOfPaths(paths: Path[]) {
-    // Calculate the distance for all paths
-    for (let path of paths) {
-        path.distance = calculateDistanceOfVec2Array([...path.points, path.target]);
-    }
+  // Calculate the distance for all paths
+  for (let path of paths) {
+    path.distance = calculateDistanceOfVec2Array([...path.points, path.target]);
+  }
 }
 export function calculateDistanceOfVec2Array(points: Vec2[]): number {
-    if (!points[0]) {
-        return 0;
+  if (!points[0]) {
+    return 0;
+  }
+  let totalDistance = 0;
+  let lastPoint = points[0];
+  // Finally, calculate the distance for the path 
+  for (let point of points) {
+    // Optimization: Don't calculate the distance between the first point and itself
+    if (point == lastPoint) {
+      continue;
     }
-    let totalDistance = 0;
-    let lastPoint = points[0];
-    // Finally, calculate the distance for the path 
-    for (let point of points) {
-        // Optimization: Don't calculate the distance between the first point and itself
-        if (point == lastPoint) {
-            continue;
-        }
-        // Sum the distances
-        totalDistance += distance(point, lastPoint);
-        lastPoint = point;
-    }
-    return totalDistance;
+    // Sum the distances
+    totalDistance += distance(point, lastPoint);
+    lastPoint = point;
+  }
+  return totalDistance;
 }
 function polygonLineSegmentToPrevAndNext(wall: Polygon2LineSegment): { prev: Vec2, next: Vec2 } {
-    return { prev: wall.p1, next: wall.p2 };
+  return { prev: wall.p1, next: wall.p2 };
 }
 function getLastLineInPath(path: Path): LineSegment {
-    const lastPoint = path.points[path.points.length - 1]
-    if (lastPoint) {
-        return { p1: lastPoint, p2: path.target };
-    } else {
-        console.error("Path contains no points");
-        return { p1: path.target, p2: path.target };
-    }
+  const lastPoint = path.points[path.points.length - 1]
+  if (lastPoint) {
+    return { p1: lastPoint, p2: path.target };
+  } else {
+    console.error("Path contains no points");
+    return { p1: path.target, p2: path.target };
+  }
 
 }
 // Given an array of Polygon2LineSegment[], of all the intersections between line and the walls,
@@ -514,92 +514,92 @@ function getLastLineInPath(path: Path): LineSegment {
 // don't allow for collisions with line.p1, they will path right through the poly that
 // they are already on the edge of.
 function getClosestIntersectionWithWalls(line: LineSegment, walls: Polygon2LineSegment[], includeStartPoint: boolean = false): { intersectingWall?: Polygon2LineSegment, closestIntersection?: Vec2 } {
-    let intersectingWall;
-    let closestIntersection;
-    let closestIntersectionDistance;
-    // Check for collisions between the last line in the path and pathing walls
-    for (let wall of walls) {
-        const intersection = lineSegmentIntersection(line, wall);
-        if (intersection) {
-            // If the intersection is at the start point of the line...
-            if (Vec.equal(line.p1, intersection)) {
-                if (!includeStartPoint) {
-                    // Since this intersection is at the start point and includeStartPoint is false
-                    // do not include this intersection
-                    continue;
-                } else {
-                    // If the line is cast towards the walkable side from the 
-                    // polygon, allow it.  Whereas if the line is cast toward the non-walkable
-                    // portion of the poly (for normal polys, the inside; for inverted polys, the outside),
-                    // it will be considered as an intersection and returned if it is the closest intersection
-                    const insideAngleOfWall = getInsideAnglesOfWall(wall);
-                    const lineIsCastIntoNoWalkZone = isAngleBetweenAngles(
-                        Vec.getAngleBetweenVec2s(line.p1, line.p2), insideAngleOfWall.start, insideAngleOfWall.end
-                    );
-                    if (!lineIsCastIntoNoWalkZone) {
-                        // Ignore the collision
-                        continue
-                    }
-                }
-            }
-            const dist = distance(line.p1, intersection);
-            // If there is no closest intersection, make this intersection the closest intersection
-            // If there is and this intersection is closer, make it the closest
-            if (!closestIntersection || (closestIntersection && closestIntersectionDistance && closestIntersectionDistance > dist)) {
-                closestIntersection = intersection;
-                closestIntersectionDistance = dist;
-                intersectingWall = wall
-            }
-
+  let intersectingWall;
+  let closestIntersection;
+  let closestIntersectionSqrDistance;
+  // Check for collisions between the last line in the path and pathing walls
+  for (let wall of walls) {
+    const intersection = lineSegmentIntersection(line, wall);
+    if (intersection) {
+      // If the intersection is at the start point of the line...
+      if (Vec.equal(line.p1, intersection)) {
+        if (!includeStartPoint) {
+          // Since this intersection is at the start point and includeStartPoint is false
+          // do not include this intersection
+          continue;
+        } else {
+          // If the line is cast towards the walkable side from the 
+          // polygon, allow it.  Whereas if the line is cast toward the non-walkable
+          // portion of the poly (for normal polys, the inside; for inverted polys, the outside),
+          // it will be considered as an intersection and returned if it is the closest intersection
+          const insideAngleOfWall = getInsideAnglesOfWall(wall);
+          const lineIsCastIntoNoWalkZone = isAngleBetweenAngles(
+            Vec.getAngleBetweenVec2s(line.p1, line.p2), insideAngleOfWall.start, insideAngleOfWall.end
+          );
+          if (!lineIsCastIntoNoWalkZone) {
+            // Ignore the collision
+            continue
+          }
         }
+      }
+      const sqrDist = math.sqrDistance(line.p1, intersection);
+      // If there is no closest intersection, make this intersection the closest intersection
+      // If there is and this intersection is closer, make it the closest
+      if (!closestIntersection || (closestIntersection && closestIntersectionSqrDistance && closestIntersectionSqrDistance > sqrDist)) {
+        closestIntersection = intersection;
+        closestIntersectionSqrDistance = sqrDist;
+        intersectingWall = wall
+      }
+
     }
-    return { intersectingWall, closestIntersection };
+  }
+  return { intersectingWall, closestIntersection };
 }
 
 // If you walked a path dropping a marker every X distance travelled, this function
 // returns the locations of the marker.
 export function pointsEveryXDistanceAlongPath(startPoint: Vec2, path: Vec2[], distanceOfIncrements: number, alreadyUsedDistance: number = 0): Vec2[] {
-    // 0. if "distance" > remaining distance to next point, set next distance to "distance" - remaining distance and go next point
-    // 1. else move "distance" along a line and place a marker
+  // 0. if "distance" > remaining distance to next point, set next distance to "distance" - remaining distance and go next point
+  // 1. else move "distance" along a line and place a marker
 
-    // Rules:
-    // Always project new points from the last point in the path
-    // If the distance to a point is < the remaining distance to go for the next point, subtrace from the remaining distance to go and continue
+  // Rules:
+  // Always project new points from the last point in the path
+  // If the distance to a point is < the remaining distance to go for the next point, subtrace from the remaining distance to go and continue
 
-    // 3 possibilities:
-    // 1. Finish right on a point
-    // 2. new point before a point with some left over
-    // 3. new point after a point with some left over, 3 turns into 1 or 2
-    const points: Vec2[] = [];
-    let lastPoint = startPoint;
-    let nextDistance = distanceOfIncrements - alreadyUsedDistance;
-    for (let point of path) {
-        const distanceToPoint = math.distance(lastPoint, point);
+  // 3 possibilities:
+  // 1. Finish right on a point
+  // 2. new point before a point with some left over
+  // 3. new point after a point with some left over, 3 turns into 1 or 2
+  const points: Vec2[] = [];
+  let lastPoint = startPoint;
+  let nextDistance = distanceOfIncrements - alreadyUsedDistance;
+  for (let point of path) {
+    const distanceToPoint = math.distance(lastPoint, point);
+    if (nextDistance > distanceToPoint) {
+      nextDistance -= distanceToPoint;
+    } else {
+      let newPoint: Vec2 = lastPoint;
+      // Always place at least one point.  In the event that nextDistance is < distanceOfIncrements AND
+      // less that distanceToPoint, it still needs a point, so make the for loop execute at least once
+      const numberOfPointsOnThisLine = Math.ceil(distanceToPoint / distanceOfIncrements);
+      for (let i = 0; i < numberOfPointsOnThisLine; i++) {
         if (nextDistance > distanceToPoint) {
-            nextDistance -= distanceToPoint;
-        } else {
-            let newPoint: Vec2 = lastPoint;
-            // Always place at least one point.  In the event that nextDistance is < distanceOfIncrements AND
-            // less that distanceToPoint, it still needs a point, so make the for loop execute at least once
-            const numberOfPointsOnThisLine = Math.ceil(distanceToPoint / distanceOfIncrements);
-            for (let i = 0; i < numberOfPointsOnThisLine; i++) {
-                if (nextDistance > distanceToPoint) {
-                    break;
-                }
-                newPoint = math.getCoordsAtDistanceTowardsTarget(
-                    lastPoint,
-                    point,
-                    nextDistance
-                )
-                points.push(newPoint);
-                nextDistance += distanceOfIncrements;
-            }
-            const leftOver = Math.abs(distance(point, newPoint));
-            nextDistance = distanceOfIncrements - leftOver;
+          break;
         }
-        // Always update the lastPoint with the point that was just processed,
-        // becauses this is where we will project from to find intermediate points
-        lastPoint = point;
+        newPoint = math.getCoordsAtDistanceTowardsTarget(
+          lastPoint,
+          point,
+          nextDistance
+        )
+        points.push(newPoint);
+        nextDistance += distanceOfIncrements;
+      }
+      const leftOver = distance(point, newPoint);
+      nextDistance = distanceOfIncrements - leftOver;
     }
-    return points
+    // Always update the lastPoint with the point that was just processed,
+    // becauses this is where we will project from to find intermediate points
+    lastPoint = point;
+  }
+  return points
 }

--- a/src/jmath/Polygon2.ts
+++ b/src/jmath/Polygon2.ts
@@ -1,54 +1,54 @@
 import * as LineSegment from "./lineSegment";
 import { Vec2 } from "./Vec";
 import * as Vec from "./Vec";
-import { distance } from "./math";
+import { distance, sqrDistance } from "./math";
 import { clockwiseAngle, isAngleBetweenAngles } from "./Angle";
 
 // Allows accessing an array without going out of bounds.  So getBoundedIndex(array.length+1)
 // will be index of 1 instead of beyond the limit of the array
 export function getLoopableIndex(index: number, array: any[]) {
-    let adjusted = index % array.length;
-    if (adjusted < 0) {
-        adjusted = array.length + adjusted;
-    }
-    return adjusted;
+  let adjusted = index % array.length;
+  if (adjusted < 0) {
+    adjusted = array.length + adjusted;
+  }
+  return adjusted;
 }
 export function getPointNormalVector(point: Vec2, prevPoint: Vec2, nextPoint: Vec2): Vec2 {
-    // Find a point along the normal:
-    let projectToPoint = { x: 0, y: 0 };
-    const dxPrev = point.x - prevPoint.x;
-    const dyPrev = point.y - prevPoint.y;
-    projectToPoint.x += dxPrev;
-    projectToPoint.y += dyPrev;
-    const dxNext = point.x - nextPoint.x;
-    const dyNext = point.y - nextPoint.y;
-    projectToPoint.x += dxNext;
-    projectToPoint.y += dyNext;
-    // Now this is tricky, since polygons are expressed in points from prev to point to next,
-    // the normal vector of a point depends on the "direction" of traversal from prev to point to next.
-    // So if the 2 lines from prev to point and from point to next make an obtuse angle, we project
-    // the normal to the outside (in the direction of the obtuse angle), but if they make an acute angle
-    // the normal point will be inside the acute angle.  The orientation of the prev point and the next point
-    // relative to the main point is what determines wether the outside angle is the obtuse or the actue angle.
-    const outsideAngle = getOutsideAngleOfPoint(prevPoint, point, nextPoint);
-    if (outsideAngle <= Math.PI / 2) {
-        // Invert
-        projectToPoint = Vec.multiply(-1, projectToPoint);
-    }
+  // Find a point along the normal:
+  let projectToPoint = { x: 0, y: 0 };
+  const dxPrev = point.x - prevPoint.x;
+  const dyPrev = point.y - prevPoint.y;
+  projectToPoint.x += dxPrev;
+  projectToPoint.y += dyPrev;
+  const dxNext = point.x - nextPoint.x;
+  const dyNext = point.y - nextPoint.y;
+  projectToPoint.x += dxNext;
+  projectToPoint.y += dyNext;
+  // Now this is tricky, since polygons are expressed in points from prev to point to next,
+  // the normal vector of a point depends on the "direction" of traversal from prev to point to next.
+  // So if the 2 lines from prev to point and from point to next make an obtuse angle, we project
+  // the normal to the outside (in the direction of the obtuse angle), but if they make an acute angle
+  // the normal point will be inside the acute angle.  The orientation of the prev point and the next point
+  // relative to the main point is what determines wether the outside angle is the obtuse or the actue angle.
+  const outsideAngle = getOutsideAngleOfPoint(prevPoint, point, nextPoint);
+  if (outsideAngle <= Math.PI / 2) {
+    // Invert
+    projectToPoint = Vec.multiply(-1, projectToPoint);
+  }
 
-    // Normalize projectToPoint so it only carries the + or -
-    if (projectToPoint.x !== 0) {
-        projectToPoint.x /= Math.abs(projectToPoint.x);
-    }
-    if (projectToPoint.y !== 0) {
-        projectToPoint.y /= Math.abs(projectToPoint.y);
-    }
-    return projectToPoint;
+  // Normalize projectToPoint so it only carries the + or -
+  if (projectToPoint.x !== 0) {
+    projectToPoint.x /= Math.abs(projectToPoint.x);
+  }
+  if (projectToPoint.y !== 0) {
+    projectToPoint.y /= Math.abs(projectToPoint.y);
+  }
+  return projectToPoint;
 }
 function getOutsideAngleOfPoint(prevPoint: Vec2, point: Vec2, nextPoint: Vec2): number {
-    const angleToPrevPoint = Vec.getAngleBetweenVec2s(point, prevPoint);
-    const angleToNextPoint = Vec.getAngleBetweenVec2s(point, nextPoint);
-    return clockwiseAngle(angleToPrevPoint, angleToNextPoint);
+  const angleToPrevPoint = Vec.getAngleBetweenVec2s(point, prevPoint);
+  const angleToNextPoint = Vec.getAngleBetweenVec2s(point, nextPoint);
+  return clockwiseAngle(angleToPrevPoint, angleToNextPoint);
 
 }
 // A line segment that contains a reference to the polygon that it belongs to
@@ -59,95 +59,95 @@ export type Polygon2LineSegment = LineSegment.LineSegment &
 // A Polygon2 is just an array of points where the last point connects to the first point to form a closed shape
 export type Polygon2 = Vec2[];
 export function mergeCollinearOverlappingSameDirectionLines(lines: LineSegment.LineSegment[]): LineSegment.LineSegment[] {
-    const newLines = [];
-    for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i];
-        if (line) {
-            const linesForMerging = lines.filter(l => {
-                const relation = LineSegment.getRelation(line, l);
-                return relation.isCollinear && relation.isOverlapping && relation.pointInSameDirection;
-            });
-            let newLine = linesForMerging[0];
-            if (newLine) {
-                for (let mergeLine of linesForMerging) {
-                    if (mergeLine == newLine) {
-                        //skip self
-                        continue;
-                    }
-                    if (distance(mergeLine.p1, newLine.p2) > distance(newLine.p1, newLine.p2)) {
-                        newLine.p1 = mergeLine.p1;
-                    }
-                    if (distance(newLine.p1, mergeLine.p2) > distance(newLine.p1, newLine.p2)) {
-                        newLine.p2 = mergeLine.p2;
-                    }
-                }
-            }
-            // Remove lines once they have been used
-            for (let removeWall of linesForMerging) {
-                lines.splice(lines.indexOf(removeWall), 1);
-            }
-            if (newLine) {
-                if (linesForMerging.length == 1 && newLine == line) {
-                    // unshift so that lines maintain their original order if not modified since
-                    // the forloop iterates it backwards
-                    newLines.unshift(newLine);
-                } else {
-                    // Add newLine back into lines array so it can be processed again until it doesn't have any lines left to merge with.
-                    lines.push(newLine);
-                }
-            }
-            i = lines.length;
+  const newLines = [];
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (line) {
+      const linesForMerging = lines.filter(l => {
+        const relation = LineSegment.getRelation(line, l);
+        return relation.isCollinear && relation.isOverlapping && relation.pointInSameDirection;
+      });
+      let newLine = linesForMerging[0];
+      if (newLine) {
+        for (let mergeLine of linesForMerging) {
+          if (mergeLine == newLine) {
+            //skip self
+            continue;
+          }
+          if (sqrDistance(mergeLine.p1, newLine.p2) > sqrDistance(newLine.p1, newLine.p2)) {
+            newLine.p1 = mergeLine.p1;
+          }
+          if (sqrDistance(newLine.p1, mergeLine.p2) > sqrDistance(newLine.p1, newLine.p2)) {
+            newLine.p2 = mergeLine.p2;
+          }
         }
+      }
+      // Remove lines once they have been used
+      for (let removeWall of linesForMerging) {
+        lines.splice(lines.indexOf(removeWall), 1);
+      }
+      if (newLine) {
+        if (linesForMerging.length == 1 && newLine == line) {
+          // unshift so that lines maintain their original order if not modified since
+          // the forloop iterates it backwards
+          newLines.unshift(newLine);
+        } else {
+          // Add newLine back into lines array so it can be processed again until it doesn't have any lines left to merge with.
+          lines.push(newLine);
+        }
+      }
+      i = lines.length;
     }
-    return newLines;
+  }
+  return newLines;
 
 }
 export function splitIntersectingLineSegments(line: LineSegment.LineSegment, lineSegments: LineSegment.LineSegment[]): LineSegment.LineSegment[] {
-    let splitLineSegments: LineSegment.LineSegment[] = []
-    let intersections: Vec2[] = [];
-    for (let other of lineSegments) {
-        if (line == other) {
-            // Don't test against self
-            continue;
-        }
-        const { isCollinear } = LineSegment.getRelation(line, other);
-        // Ignore collinear lines since even if they are overlapping
-        // they would have infinite intersections and can't be meaningfully
-        // split
-        if (isCollinear) {
-            continue;
-        }
-        const intersection = LineSegment.lineSegmentIntersection(line, other);
-        if (intersection) {
-            // Ignore intersections at vertex, these should not be "split" because
-            // if it were it would split into a "no length" line (a point).
-            if (!Vec.equal(intersection, line.p1) && !Vec.equal(intersection, line.p2)) {
-                // Don't add duplicate intersection points
-                if (intersections.findIndex(i => Vec.equal(i, intersection)) == -1) {
-                    intersections.push(intersection)
-                }
-            }
-        }
+  let splitLineSegments: LineSegment.LineSegment[] = []
+  let intersections: Vec2[] = [];
+  for (let other of lineSegments) {
+    if (line == other) {
+      // Don't test against self
+      continue;
     }
-    // Sort closest first
-    intersections.sort((a, b) => distance(line.p1, a) - distance(line.p1, b));
-    // Make new line segments
-    let lastPoint = line.p1;
-    for (let intersection of intersections) {
-        splitLineSegments.push({ p1: lastPoint, p2: intersection });
-        lastPoint = intersection;
+    const { isCollinear } = LineSegment.getRelation(line, other);
+    // Ignore collinear lines since even if they are overlapping
+    // they would have infinite intersections and can't be meaningfully
+    // split
+    if (isCollinear) {
+      continue;
     }
-    splitLineSegments.push({ p1: lastPoint, p2: line.p2 });
+    const intersection = LineSegment.lineSegmentIntersection(line, other);
+    if (intersection) {
+      // Ignore intersections at vertex, these should not be "split" because
+      // if it were it would split into a "no length" line (a point).
+      if (!Vec.equal(intersection, line.p1) && !Vec.equal(intersection, line.p2)) {
+        // Don't add duplicate intersection points
+        if (intersections.findIndex(i => Vec.equal(i, intersection)) == -1) {
+          intersections.push(intersection)
+        }
+      }
+    }
+  }
+  // Sort closest first
+  intersections.sort((a, b) => sqrDistance(line.p1, a) - sqrDistance(line.p1, b));
+  // Make new line segments
+  let lastPoint = line.p1;
+  for (let intersection of intersections) {
+    splitLineSegments.push({ p1: lastPoint, p2: intersection });
+    lastPoint = intersection;
+  }
+  splitLineSegments.push({ p1: lastPoint, p2: line.p2 });
 
-    return splitLineSegments;
+  return splitLineSegments;
 }
 export function splitIntersectingPolygon2LineSegments(lineSegments: Polygon2LineSegment[]): Polygon2LineSegment[] {
-    let splitPolygon2LineSegments: Polygon2LineSegment[] = []
-    for (let line of lineSegments) {
-        const splitLineSegments = splitIntersectingLineSegments(line, lineSegments);
-        splitPolygon2LineSegments.push(...splitLineSegments.map(ls => ({ ...ls, polygon: line.polygon })));
-    }
-    return splitPolygon2LineSegments;
+  let splitPolygon2LineSegments: Polygon2LineSegment[] = []
+  for (let line of lineSegments) {
+    const splitLineSegments = splitIntersectingLineSegments(line, lineSegments);
+    splitPolygon2LineSegments.push(...splitLineSegments.map(ls => ({ ...ls, polygon: line.polygon })));
+  }
+  return splitPolygon2LineSegments;
 }
 
 // Given an array of Polygon2s, it returns an array of Polygon2s where overlapping
@@ -155,101 +155,101 @@ export function splitIntersectingPolygon2LineSegments(lineSegments: Polygon2Line
 // Allows for "donuts": where 2 polygon2s can merge into 2 different polygon2s
 // (see tests for "donuts" demonstration).
 export function mergePolygon2s(polygons: Polygon2[]): Polygon2[] {
-    // Convert all polygons into line segments for processing:
-    let polyLineSegments = polygons.map(toPolygon2LineSegments).flat();
+  // Convert all polygons into line segments for processing:
+  let polyLineSegments = polygons.map(toPolygon2LineSegments).flat();
 
-    // Split all line segments along intersections
-    // so that there are no line segments left with intersections
-    // other than at their verticies
-    polyLineSegments = splitIntersectingPolygon2LineSegments(polyLineSegments);
+  // Split all line segments along intersections
+  // so that there are no line segments left with intersections
+  // other than at their verticies
+  polyLineSegments = splitIntersectingPolygon2LineSegments(polyLineSegments);
 
-    // resultPolys stores the merged polygons:
-    const resultPolys: Polygon2[] = [];
-    // Remove any linesegment that has it's centerpoint
-    // inside of another polygon that it is touching
-    for (let i = polyLineSegments.length - 1; i >= 0; i--) {
-        const lineSegment = polyLineSegments[i];
-        if (lineSegment) {
-            const center = LineSegment.getCenterPoint(lineSegment);
-            for (let poly of polygons) {
-                // Ignore polygon that owns the linesegment:
-                if (lineSegment.polygon == poly) {
-                    continue;
-                }
-                // Only consider polygons that the line segment touches
-                // This ensures that a rectangle can remain inside of another rectangle
-                // without being merged so long as they don't intersect (donut example)
-                if (toLineSegments(poly).filter(ls => LineSegment.isPointOnLineSegment(lineSegment.p1, ls) || LineSegment.isPointOnLineSegment(lineSegment.p2, ls)).length == 0) {
-                    continue;
-                }
-
-
-                const isInside = isVec2InsidePolygon(center, poly);
-                if (isInside) {
-                    const notDirectlyOnLine = toLineSegments(poly).every(ls => !LineSegment.isPointOnLineSegment(center, ls));
-                    // Only remove a lineSegment if it is both inside a polygon and the center point
-                    // is not directly on one of the linesegments of that polygon.
-                    // This is very important and shows it's usefulness in the 
-                    // "given boxes that are mostly identical > should keep the larger one" test where
-                    // overlapping boxes with slight differences must not be removed
-
-                    if (notDirectlyOnLine) {
-                        polyLineSegments.splice(i, 1);
-                        break;
-                    }
-                }
-
-            }
+  // resultPolys stores the merged polygons:
+  const resultPolys: Polygon2[] = [];
+  // Remove any linesegment that has it's centerpoint
+  // inside of another polygon that it is touching
+  for (let i = polyLineSegments.length - 1; i >= 0; i--) {
+    const lineSegment = polyLineSegments[i];
+    if (lineSegment) {
+      const center = LineSegment.getCenterPoint(lineSegment);
+      for (let poly of polygons) {
+        // Ignore polygon that owns the linesegment:
+        if (lineSegment.polygon == poly) {
+          continue;
         }
-    }
-    // Remove dead ends (2 lines that double back on themselves) (also known as reversals):
-    let reversals: Polygon2LineSegment[] = []
-    for (let line of polyLineSegments) {
-        reversals.push(...polyLineSegments.filter(other => Vec.equal(line.p1, other.p2) && Vec.equal(line.p2, other.p1)));
-    }
-    polyLineSegments = polyLineSegments.filter(line => !reversals.includes(line));
-    // Remove unnecessary in-between verticies:
-    const lineSegments = mergeCollinearOverlappingSameDirectionLines(polyLineSegments)
-    // Turn all remaining line segments into polygons:
-    for (let i = lineSegments.length - 1; i >= 0; i--) {
-        const lineSegment = lineSegments[i];
-        if (lineSegment) {
-            const poly = processLineSegment(lineSegment, lineSegments);
-            // Valid polygons must be 3 points or more, or else it will just be a line
-            if (poly && poly.length > 2) {
-                resultPolys.push(poly);
-            }
+        // Only consider polygons that the line segment touches
+        // This ensures that a rectangle can remain inside of another rectangle
+        // without being merged so long as they don't intersect (donut example)
+        if (toLineSegments(poly).filter(ls => LineSegment.isPointOnLineSegment(lineSegment.p1, ls) || LineSegment.isPointOnLineSegment(lineSegment.p2, ls)).length == 0) {
+          continue;
         }
-    }
 
-    return resultPolys;
+
+        const isInside = isVec2InsidePolygon(center, poly);
+        if (isInside) {
+          const notDirectlyOnLine = toLineSegments(poly).every(ls => !LineSegment.isPointOnLineSegment(center, ls));
+          // Only remove a lineSegment if it is both inside a polygon and the center point
+          // is not directly on one of the linesegments of that polygon.
+          // This is very important and shows it's usefulness in the 
+          // "given boxes that are mostly identical > should keep the larger one" test where
+          // overlapping boxes with slight differences must not be removed
+
+          if (notDirectlyOnLine) {
+            polyLineSegments.splice(i, 1);
+            break;
+          }
+        }
+
+      }
+    }
+  }
+  // Remove dead ends (2 lines that double back on themselves) (also known as reversals):
+  let reversals: Polygon2LineSegment[] = []
+  for (let line of polyLineSegments) {
+    reversals.push(...polyLineSegments.filter(other => Vec.equal(line.p1, other.p2) && Vec.equal(line.p2, other.p1)));
+  }
+  polyLineSegments = polyLineSegments.filter(line => !reversals.includes(line));
+  // Remove unnecessary in-between verticies:
+  const lineSegments = mergeCollinearOverlappingSameDirectionLines(polyLineSegments)
+  // Turn all remaining line segments into polygons:
+  for (let i = lineSegments.length - 1; i >= 0; i--) {
+    const lineSegment = lineSegments[i];
+    if (lineSegment) {
+      const poly = processLineSegment(lineSegment, lineSegments);
+      // Valid polygons must be 3 points or more, or else it will just be a line
+      if (poly && poly.length > 2) {
+        resultPolys.push(poly);
+      }
+    }
+  }
+
+  return resultPolys;
 }
 export function growOverlappingCollinearLinesInDirectionOfP2(line: LineSegment.LineSegment, walls: LineSegment.LineSegment[]): { grownLine: LineSegment.LineSegment, removedLines: LineSegment.LineSegment[] } {
-    // Grow test line from line.p1 to the farthest colinear, touching line's p2
-    const removedLines = [];
-    let testLineGrew = false;
-    let relevantWalls = walls.filter(w => LineSegment.isCollinearAndPointInSameDirection(line, w));
-    const originalNumberOfPotentialGrowthLoops = relevantWalls.length;
-    for (let i = 0; i < originalNumberOfPotentialGrowthLoops; i++) {
-        testLineGrew = false;
-        for (let wall of relevantWalls) {
-            if (LineSegment.isCollinearAndOverlapping(line, wall) && distance(line.p1, line.p2) < distance(line.p1, wall.p2)) {
-                testLineGrew = true;
-                // Remove the wall that was used for growing
-                relevantWalls = relevantWalls.filter(x => x !== wall);
-                removedLines.push(wall);
+  // Grow test line from line.p1 to the farthest colinear, touching line's p2
+  const removedLines = [];
+  let testLineGrew = false;
+  let relevantWalls = walls.filter(w => LineSegment.isCollinearAndPointInSameDirection(line, w));
+  const originalNumberOfPotentialGrowthLoops = relevantWalls.length;
+  for (let i = 0; i < originalNumberOfPotentialGrowthLoops; i++) {
+    testLineGrew = false;
+    for (let wall of relevantWalls) {
+      if (LineSegment.isCollinearAndOverlapping(line, wall) && sqrDistance(line.p1, line.p2) < sqrDistance(line.p1, wall.p2)) {
+        testLineGrew = true;
+        // Remove the wall that was used for growing
+        relevantWalls = relevantWalls.filter(x => x !== wall);
+        removedLines.push(wall);
 
-                line.p2 = wall.p2;
-                break;
-            }
-        }
-        if (!testLineGrew) {
-            break;
-
-        }
+        line.p2 = wall.p2;
+        break;
+      }
+    }
+    if (!testLineGrew) {
+      break;
 
     }
-    return { grownLine: line, removedLines };
+
+  }
+  return { grownLine: line, removedLines };
 
 }
 
@@ -258,309 +258,309 @@ export function growOverlappingCollinearLinesInDirectionOfP2(line: LineSegment.L
 // Returns a polygon and mutates the lineSegments array to remove the segments that
 // were used or left dangling
 export function processLineSegment(processingLineSegment: LineSegment.LineSegment, lineSegments: LineSegment.LineSegment[]): Polygon2 {
-    // Add point to the newPoly
-    const newPoly: Polygon2 = [processingLineSegment.p1];
-    let currentLine = processingLineSegment;
+  // Add point to the newPoly
+  const newPoly: Polygon2 = [processingLineSegment.p1];
+  let currentLine = processingLineSegment;
 
-    // These will be removed if they do not become part of the poly because they touch the poly.
-    let danglingLineSegments = [];
-    // Line segments used in the newPoly. LineSegments are moved out of the lineSegments array and into
-    // this array during processing so that polygons can reconnect to already processed lineSegments, AND
-    // so that these lineSegments will be premanently removed from the lineSegments array once this function
-    // returns.
-    let usedLineSegments = [];
-    // lastMatch is a point in the poly that also exists previously in the poly's points.
-    // This is important for polygons that share a single vertex but nothing else.  Since they are
-    // touching, they need to be merged, but we don't want the algorithm to exit early just
-    // because it found a match (a closed poly), so it stores the last match and carries on looking.
-    // If it reaches a dead end and there is a match, it takes the closed poly that it already found - otherwise
-    // there is no poly.  If it finds 2 points in a row that are already in the poly, it has now begun to loop
-    // and knows that the poly it found is fully complete and can return with that poly.
-    let lastMatch: Vec2 | undefined = undefined;
-    let lastIntersection: Vec2 | undefined = undefined;
+  // These will be removed if they do not become part of the poly because they touch the poly.
+  let danglingLineSegments = [];
+  // Line segments used in the newPoly. LineSegments are moved out of the lineSegments array and into
+  // this array during processing so that polygons can reconnect to already processed lineSegments, AND
+  // so that these lineSegments will be premanently removed from the lineSegments array once this function
+  // returns.
+  let usedLineSegments = [];
+  // lastMatch is a point in the poly that also exists previously in the poly's points.
+  // This is important for polygons that share a single vertex but nothing else.  Since they are
+  // touching, they need to be merged, but we don't want the algorithm to exit early just
+  // because it found a match (a closed poly), so it stores the last match and carries on looking.
+  // If it reaches a dead end and there is a match, it takes the closed poly that it already found - otherwise
+  // there is no poly.  If it finds 2 points in a row that are already in the poly, it has now begun to loop
+  // and knows that the poly it found is fully complete and can return with that poly.
+  let lastMatch: Vec2 | undefined = undefined;
+  let lastIntersection: Vec2 | undefined = undefined;
 
-    // Loop Branch:
-    do {
-        // Get the closest branch
-        const branch = getClosestBranch(currentLine, [...lineSegments, ...danglingLineSegments, ...usedLineSegments]);
-        if (branch === undefined) {
-            if (lastMatch) {
-                // This is the first way to close a poly.  Branching has reached a dead end
-                // and there is a lastMatch so close the poly at the last match.
-                const matches = newPoly.map(p => lastMatch && Vec.equal(p, lastMatch))
-                return newPoly.slice(matches.indexOf(true), matches.lastIndexOf(true));
-            } else {
-                // Return an empty polygon since it did not reconnect to itself
-                return [];
-            }
-        } else {
-            const indexOfBranchIntersectionInPoly = newPoly.findIndex(p => Vec.equal(branch.intersection, p));
-            if (indexOfBranchIntersectionInPoly !== -1) {
-                if (lastMatch && lastIntersection && Vec.equal(lastMatch, lastIntersection)) {
-                    // This is the second way (and most common) way to close a poly.
-                    // The lastIntersection is also a match for a previous point in the poly
-                    // AND the current intersection is a match.  Two matches in a row
-                    // means iterating along branches will now fully repeat which means
-                    // we've found a perfect closed polygon.
-                    // So close the polygon by removing the beginning dangling points (if any)
-                    // and removing the last point (the last intersection) because it'll be
-                    // the same as the first point after the beginning dangling points are removed
-                    return newPoly.slice(indexOfBranchIntersectionInPoly - 1, -1);
-                }
-            }
-
-
+  // Loop Branch:
+  do {
+    // Get the closest branch
+    const branch = getClosestBranch(currentLine, [...lineSegments, ...danglingLineSegments, ...usedLineSegments]);
+    if (branch === undefined) {
+      if (lastMatch) {
+        // This is the first way to close a poly.  Branching has reached a dead end
+        // and there is a lastMatch so close the poly at the last match.
+        const matches = newPoly.map(p => lastMatch && Vec.equal(p, lastMatch))
+        return newPoly.slice(matches.indexOf(true), matches.lastIndexOf(true));
+      } else {
+        // Return an empty polygon since it did not reconnect to itself
+        return [];
+      }
+    } else {
+      const indexOfBranchIntersectionInPoly = newPoly.findIndex(p => Vec.equal(branch.intersection, p));
+      if (indexOfBranchIntersectionInPoly !== -1) {
+        if (lastMatch && lastIntersection && Vec.equal(lastMatch, lastIntersection)) {
+          // This is the second way (and most common) way to close a poly.
+          // The lastIntersection is also a match for a previous point in the poly
+          // AND the current intersection is a match.  Two matches in a row
+          // means iterating along branches will now fully repeat which means
+          // we've found a perfect closed polygon.
+          // So close the polygon by removing the beginning dangling points (if any)
+          // and removing the last point (the last intersection) because it'll be
+          // the same as the first point after the beginning dangling points are removed
+          return newPoly.slice(indexOfBranchIntersectionInPoly - 1, -1);
         }
-        // Now that we have a branch, split both the current line and the next line
-        if (Vec.equal(branch.intersection, branch.branchingLine.p2)) {
-            console.error('Unexpected: intersection should not be equal to branchingLine.p2')
-        }
-        if (Vec.equal(branch.intersection, currentLine.p1)) {
-            console.error('Unexpected: intersection should not be equal to currentLine.p1')
-        }
-        // Remove currentLine and branchingLine from line segments because they are either
-        // wholy used in the newPoly or they have been split and half of the split is dangling
-        // and the other half is used in the newPoly.
-        const branchingLineIndex = lineSegments.findIndex(ls => ls == branch.branchingLine);
-        if (branchingLineIndex !== -1) {
-            usedLineSegments.push(...lineSegments.splice(branchingLineIndex, 1));
-        }
-        const currentLineIndex = lineSegments.findIndex(ls => ls == currentLine);
-        if (currentLineIndex !== -1) {
-            usedLineSegments.push(...lineSegments.splice(currentLineIndex, 1));
-        }
-
-        // If intersection is not the end point of the current line, split the current line
-        if (!Vec.equal(branch.intersection, currentLine.p2)) {
-            danglingLineSegments.push({ p1: branch.intersection, p2: currentLine.p2 });
-        }
-        // Make the next current line be from intersection to branchingLine.p2
-        currentLine = { p1: branch.intersection, p2: branch.branchingLine.p2 };
-
-        // If intersection is not equal to p1 of branchingLine, split branching line so that the
-        // later half (intersection to p2) is the currentLine and the former half becomes dangling.
-        if (!Vec.equal(branch.intersection, branch.branchingLine.p1)) {
-            danglingLineSegments.push({ p1: branch.branchingLine.p1, p2: branch.intersection });
-        }
-        // // Check to see if intersection is already in the poly
-        // // Closes when the point about to be added is in the newPoly
-        const indexOfP1Match = newPoly.findIndex(p => Vec.equal(branch.intersection, p));
-        if (indexOfP1Match !== -1) {
-            lastMatch = branch.intersection;
-        }
-        lastIntersection = branch.intersection;
-
-        // Add that point to newPoly
-        newPoly.push(currentLine.p1);
+      }
 
 
-    } while (true);
+    }
+    // Now that we have a branch, split both the current line and the next line
+    if (Vec.equal(branch.intersection, branch.branchingLine.p2)) {
+      console.error('Unexpected: intersection should not be equal to branchingLine.p2')
+    }
+    if (Vec.equal(branch.intersection, currentLine.p1)) {
+      console.error('Unexpected: intersection should not be equal to currentLine.p1')
+    }
+    // Remove currentLine and branchingLine from line segments because they are either
+    // wholy used in the newPoly or they have been split and half of the split is dangling
+    // and the other half is used in the newPoly.
+    const branchingLineIndex = lineSegments.findIndex(ls => ls == branch.branchingLine);
+    if (branchingLineIndex !== -1) {
+      usedLineSegments.push(...lineSegments.splice(branchingLineIndex, 1));
+    }
+    const currentLineIndex = lineSegments.findIndex(ls => ls == currentLine);
+    if (currentLineIndex !== -1) {
+      usedLineSegments.push(...lineSegments.splice(currentLineIndex, 1));
+    }
+
+    // If intersection is not the end point of the current line, split the current line
+    if (!Vec.equal(branch.intersection, currentLine.p2)) {
+      danglingLineSegments.push({ p1: branch.intersection, p2: currentLine.p2 });
+    }
+    // Make the next current line be from intersection to branchingLine.p2
+    currentLine = { p1: branch.intersection, p2: branch.branchingLine.p2 };
+
+    // If intersection is not equal to p1 of branchingLine, split branching line so that the
+    // later half (intersection to p2) is the currentLine and the former half becomes dangling.
+    if (!Vec.equal(branch.intersection, branch.branchingLine.p1)) {
+      danglingLineSegments.push({ p1: branch.branchingLine.p1, p2: branch.intersection });
+    }
+    // // Check to see if intersection is already in the poly
+    // // Closes when the point about to be added is in the newPoly
+    const indexOfP1Match = newPoly.findIndex(p => Vec.equal(branch.intersection, p));
+    if (indexOfP1Match !== -1) {
+      lastMatch = branch.intersection;
+    }
+    lastIntersection = branch.intersection;
+
+    // Add that point to newPoly
+    newPoly.push(currentLine.p1);
+
+
+  } while (true);
 }
 export function toLineSegments(poly: Polygon2): LineSegment.LineSegment[] {
-    let lastPoint = null;
-    if (poly[0] == undefined) {
-        return [];
-    }
-    let lineSegments: LineSegment.LineSegment[] = [];
-    for (let point of poly) {
-        if (lastPoint) {
-            lineSegments.push({ p1: lastPoint, p2: point });
-        }
-        lastPoint = point;
-    }
-    // Add last point to first point:
+  let lastPoint = null;
+  if (poly[0] == undefined) {
+    return [];
+  }
+  let lineSegments: LineSegment.LineSegment[] = [];
+  for (let point of poly) {
     if (lastPoint) {
-        lineSegments.push({ p1: lastPoint, p2: poly[0] });
-    } else {
-        console.error('Error should never happen, lastPoint is falsey');
+      lineSegments.push({ p1: lastPoint, p2: point });
     }
-    return lineSegments;
+    lastPoint = point;
+  }
+  // Add last point to first point:
+  if (lastPoint) {
+    lineSegments.push({ p1: lastPoint, p2: poly[0] });
+  } else {
+    console.error('Error should never happen, lastPoint is falsey');
+  }
+  return lineSegments;
 }
 export function toPolygon2LineSegments(polygon: Polygon2): Polygon2LineSegment[] {
-    return toLineSegments(polygon).map(ls => ({ ...ls, polygon }));
+  return toLineSegments(polygon).map(ls => ({ ...ls, polygon }));
 }
 function getClosestBranch(line: LineSegment.LineSegment, lineSegments: LineSegment.LineSegment[]): Branch | undefined {
 
-    let branches: Branch[] = [];
-    // Check for collisions between the last line in path and line segments
-    for (let wall of lineSegments) {
-        if (LineSegment.equal(line, wall)) {
-            // Don't test for intersections with self
-            continue;
-        }
-        let intersection = LineSegment.lineSegmentIntersection(line, wall);
-        if (intersection) {
-            // Round the intersection since points that are of by 0.00000000001 (roughly) should be considered idential
-            // (the lineSegment intersection function isn't perfect)
-            intersection = Vec.round(intersection);
-            const dist = distance(line.p1, intersection);
-            // don't consider lines that intersect with p1 or else it'll return
-            // a previous line in the path
-            if (dist == 0) {
-                continue;
-            }
-            // relative angle:
-            const lastLineAngle = Vec.getAngleBetweenVec2s(intersection, line.p1);
-            // If the intersection is the first vertex then the next point is the second vertex
-            // but if the intersection is just an intersection along the line, then the next point is the first vertex
-            const nextLineAngle = Vec.getAngleBetweenVec2s(intersection, wall.p2);
-            const branchAngle = clockwiseAngle(lastLineAngle, nextLineAngle);
-
-            // Exclude branches where the intersection is equal to the end point
-            if (!Vec.equal(intersection, wall.p2)) {
-                branches.push({
-                    branchAngle,
-                    distance: dist,
-                    intersection,
-                    branchingLine: wall
-                });
-            }
-        }
+  let branches: Branch[] = [];
+  // Check for collisions between the last line in path and line segments
+  for (let wall of lineSegments) {
+    if (LineSegment.equal(line, wall)) {
+      // Don't test for intersections with self
+      continue;
     }
-    // Sort branches by distance (then by angle)
-    branches = branches.sort((a, b) => {
-        const diffDistance = a.distance - b.distance
-        // If distance is identical sort by smallest angle
-        if (diffDistance === 0) {
-            return a.branchAngle - b.branchAngle;
-        } else {
-            return diffDistance;
-        }
+    let intersection = LineSegment.lineSegmentIntersection(line, wall);
+    if (intersection) {
+      // Round the intersection since points that are of by 0.00000000001 (roughly) should be considered idential
+      // (the lineSegment intersection function isn't perfect)
+      intersection = Vec.round(intersection);
+      const dist = distance(line.p1, intersection);
+      // don't consider lines that intersect with p1 or else it'll return
+      // a previous line in the path
+      if (dist == 0) {
+        continue;
+      }
+      // relative angle:
+      const lastLineAngle = Vec.getAngleBetweenVec2s(intersection, line.p1);
+      // If the intersection is the first vertex then the next point is the second vertex
+      // but if the intersection is just an intersection along the line, then the next point is the first vertex
+      const nextLineAngle = Vec.getAngleBetweenVec2s(intersection, wall.p2);
+      const branchAngle = clockwiseAngle(lastLineAngle, nextLineAngle);
 
-    });
-    // console.log('branches', LineSegment.toString(line), branches.map(b => ({
-    //     ...b, branchingLine: LineSegment.toString(b.branchingLine), branchAngle: b.branchAngle * 180 / Math.PI
-    // })))
-
-    // Find the closest branch with a branchAngle < 180 because a branch angle of > 180 degrees
-    // (if it's not the last branch means that it branches off INSIDE of another branch
-    // if there are none, find the furthest with a branchAngle of 180 exactly (this is the farthest point
-    // along a straight line)
-
-
-    // Return the closest branch with an angle < 180 degrees
-    for (let branch of branches) {
-        if (branch.branchAngle < Math.PI) {
-            return branch;
-        }
+      // Exclude branches where the intersection is equal to the end point
+      if (!Vec.equal(intersection, wall.p2)) {
+        branches.push({
+          branchAngle,
+          distance: dist,
+          intersection,
+          branchingLine: wall
+        });
+      }
     }
-    // If there are no branches with an angle < 180 degrees, then take farthest branch with the smallest angle
-    // which is the branch at the end of the test line with the smallest angle
-    return branches.sort((a, b) => {
-        // Sort farthest first
-        const diffDistance = b.distance - a.distance
-        // If distance is identical sort by smallest angle
-        if (diffDistance === 0) {
-            return a.branchAngle - b.branchAngle;
-        } else {
-            return diffDistance;
-        }
-    })[0];
+  }
+  // Sort branches by distance (then by angle)
+  branches = branches.sort((a, b) => {
+    const diffDistance = a.distance - b.distance
+    // If distance is identical sort by smallest angle
+    if (diffDistance === 0) {
+      return a.branchAngle - b.branchAngle;
+    } else {
+      return diffDistance;
+    }
+
+  });
+  // console.log('branches', LineSegment.toString(line), branches.map(b => ({
+  //     ...b, branchingLine: LineSegment.toString(b.branchingLine), branchAngle: b.branchAngle * 180 / Math.PI
+  // })))
+
+  // Find the closest branch with a branchAngle < 180 because a branch angle of > 180 degrees
+  // (if it's not the last branch means that it branches off INSIDE of another branch
+  // if there are none, find the furthest with a branchAngle of 180 exactly (this is the farthest point
+  // along a straight line)
+
+
+  // Return the closest branch with an angle < 180 degrees
+  for (let branch of branches) {
+    if (branch.branchAngle < Math.PI) {
+      return branch;
+    }
+  }
+  // If there are no branches with an angle < 180 degrees, then take farthest branch with the smallest angle
+  // which is the branch at the end of the test line with the smallest angle
+  return branches.sort((a, b) => {
+    // Sort farthest first
+    const diffDistance = b.distance - a.distance
+    // If distance is identical sort by smallest angle
+    if (diffDistance === 0) {
+      return a.branchAngle - b.branchAngle;
+    } else {
+      return diffDistance;
+    }
+  })[0];
 }
 // Refactored from Polygon to Polygon2
 // Note: There is a slight flaw in this algorithm in that if the point lies
 // directly on a line of the poly on the left side, it will yield a false negative
 export function isVec2InsidePolygon(point: Vec2, polygon: Polygon2): boolean {
-    // From geeksforgeeks.com: 
-    // 1) Draw a horizontal line to the right of each point and extend it to infinity 
-    // 2) Count the number of times the line intersects with polygon edges. 
-    // 3) A point is inside the polygon if either count of intersections is odd or point lies on an edge of polygon. 
-    // If none of the conditions is true, then point lies outside
-    // Note: we must test both a horizontal line and a vertical line in order to
-    // account for corner cases such as the horizontal line intersecting directly with a vertex of a 
-    // poly (which would be 1 intersection, but the point could still be outside);
-    // Corner cases include when the test line intersects directly with a vertex or perfectly with an
-    // edge.  Intersecting with multiple points on the same edge should be reduced to 1 intersection
-    // We do two lines to account for the corner case of intersecting directly with a vertex.
+  // From geeksforgeeks.com: 
+  // 1) Draw a horizontal line to the right of each point and extend it to infinity 
+  // 2) Count the number of times the line intersects with polygon edges. 
+  // 3) A point is inside the polygon if either count of intersections is odd or point lies on an edge of polygon. 
+  // If none of the conditions is true, then point lies outside
+  // Note: we must test both a horizontal line and a vertical line in order to
+  // account for corner cases such as the horizontal line intersecting directly with a vertex of a 
+  // poly (which would be 1 intersection, but the point could still be outside);
+  // Corner cases include when the test line intersects directly with a vertex or perfectly with an
+  // edge.  Intersecting with multiple points on the same edge should be reduced to 1 intersection
+  // We do two lines to account for the corner case of intersecting directly with a vertex.
 
-    const horizontalLine: LineSegment.LineSegment = { p1: point, p2: { x: Number.MAX_SAFE_INTEGER, y: point.y } };
-    // Start outside, so each odd number of flips will determine it to be inside
-    let isInside = false;
-    const intersections: Vec2[] = [];
-    for (let wall of toLineSegments(polygon)) {
-        const _intersection = LineSegment.lineSegmentIntersection(horizontalLine, wall)
-        // Rounding and removing extra zeros: https://stackoverflow.com/a/12830454/4418836
-        // See test
-        // 'should return false for this real world example which would incur a floating point error without the current form of the function'
-        // for explanation
-        const intersection = _intersection ? { x: +_intersection.x.toFixed(2), y: +_intersection.y.toFixed(2) } : undefined
+  const horizontalLine: LineSegment.LineSegment = { p1: point, p2: { x: Number.MAX_SAFE_INTEGER, y: point.y } };
+  // Start outside, so each odd number of flips will determine it to be inside
+  let isInside = false;
+  const intersections: Vec2[] = [];
+  for (let wall of toLineSegments(polygon)) {
+    const _intersection = LineSegment.lineSegmentIntersection(horizontalLine, wall)
+    // Rounding and removing extra zeros: https://stackoverflow.com/a/12830454/4418836
+    // See test
+    // 'should return false for this real world example which would incur a floating point error without the current form of the function'
+    // for explanation
+    const intersection = _intersection ? { x: +_intersection.x.toFixed(2), y: +_intersection.y.toFixed(2) } : undefined
 
-        //  Don't process the same intersection more than once
-        //  Only process intersections at verticies once
-        if (intersection && !intersections.find(i =>
-            // intersection already processed
-            Vec.equal(i, intersection) &&
-            // intersection equals a vertex of the poly
-            polygon.some(p => Vec.equal(intersection, p))
-        )) {
-            intersections.push(intersection);
-            // If the intersection is at a vertex of the polygon, this is a special case and must be handled by checking the
-            // angles of what happens when the line goes through the intersection
-            // This logic solves these corner cases:
-            // 1. point is same location as a vertex of the polygon (inside)
-            // 2. point is horizontal to a vertex of the polygon (possibly inside or outside)
-            // 3. point is colinear with, but not on, a horizontal edge of the polygon (possibly inside or outside)
-            if (Vec.equal(intersection, point)) {
-                // The point itself is an intersection point, meaning the point lies directly on one of the walls of the polygon
-                // then it obviously is inside of the polygon (this implementation includes ON the walls as inside)
-                // Note: This is so for inverted polygons too.
-                return true
-            } else if (Vec.equal(intersection, wall.p1) || Vec.equal(intersection, wall.p2)) {
-                // Get the INSIDE angle of the vertex (relative to it's polygon)
-                const indexOfVertex = polygon.findIndex(p => Vec.equal(p, intersection));
-                const nextPoint = polygon[getLoopableIndex(indexOfVertex + 1, polygon)];
-                const prevPoint = polygon[getLoopableIndex(indexOfVertex - 1, polygon)];
-                if (nextPoint && prevPoint) {
+    //  Don't process the same intersection more than once
+    //  Only process intersections at verticies once
+    if (intersection && !intersections.find(i =>
+      // intersection already processed
+      Vec.equal(i, intersection) &&
+      // intersection equals a vertex of the poly
+      polygon.some(p => Vec.equal(intersection, p))
+    )) {
+      intersections.push(intersection);
+      // If the intersection is at a vertex of the polygon, this is a special case and must be handled by checking the
+      // angles of what happens when the line goes through the intersection
+      // This logic solves these corner cases:
+      // 1. point is same location as a vertex of the polygon (inside)
+      // 2. point is horizontal to a vertex of the polygon (possibly inside or outside)
+      // 3. point is colinear with, but not on, a horizontal edge of the polygon (possibly inside or outside)
+      if (Vec.equal(intersection, point)) {
+        // The point itself is an intersection point, meaning the point lies directly on one of the walls of the polygon
+        // then it obviously is inside of the polygon (this implementation includes ON the walls as inside)
+        // Note: This is so for inverted polygons too.
+        return true
+      } else if (Vec.equal(intersection, wall.p1) || Vec.equal(intersection, wall.p2)) {
+        // Get the INSIDE angle of the vertex (relative to it's polygon)
+        const indexOfVertex = polygon.findIndex(p => Vec.equal(p, intersection));
+        const nextPoint = polygon[getLoopableIndex(indexOfVertex + 1, polygon)];
+        const prevPoint = polygon[getLoopableIndex(indexOfVertex - 1, polygon)];
+        if (nextPoint && prevPoint) {
 
-                    const startClockwiseAngle = Vec.getAngleBetweenVec2s(intersection, nextPoint);
-                    const endClockwiseAngle = Vec.getAngleBetweenVec2s(intersection, prevPoint);
-                    // Take the vectors: line.p1 (the point) to vertex/intersection and vertex/intersection to line.p2
-                    const v1Angle = Vec.getAngleBetweenVec2s(intersection, horizontalLine.p1);
-                    const v2Angle = Vec.getAngleBetweenVec2s(intersection, horizontalLine.p2);
-                    const allowableAngle = clockwiseAngle(startClockwiseAngle, endClockwiseAngle);
-                    const v1AngleInside = Vec.equal(intersection, point) || clockwiseAngle(startClockwiseAngle, v1Angle) <= allowableAngle;
-                    const v2AngleInside = clockwiseAngle(startClockwiseAngle, v2Angle) <= allowableAngle;
-                    // Only flip if v1AngleInside XOR v2AngleInside
-                    if (v1AngleInside !== v2AngleInside) {
-                        isInside = !isInside;
-                    }
-                    // Debug logging
-                    // console.log(' start/end', Math.round(startClockwiseAngle * 180 / Math.PI), Math.round(endClockwiseAngle * 180 / Math.PI));
-                    // console.log(' v1angle/v2angle', Math.round(v1Angle * 180 / Math.PI), Math.round(v2Angle * 180 / Math.PI));
-                    // console.log(' not inside angle:', Math.round(clockwiseAngle(startClockwiseAngle, v1Angle) * 180 / Math.PI), Math.round(clockwiseAngle(startClockwiseAngle, v2Angle) * 180 / Math.PI), Math.round(allowableAngle * 180 / Math.PI), v1AngleInside, v2AngleInside)
-                } else {
-                    console.error('Next point or prev point is undefined. This error should never occur.');
-                }
-            } else {
-                // If it intersects with a wall, flip the bool
-                isInside = !isInside
-            }
+          const startClockwiseAngle = Vec.getAngleBetweenVec2s(intersection, nextPoint);
+          const endClockwiseAngle = Vec.getAngleBetweenVec2s(intersection, prevPoint);
+          // Take the vectors: line.p1 (the point) to vertex/intersection and vertex/intersection to line.p2
+          const v1Angle = Vec.getAngleBetweenVec2s(intersection, horizontalLine.p1);
+          const v2Angle = Vec.getAngleBetweenVec2s(intersection, horizontalLine.p2);
+          const allowableAngle = clockwiseAngle(startClockwiseAngle, endClockwiseAngle);
+          const v1AngleInside = Vec.equal(intersection, point) || clockwiseAngle(startClockwiseAngle, v1Angle) <= allowableAngle;
+          const v2AngleInside = clockwiseAngle(startClockwiseAngle, v2Angle) <= allowableAngle;
+          // Only flip if v1AngleInside XOR v2AngleInside
+          if (v1AngleInside !== v2AngleInside) {
+            isInside = !isInside;
+          }
+          // Debug logging
+          // console.log(' start/end', Math.round(startClockwiseAngle * 180 / Math.PI), Math.round(endClockwiseAngle * 180 / Math.PI));
+          // console.log(' v1angle/v2angle', Math.round(v1Angle * 180 / Math.PI), Math.round(v2Angle * 180 / Math.PI));
+          // console.log(' not inside angle:', Math.round(clockwiseAngle(startClockwiseAngle, v1Angle) * 180 / Math.PI), Math.round(clockwiseAngle(startClockwiseAngle, v2Angle) * 180 / Math.PI), Math.round(allowableAngle * 180 / Math.PI), v1AngleInside, v2AngleInside)
+        } else {
+          console.error('Next point or prev point is undefined. This error should never occur.');
         }
+      } else {
+        // If it intersects with a wall, flip the bool
+        isInside = !isInside
+      }
     }
-    return isInside;
+  }
+  return isInside;
 
 }
 // Refactored from Polygon.ts
 function projectPointForPathingMesh(polygon: Polygon2, pointIndex: number, magnitude: number): Vec2 {
-    const point = polygon[pointIndex];
-    if (point) {
-        const nextPoint = polygon[getLoopableIndex(pointIndex + 1, polygon)];
-        const prevPoint = polygon[getLoopableIndex(pointIndex - 1, polygon)];
-        if (nextPoint && prevPoint) {
-            const projectToPoint = getPointNormalVector(point, prevPoint, nextPoint)
-            projectToPoint.x *= magnitude;
-            projectToPoint.y *= magnitude;
-            // Round to the nearest whole number to avoid floating point inequalities later
-            // when processing these points
-            return Vec.round(Vec.add(point, projectToPoint));
-        } else {
-            console.error('projectPointForPathingMesh: nextPoint or prevPoint is undefined.  This error should never happen.');
-            return { x: 0, y: 0 };
-        }
+  const point = polygon[pointIndex];
+  if (point) {
+    const nextPoint = polygon[getLoopableIndex(pointIndex + 1, polygon)];
+    const prevPoint = polygon[getLoopableIndex(pointIndex - 1, polygon)];
+    if (nextPoint && prevPoint) {
+      const projectToPoint = getPointNormalVector(point, prevPoint, nextPoint)
+      projectToPoint.x *= magnitude;
+      projectToPoint.y *= magnitude;
+      // Round to the nearest whole number to avoid floating point inequalities later
+      // when processing these points
+      return Vec.round(Vec.add(point, projectToPoint));
     } else {
-        console.error('projectPointForPathingMesh: point is undefined.  This error should never happen.');
-        return { x: 0, y: 0 };
+      console.error('projectPointForPathingMesh: nextPoint or prevPoint is undefined.  This error should never happen.');
+      return { x: 0, y: 0 };
     }
+  } else {
+    console.error('projectPointForPathingMesh: point is undefined.  This error should never happen.');
+    return { x: 0, y: 0 };
+  }
 
 }
 // Refactored from Polygon.ts
@@ -568,53 +568,53 @@ function projectPointForPathingMesh(polygon: Polygon2, pointIndex: number, magni
 // along the normal vectors of each vertex.
 // Pure: returns a new polygon without mutating the old
 export function expandPolygon(polygon: Polygon2, magnitude: number): Polygon2 {
-    return polygon.map((_p, i) => projectPointForPathingMesh(polygon, i, magnitude));
+  return polygon.map((_p, i) => projectPointForPathingMesh(polygon, i, magnitude));
 }
 
 // Refactored from Polygon.ts
 export function* makePolygonIndexIterator(polygon: Polygon2, startIndex: number = 0): Generator<number, undefined> {
 
-    for (let i = startIndex; i < startIndex + polygon.length; i++) {
-        yield getLoopableIndex(i, polygon);
+  for (let i = startIndex; i < startIndex + polygon.length; i++) {
+    yield getLoopableIndex(i, polygon);
 
-    }
+  }
 
-    return
+  return
 }
 // Refactored from Polygon.ts
 export function getPointsFromPolygonStartingAt(polygon: Polygon2, startPoint: Vec2): Vec2[] {
-    const startPointIndex = polygon.findIndex(p => Vec.equal(p, startPoint))
-    if (startPointIndex == -1) {
-        // startPoint is not on polygon;
-        // Note sometimes this function is used to determine if two polygons are equivalent
-        // so it is within the relm of regular usage to pass a startPoint that pay not
-        // exist on polygon.points
-        return []
-    } else {
-        const polygonIndicies = Array.from(makePolygonIndexIterator(polygon, startPointIndex))
-        const vec2s = polygonIndicies.map(i => {
-            if (polygon[i]) {
-                return polygon[i];
-            } else {
-                return undefined
-            }
-        })
-        // Typeguard
-        if (vec2s.some(v => v == undefined)) {
-            console.error('One or more polygonIndicies are undefined')
-            return [];
-        }
-        return vec2s as Vec2[];
+  const startPointIndex = polygon.findIndex(p => Vec.equal(p, startPoint))
+  if (startPointIndex == -1) {
+    // startPoint is not on polygon;
+    // Note sometimes this function is used to determine if two polygons are equivalent
+    // so it is within the relm of regular usage to pass a startPoint that pay not
+    // exist on polygon.points
+    return []
+  } else {
+    const polygonIndicies = Array.from(makePolygonIndexIterator(polygon, startPointIndex))
+    const vec2s = polygonIndicies.map(i => {
+      if (polygon[i]) {
+        return polygon[i];
+      } else {
+        return undefined
+      }
+    })
+    // Typeguard
+    if (vec2s.some(v => v == undefined)) {
+      console.error('One or more polygonIndicies are undefined')
+      return [];
     }
+    return vec2s as Vec2[];
+  }
 }
 // Refactored from Polygon.ts
 export function doesVertexBelongToPolygon(p: Vec2, poly: Polygon2): boolean {
-    return !!poly.find(x => Vec.equal(x, p));
+  return !!poly.find(x => Vec.equal(x, p));
 }
 // Refactored from Polygon.ts
 export function getInsideAnglesOfWall(p: Polygon2LineSegment): { start: number, end: number } {
-    const A = Vec.getAngleBetweenVec2s(p.p1, p.p2);
-    return { start: A, end: A - Math.PI };
+  const A = Vec.getAngleBetweenVec2s(p.p1, p.p2);
+  return { start: A, end: A - Math.PI };
 }
 // Refactored from Polygon.ts
 // In radians
@@ -622,41 +622,41 @@ export function getInsideAnglesOfWall(p: Polygon2LineSegment): { start: number, 
 // The "inside angle" is the angle that points towards the inside ("non-walkable")
 // part of the polygon
 export function getInsideAnglesOfPoint(polygon: Polygon2, pointIndex: number): { start: number, end: number } {
-    const point = polygon[pointIndex];
-    if (point) {
-        const nextPoint = polygon[getLoopableIndex(pointIndex + 1, polygon)];
-        const prevPoint = polygon[getLoopableIndex(pointIndex - 1, polygon)];
-        if (nextPoint && prevPoint) {
-            const angleToPrevPoint = Vec.getAngleBetweenVec2s(point, prevPoint);
-            const angleToNextPoint = Vec.getAngleBetweenVec2s(point, nextPoint);
-            return { start: angleToNextPoint, end: angleToPrevPoint };
-        } else {
-            console.error('getInsideAnglesOfPoint: nextPoint or prevPoint is undefined. This error should never happen.');
-            return { start: 0, end: 0 };
-        }
+  const point = polygon[pointIndex];
+  if (point) {
+    const nextPoint = polygon[getLoopableIndex(pointIndex + 1, polygon)];
+    const prevPoint = polygon[getLoopableIndex(pointIndex - 1, polygon)];
+    if (nextPoint && prevPoint) {
+      const angleToPrevPoint = Vec.getAngleBetweenVec2s(point, prevPoint);
+      const angleToNextPoint = Vec.getAngleBetweenVec2s(point, nextPoint);
+      return { start: angleToNextPoint, end: angleToPrevPoint };
     } else {
-        console.error('getInsideAnglesOfPoint: point is undefined. This error should never happen.');
-        return { start: 0, end: 0 };
+      console.error('getInsideAnglesOfPoint: nextPoint or prevPoint is undefined. This error should never happen.');
+      return { start: 0, end: 0 };
     }
+  } else {
+    console.error('getInsideAnglesOfPoint: point is undefined. This error should never happen.');
+    return { start: 0, end: 0 };
+  }
 }
 // Refactored from Polygon.ts
 // Returns true if casting a line from point (a vertex on a polygon) to a target Vec2 passes through the
 // inside of point's polygon
 export function doesLineFromPointToTargetProjectAwayFromOwnPolygon(polygon: Polygon2, pointIndex: number, target: Vec2): boolean {
-    const point = polygon[pointIndex];
-    if (point !== undefined) {
-        const { start, end } = getInsideAnglesOfPoint(polygon, pointIndex);
-        const angleToTarget = Vec.getAngleBetweenVec2s(point, target);
-        return !isAngleBetweenAngles(angleToTarget, start, end);
-    } else {
-        console.error("Invalid pointIndex");
-        return false;
-    }
+  const point = polygon[pointIndex];
+  if (point !== undefined) {
+    const { start, end } = getInsideAnglesOfPoint(polygon, pointIndex);
+    const angleToTarget = Vec.getAngleBetweenVec2s(point, target);
+    return !isAngleBetweenAngles(angleToTarget, start, end);
+  } else {
+    console.error("Invalid pointIndex");
+    return false;
+  }
 }
 export interface Branch {
-    // in rads
-    branchAngle: number;
-    distance: number;
-    intersection: Vec.Vec2;
-    branchingLine: LineSegment.LineSegment;
+  // in rads
+  branchAngle: number;
+  distance: number;
+  intersection: Vec.Vec2;
+  branchingLine: LineSegment.LineSegment;
 }

--- a/src/jmath/Polygon2.ts
+++ b/src/jmath/Polygon2.ts
@@ -1,7 +1,7 @@
 import * as LineSegment from "./lineSegment";
 import { Vec2 } from "./Vec";
 import * as Vec from "./Vec";
-import { distance, sortCosestTo, sqrDistance } from "./math";
+import { distance, sortCosestTo } from "./math";
 import { clockwiseAngle, isAngleBetweenAngles } from "./Angle";
 
 // Allows accessing an array without going out of bounds.  So getBoundedIndex(array.length+1)
@@ -74,10 +74,10 @@ export function mergeCollinearOverlappingSameDirectionLines(lines: LineSegment.L
             //skip self
             continue;
           }
-          if (sqrDistance(mergeLine.p1, newLine.p2) > sqrDistance(newLine.p1, newLine.p2)) {
+          if (distance(mergeLine.p1, newLine.p2) > distance(newLine.p1, newLine.p2)) {
             newLine.p1 = mergeLine.p1;
           }
-          if (sqrDistance(newLine.p1, mergeLine.p2) > sqrDistance(newLine.p1, newLine.p2)) {
+          if (distance(newLine.p1, mergeLine.p2) > distance(newLine.p1, newLine.p2)) {
             newLine.p2 = mergeLine.p2;
           }
         }
@@ -233,7 +233,7 @@ export function growOverlappingCollinearLinesInDirectionOfP2(line: LineSegment.L
   for (let i = 0; i < originalNumberOfPotentialGrowthLoops; i++) {
     testLineGrew = false;
     for (let wall of relevantWalls) {
-      if (LineSegment.isCollinearAndOverlapping(line, wall) && sqrDistance(line.p1, line.p2) < sqrDistance(line.p1, wall.p2)) {
+      if (LineSegment.isCollinearAndOverlapping(line, wall) && distance(line.p1, line.p2) < distance(line.p1, wall.p2)) {
         testLineGrew = true;
         // Remove the wall that was used for growing
         relevantWalls = relevantWalls.filter(x => x !== wall);

--- a/src/jmath/Polygon2.ts
+++ b/src/jmath/Polygon2.ts
@@ -1,7 +1,7 @@
 import * as LineSegment from "./lineSegment";
 import { Vec2 } from "./Vec";
 import * as Vec from "./Vec";
-import { distance, sqrDistance } from "./math";
+import { distance, sortCosestTo, sqrDistance } from "./math";
 import { clockwiseAngle, isAngleBetweenAngles } from "./Angle";
 
 // Allows accessing an array without going out of bounds.  So getBoundedIndex(array.length+1)
@@ -130,7 +130,7 @@ export function splitIntersectingLineSegments(line: LineSegment.LineSegment, lin
     }
   }
   // Sort closest first
-  intersections.sort((a, b) => sqrDistance(line.p1, a) - sqrDistance(line.p1, b));
+  intersections.sort(sortCosestTo(line.p1));
   // Make new line segments
   let lastPoint = line.p1;
   for (let intersection of intersections) {

--- a/src/jmath/Vec.ts
+++ b/src/jmath/Vec.ts
@@ -97,7 +97,7 @@ export function reflectOnNormal(v: Vec2, normal: Vec2): Vec2 {
 // Like a heavy box hitting a wall and continuing to slide parallel to it
 // Normal must be normalized before passing it here
 export function projectOnNormal(v: Vec2, normal: Vec2): Vec2 {
-  const scalar = dotProduct(v, normal) / dotProduct(normal, normal);
+  const scalar = dotProduct(v, normal);
   return multiply(scalar, normal);
 }
 // Magnitude without the sqrt() function - Use when performance is a concern

--- a/src/jmath/Vec.ts
+++ b/src/jmath/Vec.ts
@@ -100,17 +100,9 @@ export function projectOnNormal(v: Vec2, normal: Vec2): Vec2 {
   const scalar = dotProduct(v, normal);
   return multiply(scalar, normal);
 }
-// Magnitude without the sqrt() function - Use when performance is a concern
-// When comparing the length of two vectors, compare sqrMagnitudes
-// When comparing to a distance, use (sqrMagnitude > sqrDistance)
-// *or to (distance * distance) where distance is a constant
-// ... instead of (magnitude to magnitude) or (magnitude to distance)
-export function sqrMagnitude(p: Vec2): number {
-  return p.x * p.x + p.y * p.y;
-}
 // Magnitude of a vector
 export function magnitude(p: Vec2): number {
-  return Math.sqrt(sqrMagnitude(p));
+  return Math.sqrt(p.x * p.x + p.y * p.y);
 }
 export function equal(p1: Vec2, p2: Vec2): boolean {
   return p1.x == p2.x && p1.y == p2.y;

--- a/src/jmath/lineSegment.ts
+++ b/src/jmath/lineSegment.ts
@@ -1,4 +1,4 @@
-import { distance } from "./math";
+import { sqrDistance } from "./math";
 import * as Vec from "./Vec";
 export interface LineSegment {
   p1: Vec.Vec2;
@@ -219,7 +219,7 @@ export function isCollinearAndOverlapping(l1: LineSegment, l2: LineSegment): boo
 }
 
 export function closestLineSegmentIntersectionWithLine(l1: LineSegment, otherLines: LineSegment[]): { intersection: Vec.Vec2, lineSegment: LineSegment } | undefined {
-  let shortestDistance = Number.MAX_SAFE_INTEGER;
+  let shortestSqrDist = Number.MAX_SAFE_INTEGER;
   let closestIntersection = undefined;
   let lineThatIntersected = undefined;
   for (let line of otherLines) {
@@ -229,9 +229,9 @@ export function closestLineSegmentIntersectionWithLine(l1: LineSegment, otherLin
     }
     const intersection = lineSegmentIntersection(l1, line);
     if (intersection) {
-      const distanceToIntersection = distance(l1.p1, intersection);
-      if (!closestIntersection || distanceToIntersection < shortestDistance) {
-        shortestDistance = distanceToIntersection;
+      const sqrDistToIntersection = sqrDistance(l1.p1, intersection);
+      if (!closestIntersection || sqrDistToIntersection < shortestSqrDist) {
+        shortestSqrDist = sqrDistToIntersection;
         closestIntersection = intersection;
         lineThatIntersected = line;
       }

--- a/src/jmath/lineSegment.ts
+++ b/src/jmath/lineSegment.ts
@@ -1,4 +1,4 @@
-import { sqrDistance } from "./math";
+import { distance } from "./math";
 import * as Vec from "./Vec";
 export interface LineSegment {
   p1: Vec.Vec2;
@@ -219,7 +219,7 @@ export function isCollinearAndOverlapping(l1: LineSegment, l2: LineSegment): boo
 }
 
 export function closestLineSegmentIntersectionWithLine(l1: LineSegment, otherLines: LineSegment[]): { intersection: Vec.Vec2, lineSegment: LineSegment } | undefined {
-  let shortestSqrDist = Number.MAX_SAFE_INTEGER;
+  let shortestDist = Number.MAX_SAFE_INTEGER;
   let closestIntersection = undefined;
   let lineThatIntersected = undefined;
   for (let line of otherLines) {
@@ -229,9 +229,9 @@ export function closestLineSegmentIntersectionWithLine(l1: LineSegment, otherLin
     }
     const intersection = lineSegmentIntersection(l1, line);
     if (intersection) {
-      const sqrDistToIntersection = sqrDistance(l1.p1, intersection);
-      if (!closestIntersection || sqrDistToIntersection < shortestSqrDist) {
-        shortestSqrDist = sqrDistToIntersection;
+      const distToIntersection = distance(l1.p1, intersection);
+      if (!closestIntersection || distToIntersection < shortestDist) {
+        shortestDist = distToIntersection;
         closestIntersection = intersection;
         lineThatIntersected = line;
       }

--- a/src/jmath/math.ts
+++ b/src/jmath/math.ts
@@ -53,6 +53,10 @@ export function sqrDistance(coords1: Vec2, coords2: Vec2): number {
 export function distance(coords1: Vec2, coords2: Vec2): number {
   return Math.sqrt(sqrDistance(coords1, coords2));
 }
+// returns a function to be passed into a .sort() callback
+export function sortCosestTo(point: Vec2): (a: Vec2, b: Vec2) => number {
+  return (a: Vec2, b: Vec2) => sqrDistance(a, point) - sqrDistance(b, point);
+}
 
 // Returns a point distance away from origin in the direction of the angle radians
 // Currently used for finding best path to LOS for an archer

--- a/src/jmath/math.ts
+++ b/src/jmath/math.ts
@@ -41,21 +41,14 @@ export function getCoordsAtDistanceTowardsTarget(start: Vec2, target: Vec2, trav
     y: start.y + result.y
   }
 }
-// Distance without the sqrt() function - Use when performance is a concern
-// When comparing distances, compare sqrDistances
-// When comparing to a vector, use (sqrMagnitude to sqrDistance)
-// ... instead of (distance to distance) or (magnitude to distance)
-export function sqrDistance(coords1: Vec2, coords2: Vec2): number {
+export function distance(coords1: Vec2, coords2: Vec2): number {
   const dx = coords1.x - coords2.x;
   const dy = coords1.y - coords2.y;
-  return dx * dx + dy * dy;
-}
-export function distance(coords1: Vec2, coords2: Vec2): number {
-  return Math.sqrt(sqrDistance(coords1, coords2));
+  return Math.sqrt(dx * dx + dy * dy);
 }
 // returns a function to be passed into a .sort() callback
 export function sortCosestTo(point: Vec2): (a: Vec2, b: Vec2) => number {
-  return (a: Vec2, b: Vec2) => sqrDistance(a, point) - sqrDistance(b, point);
+  return (a: Vec2, b: Vec2) => distance(a, point) - distance(b, point);
 }
 
 // Returns a point distance away from origin in the direction of the angle radians

--- a/src/jmath/moveWithCollision.ts
+++ b/src/jmath/moveWithCollision.ts
@@ -66,10 +66,10 @@ export type Circle = {
   radius: number;
 } & Vec2;
 export function isVecIntersectingVecWithCustomRadius(c1: Vec2, c2: Vec2, radius: number): boolean {
-  return math.sqrDistance(c1, c2) <= radius * radius;
+  return math.distance(c1, c2) <= radius;
 }
 export function isCircleIntersectingCircle(c1: Circle, c2: Circle): boolean {
-  return math.sqrDistance(c1, c2) <= (c1.radius + c2.radius) * (c1.radius + c2.radius);
+  return math.distance(c1, c2) <= c1.radius + c2.radius;
 }
 // Given a position ("from"), inside a circle, move the circle away from the position "from",
 // until "from" is at the edge of the cricle.

--- a/src/jmath/moveWithCollision.ts
+++ b/src/jmath/moveWithCollision.ts
@@ -66,10 +66,10 @@ export type Circle = {
   radius: number;
 } & Vec2;
 export function isVecIntersectingVecWithCustomRadius(c1: Vec2, c2: Vec2, radius: number): boolean {
-  return distance(c1, c2) <= radius;
+  return math.sqrDistance(c1, c2) <= radius * radius;
 }
 export function isCircleIntersectingCircle(c1: Circle, c2: Circle): boolean {
-  return distance(c1, c2) <= c1.radius + c2.radius;
+  return math.sqrDistance(c1, c2) <= (c1.radius + c2.radius) * (c1.radius + c2.radius);
 }
 // Given a position ("from"), inside a circle, move the circle away from the position "from",
 // until "from" is at the edge of the cricle.


### PR DESCRIPTION
Closes #368 
Closes #372
Closes #373 - Possible now that targeting order is predictable

- Targeting spells add new targets in a predictable manner (similar to the animation, based on distance rather than the order the units were first created)
- Some code convenience things like sortClosestTo()