### PR TITLE
Game State / Turn Phase Refactor

### DIFF
--- a/public/spellmasons-mods/Renes_gimmicks/cards/Burning_rage.ts
+++ b/public/spellmasons-mods/Renes_gimmicks/cards/Burning_rage.ts
@@ -2,101 +2,101 @@
 import type { Spell } from '../../types/cards/index';
 
 const {
-    particleEmitter,
-    Particles,
-    PixiUtils,
-    cardUtils,
-    commonTypes,
-    cards,
-    cardsUtil,
-    FloatingText,
-    ParticleCollection
+  particleEmitter,
+  Particles,
+  PixiUtils,
+  cardUtils,
+  commonTypes,
+  cards,
+  cardsUtil,
+  FloatingText,
+  ParticleCollection
 } = globalThis.SpellmasonsAPI;
 const BURNING_RAGE_PARTICLE_EMITTER_NAME = 'BURNING_RAGE';
 
 function makeBurningRageParticles(follow, prediction: boolean, underworld) {
-    if (prediction || globalThis.headless) {
-        // Don't show if just a prediction or running on the server (globalThis.headless)
-        return;
-    }
-    const texture = Particles.createParticleTexture();
-    if (!texture) {
-        Particles.logNoTextureWarning('makeBurningRageParticles');
-        return;
-    }
-    const particleConfig =
-        particleEmitter.upgradeConfig({
-            autoUpdate: true,
-            "alpha": {
-                "start": 1,
-                "end": 0
-            },
-            "scale": {
-                "start": 1,
-                "end": 0.25,
-                "minimumScaleMultiplier": 1
-            },
-            "color": {
-                "start": "#9e1818",
-                "end": "#ffee00"
-            },
-            "speed": {
-                "start": 20,
-                "end": 60,
-                "minimumSpeedMultiplier": 1
-            },
-            "acceleration": {
-                "x": 0,
-                "y": -50
-            },
-            "maxSpeed": 0,
-            "startRotation": {
-                "min": 265,
-                "max": 275
-            },
-            "noRotation": false,
-            "rotationSpeed": {
-                "min": 0,
-                "max": 0
-            },
-            "lifetime": {
-                "min": 1,
-                "max": 1.5
-            },
-            "blendMode": "normal",
-            "frequency": 0.45,
-            "emitterLifetime": -1,
-            "maxParticles": 20,
-            "pos": {
-                "x": 0,
-                "y": 0
-            },
-            "addAtBack": false,
-            "spawnType": "circle",
-            "spawnCircle": {
-                "x": 0,
-                "y": 0,
-                "r": 25
-            }
-        }, [texture]);
-    if (PixiUtils.containerUnits) {
-        const wrapped = Particles.wrappedEmitter(particleConfig, PixiUtils.containerUnits);
-        if (wrapped) {
-            const { container, emitter } = wrapped;
-            // @ts-ignore adding name prop to identify emitter for later removal
-            emitter.name = BURNING_RAGE_PARTICLE_EMITTER_NAME;
-            underworld.particleFollowers.push({
-                displayObject: container,
-                emitter,
-                target: follow
-            })
-        } else {
-            console.error('Failed to create BurnigRage particle emitter');
-        }
+  if (prediction || globalThis.headless) {
+    // Don't show if just a prediction or running on the server (globalThis.headless)
+    return;
+  }
+  const texture = Particles.createParticleTexture();
+  if (!texture) {
+    Particles.logNoTextureWarning('makeBurningRageParticles');
+    return;
+  }
+  const particleConfig =
+    particleEmitter.upgradeConfig({
+      autoUpdate: true,
+      "alpha": {
+        "start": 1,
+        "end": 0
+      },
+      "scale": {
+        "start": 1,
+        "end": 0.25,
+        "minimumScaleMultiplier": 1
+      },
+      "color": {
+        "start": "#9e1818",
+        "end": "#ffee00"
+      },
+      "speed": {
+        "start": 20,
+        "end": 60,
+        "minimumSpeedMultiplier": 1
+      },
+      "acceleration": {
+        "x": 0,
+        "y": -50
+      },
+      "maxSpeed": 0,
+      "startRotation": {
+        "min": 265,
+        "max": 275
+      },
+      "noRotation": false,
+      "rotationSpeed": {
+        "min": 0,
+        "max": 0
+      },
+      "lifetime": {
+        "min": 1,
+        "max": 1.5
+      },
+      "blendMode": "normal",
+      "frequency": 0.45,
+      "emitterLifetime": -1,
+      "maxParticles": 20,
+      "pos": {
+        "x": 0,
+        "y": 0
+      },
+      "addAtBack": false,
+      "spawnType": "circle",
+      "spawnCircle": {
+        "x": 0,
+        "y": 0,
+        "r": 25
+      }
+    }, [texture]);
+  if (PixiUtils.containerUnits) {
+    const wrapped = Particles.wrappedEmitter(particleConfig, PixiUtils.containerUnits);
+    if (wrapped) {
+      const { container, emitter } = wrapped;
+      // @ts-ignore adding name prop to identify emitter for later removal
+      emitter.name = BURNING_RAGE_PARTICLE_EMITTER_NAME;
+      underworld.particleFollowers.push({
+        displayObject: container,
+        emitter,
+        target: follow
+      })
     } else {
-        return;
+      console.error('Failed to create BurnigRage particle emitter');
     }
-    //Particles.simpleEmitter(position, config, () => { }, Particles.containerParticlesUnderUnits);
+  } else {
+    return;
+  }
+  //Particles.simpleEmitter(position, config, () => { }, Particles.containerParticlesUnderUnits);
 }
 
 const { refundLastSpell } = cards;
@@ -109,88 +109,87 @@ const attackMultiplier = 5;
 
 const cardId = 'Burning Rage';
 const spell: Spell = {
-    card: {
-        id: cardId,
-        category: CardCategory.Curses,
-        supportQuantity: true,
-        manaCost: 35,
-        healthCost: 0,
-        expenseScaling: 2,
-        probability: probabilityMap[CardRarity.RARE],
-        thumbnail: 'spellmasons-mods/Renes_gimmicks/graphics/icons/Burninig_rage.png',
-        sfx: 'poison',
-        description: [`Each stack causes target to take ${damageMultiplier} damage, but also increases the target's damage by ${attackMultiplier}. Staks increase each turn`],
-        effect: async (state, card, quantity, underworld, prediction) => {
-            //Only filter unit thats are alive
-            const targets = state.targetedUnits.filter(u => u.alive);
-            //Refund if targets no one that can attack
-            if (targets.length == 0) {
-                refundLastSpell(state, prediction, 'No target, mana refunded')
-            } else {
-                if (!prediction) {
-                    playDefaultSpellSFX(card, prediction);
-                }
-                for (let unit of targets) {
-                    Unit.addModifier(unit, card.id, underworld, prediction, quantity);
-                    unit.damage += quantity * attackMultiplier;
-                }
-            }
-            if (!prediction && !globalThis.headless) {
-                await new Promise((resolve) => {
-                    setTimeout(resolve, 100);
-                })
-            }
-            return state;
-        },
-    },
-    modifiers: {
-        add,
-        remove,
-    },
-    events: {
-        onTurnStart: async (unit, prediction, underworld) => {
-            // Damage unit and increment modifier counter
-            const modifier = unit.modifiers[cardId];
-            if (modifier && !prediction) {
-                Unit.takeDamage(unit, modifier.quantity * damageMultiplier, undefined, underworld, prediction);
-                FloatingText.default({
-                    coords: unit,
-                    text: `${modifier.quantity * damageMultiplier} rage damage`,
-                    style: { fill: 'red', strokeThickness: 1 }
-                });
-                unit.damage += attackMultiplier;
-                modifier.quantity++;
-            }
-            return false;
+  card: {
+    id: cardId,
+    category: CardCategory.Curses,
+    supportQuantity: true,
+    manaCost: 35,
+    healthCost: 0,
+    expenseScaling: 2,
+    probability: probabilityMap[CardRarity.RARE],
+    thumbnail: 'spellmasons-mods/Renes_gimmicks/graphics/icons/Burninig_rage.png',
+    sfx: 'poison',
+    description: [`Each stack causes target to take ${damageMultiplier} damage, but also increases the target's damage by ${attackMultiplier}. Staks increase each turn`],
+    effect: async (state, card, quantity, underworld, prediction) => {
+      //Only filter unit thats are alive
+      const targets = state.targetedUnits.filter(u => u.alive);
+      //Refund if targets no one that can attack
+      if (targets.length == 0) {
+        refundLastSpell(state, prediction, 'No target, mana refunded')
+      } else {
+        if (!prediction) {
+          playDefaultSpellSFX(card, prediction);
         }
+        for (let unit of targets) {
+          Unit.addModifier(unit, card.id, underworld, prediction, quantity);
+          unit.damage += quantity * attackMultiplier;
+        }
+      }
+      if (!prediction && !globalThis.headless) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 100);
+        })
+      }
+      return state;
+    },
+  },
+  modifiers: {
+    add,
+    remove,
+  },
+  events: {
+    onTurnStart: async (unit, prediction, underworld) => {
+      // Damage unit and increment modifier counter
+      const modifier = unit.modifiers[cardId];
+      if (modifier && !prediction) {
+        Unit.takeDamage(unit, modifier.quantity * damageMultiplier, undefined, underworld, prediction);
+        FloatingText.default({
+          coords: unit,
+          text: `${modifier.quantity * damageMultiplier} rage damage`,
+          style: { fill: 'red', strokeThickness: 1 }
+        });
+        unit.damage += attackMultiplier;
+        modifier.quantity++;
+      }
     }
+  }
 };
 function add(unit, underworld, prediction, quantity) {
-    cardsUtil.getOrInitModifier(unit, cardId, {
-        isCurse: true, quantity, persistBetweenLevels: false,
-    }, () => {
-        //Adds event
-        if (!unit.onTurnStartEvents.includes(cardId)) {
-            unit.onTurnStartEvents.push(cardId);
-        }
-        makeBurningRageParticles(unit, prediction, underworld);
-    });
+  cardsUtil.getOrInitModifier(unit, cardId, {
+    isCurse: true, quantity, persistBetweenLevels: false,
+  }, () => {
+    //Adds event
+    if (!unit.onTurnStartEvents.includes(cardId)) {
+      unit.onTurnStartEvents.push(cardId);
+    }
+    makeBurningRageParticles(unit, prediction, underworld);
+  });
 }
 function remove(unit, underworld) {
-    unit.damage -= unit.modifiers[cardId].quantity * attackMultiplier;
-    unit.damage = Math.max(unit.damage, 0);
-    let removeFollower = undefined;
-    for (let follower of underworld.particleFollowers) {
-        if (follower.emitter.name === BURNING_RAGE_PARTICLE_EMITTER_NAME && follower.target == unit) {
-            // Remove emitter
-            ParticleCollection.stopAndDestroyForeverEmitter(follower.emitter);
-            removeFollower = follower;
-            break;
-        }
+  unit.damage -= unit.modifiers[cardId].quantity * attackMultiplier;
+  unit.damage = Math.max(unit.damage, 0);
+  let removeFollower = undefined;
+  for (let follower of underworld.particleFollowers) {
+    if (follower.emitter.name === BURNING_RAGE_PARTICLE_EMITTER_NAME && follower.target == unit) {
+      // Remove emitter
+      ParticleCollection.stopAndDestroyForeverEmitter(follower.emitter);
+      removeFollower = follower;
+      break;
     }
-    if (removeFollower) {
-        underworld.particleFollowers = underworld.particleFollowers.filter(pf => pf !== removeFollower);
-    }
-    // console.log('jtest', underworld.particleEmitter)
+  }
+  if (removeFollower) {
+    underworld.particleFollowers = underworld.particleFollowers.filter(pf => pf !== removeFollower);
+  }
+  // console.log('jtest', underworld.particleEmitter)
 }
 export default spell;

--- a/public/spellmasons-mods/Renes_gimmicks/cards/Caltrops.ts
+++ b/public/spellmasons-mods/Renes_gimmicks/cards/Caltrops.ts
@@ -4,12 +4,12 @@ import type { Spell } from '../../types/cards/index';
 import { IUnit, isUnit } from '../../types/entity/Unit';
 
 const {
-    cardUtils,
-    commonTypes,
-    cards,
-    cardsUtil,
-    Particles,
-    FloatingText,
+  cardUtils,
+  commonTypes,
+  cards,
+  cardsUtil,
+  Particles,
+  FloatingText,
 } = globalThis.SpellmasonsAPI;
 
 const { refundLastSpell } = cards;
@@ -22,108 +22,108 @@ const distanceToDamageRatio = 0.05;
 
 const cardId = 'Caltrops';
 const spell: Spell = {
-    card: {
-        id: cardId,
-        category: CardCategory.Curses,
-        supportQuantity: true,
-        manaCost: 30,
-        healthCost: 0,
-        expenseScaling: 1.5,
-        probability: probabilityMap[CardRarity.UNCOMMON],
-        thumbnail: 'spellmasons-mods/Renes_gimmicks/graphics/icons/' + cardId + '.png',
-        sfx: 'hurt',
-        description: [`Target takes some damage it moves. Stacks, casting again replenishes duration up to ${maxDuration} turns. (Updates on turn change, recasts or damage)`],
-        effect: async (state, card, quantity, underworld, prediction) => {
-            let promises: any[] = [];
-            //Living units
-            const targets = state.targetedUnits.filter(u => u.alive);
+  card: {
+    id: cardId,
+    category: CardCategory.Curses,
+    supportQuantity: true,
+    manaCost: 30,
+    healthCost: 0,
+    expenseScaling: 1.5,
+    probability: probabilityMap[CardRarity.UNCOMMON],
+    thumbnail: 'spellmasons-mods/Renes_gimmicks/graphics/icons/' + cardId + '.png',
+    sfx: 'hurt',
+    description: [`Target takes some damage it moves. Stacks, casting again replenishes duration up to ${maxDuration} turns. (Updates on turn change, recasts or damage)`],
+    effect: async (state, card, quantity, underworld, prediction) => {
+      let promises: any[] = [];
+      //Living units
+      const targets = state.targetedUnits.filter(u => u.alive);
 
-            //Refund if no targets, this is before mana trails to help save time
-            if (targets.length == 0) {
-                refundLastSpell(state, prediction, 'No targets damaged, mana refunded');
-                return state;
-            }
-            for (let unit of targets) {
-                Unit.addModifier(unit, cardId, underworld, prediction, maxDuration, { amount: quantity });
-                if (!prediction) {
-                    triggerDistanceDamage(unit, underworld, prediction);
-                }
-            }
-            return state;
-        },
+      //Refund if no targets, this is before mana trails to help save time
+      if (targets.length == 0) {
+        refundLastSpell(state, prediction, 'No targets damaged, mana refunded');
+        return state;
+      }
+      for (let unit of targets) {
+        Unit.addModifier(unit, cardId, underworld, prediction, maxDuration, { amount: quantity });
+        if (!prediction) {
+          triggerDistanceDamage(unit, underworld, prediction);
+        }
+      }
+      return state;
     },
-    modifiers: {
-        add,
-    },
-    events: {
-        //onMove: (unit, newLocation) => {triggerDistanceDamage(unit);return newLocation},
-        onDamage: (unit, amount, underworld, prediction) => { triggerDistanceDamage(unit, underworld, prediction); return amount },
-        onTurnStart: async (unit, prediction, underworld) => { triggerDistanceDamage(unit, underworld, prediction); return false },
-        onTurnEnd: async (unit, prediction, underworld) => { triggerDistanceDamage(unit, underworld, prediction); },
-    },
+  },
+  modifiers: {
+    add,
+  },
+  events: {
+    //onMove: (unit, newLocation) => {triggerDistanceDamage(unit);return newLocation},
+    onDamage: (unit, amount, underworld, prediction) => { triggerDistanceDamage(unit, underworld, prediction); return amount },
+    onTurnStart: async (unit, prediction, underworld) => { triggerDistanceDamage(unit, underworld, prediction); },
+    onTurnEnd: async (unit, prediction, underworld) => { triggerDistanceDamage(unit, underworld, prediction); },
+  },
 };
 
 function add(unit, underworld, prediction, quantity, extra) {
-    let firstStack = !unit.onTurnStartEvents.includes(cardId);
-    const modifier = cardsUtil.getOrInitModifier(unit, cardId, {
-        isCurse: false, quantity, persistBetweenLevels: false,
-    }, () => {
-        //Register onTurn
-        if (firstStack) {
-            //unit.onMove.push(cardId);
-            unit.onTurnEndEvents.push(cardId);
-            unit.onTurnStartEvents.push(cardId);
-            unit.onDamageEvents.push(cardId);
-        }
-    });
+  let firstStack = !unit.onTurnStartEvents.includes(cardId);
+  const modifier = cardsUtil.getOrInitModifier(unit, cardId, {
+    isCurse: false, quantity, persistBetweenLevels: false,
+  }, () => {
+    //Register onTurn
     if (firstStack) {
-        modifier.last_x = unit.x;
-        modifier.last_y = unit.y;
+      //unit.onMove.push(cardId);
+      unit.onTurnEndEvents.push(cardId);
+      unit.onTurnStartEvents.push(cardId);
+      unit.onDamageEvents.push(cardId);
     }
-
-    if (modifier.quantity > maxDuration) {
-        modifier.quantity = maxDuration; //All casts give maxDuration turns, the max duration. When over maxDuration, a new cast was done so update stacks
-    }
-    if (!prediction) {
-        modifier.caltropsCounter = (modifier.caltropsCounter || 0) + extra.amount;
-        updateTooltip(unit);
-    }
-}
-function caltropsAmount(castquantity: number) {
-    let caltrops = 1;
-    if (castquantity > 0) {
-        caltrops = castquantity * 1;
-    }
-    return caltrops;
-}
-function updateTooltip(unit) {
-    const modifier = unit.modifiers && unit.modifiers[cardId];
-    if (modifier) {
-        modifier.tooltip = `When target moves deal ${caltropsAmount(modifier.caltropsCounter)} damage, lasts ${modifier.quantity} turns`
-    }
-}
-function triggerDistanceDamage(unit: IUnit, underworld: Underworld, prediction = false) {
-    const modifier = unit.modifiers && unit.modifiers[cardId];
-    let x_diff = unit.x - modifier.last_x;
-    let y_diff = unit.y - modifier.last_y;
-    if (x_diff == 0 && y_diff == 0) {
-        return
-    };
-    let damage = Math.sqrt(x_diff * x_diff + y_diff * y_diff);
-    damage = damage * distanceToDamageRatio * modifier.caltropsCounter;
-    damage -= damage % 1;
-    if (!modifier || damage < 1) {
-        return
-    };
+  });
+  if (firstStack) {
     modifier.last_x = unit.x;
     modifier.last_y = unit.y;
-    Unit.takeDamage(unit, damage, undefined, underworld, prediction);
-    if (!prediction) {
-        FloatingText.default({
-            coords: unit,
-            text: `${damage} caltrops damage`,
-            style: { fill: '#grey', strokeThickness: 1 }
-        });
-    }
+  }
+
+  if (modifier.quantity > maxDuration) {
+    modifier.quantity = maxDuration; //All casts give maxDuration turns, the max duration. When over maxDuration, a new cast was done so update stacks
+  }
+  if (!prediction) {
+    modifier.caltropsCounter = (modifier.caltropsCounter || 0) + extra.amount;
+    updateTooltip(unit);
+  }
+}
+function caltropsAmount(castquantity: number) {
+  let caltrops = 1;
+  if (castquantity > 0) {
+    caltrops = castquantity * 1;
+  }
+  return caltrops;
+}
+function updateTooltip(unit) {
+  const modifier = unit.modifiers && unit.modifiers[cardId];
+  if (modifier) {
+    modifier.tooltip = `When target moves deal ${caltropsAmount(modifier.caltropsCounter)} damage, lasts ${modifier.quantity} turns`
+  }
+}
+function triggerDistanceDamage(unit: IUnit, underworld: Underworld, prediction = false) {
+  const modifier = unit.modifiers && unit.modifiers[cardId];
+  let x_diff = unit.x - modifier.last_x;
+  let y_diff = unit.y - modifier.last_y;
+  if (x_diff == 0 && y_diff == 0) {
+    return
+  };
+  let damage = Math.sqrt(x_diff * x_diff + y_diff * y_diff);
+  damage = damage * distanceToDamageRatio * modifier.caltropsCounter;
+  damage -= damage % 1;
+  if (!modifier || damage < 1) {
+    return
+  };
+  modifier.last_x = unit.x;
+  modifier.last_y = unit.y;
+  Unit.takeDamage(unit, damage, undefined, underworld, prediction);
+  if (!prediction) {
+    FloatingText.default({
+      coords: unit,
+      text: `${damage} caltrops damage`,
+      style: { fill: '#grey', strokeThickness: 1 }
+    });
+  }
 }
 export default spell;

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Decay.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Decay.ts
@@ -1,13 +1,13 @@
 /// <reference path="../../globalTypes.d.ts" />
 import type { Spell } from '../../types/cards/index';
 const {
-    PixiUtils,
-    cardUtils,
-    commonTypes,
-    cards,
-    cardsUtil,
-    FloatingText,
-    JImage
+  PixiUtils,
+  cardUtils,
+  commonTypes,
+  cards,
+  cardsUtil,
+  FloatingText,
+  JImage
 } = globalThis.SpellmasonsAPI;
 
 const { refundLastSpell } = cards;
@@ -17,69 +17,68 @@ const { CardCategory, probabilityMap, CardRarity } = commonTypes;
 
 const cardId = 'Decay';
 const spell: Spell = {
-    card: {
-        id: cardId,
-        category: CardCategory.Curses,
-        supportQuantity: true,
-        manaCost: 35,
-        healthCost: 0,
-        expenseScaling: 2,
-        probability: probabilityMap[CardRarity.RARE], 
-        thumbnail: 'spellmasons-mods/Wodes_grimoire/graphics/icons/spelliconDecay.png',
-        sfx: 'poison',
-        description: [`Causes the target to take damage equal to the number of decay stacks squared at the start of their turn. The target then gains another stack.`],
-        effect: async (state, card, quantity, underworld, prediction) => {
-            //Only filter unit thats are alive
-            const targets = state.targetedUnits.filter(u => u.alive);
-            //Refund if targets no one that can attack
-            if (targets.length == 0) {
-                refundLastSpell(state, prediction, 'No target, mana refunded')
-            } else {
-                if (!prediction){
-                    playDefaultSpellSFX(card, prediction);
-                }
-                for (let unit of targets) {
-                    Unit.addModifier(unit, card.id, underworld, prediction, quantity);
-                }
-            }
-            if (!prediction && !globalThis.headless) {
-                await new Promise((resolve) => {
-                    setTimeout(resolve, 100);  
-                })
-            }
-            return state;
-        },
-    },
-    modifiers: {
-        add,
-    },
-    events: {
-        onTurnStart: async (unit, prediction, underworld) => {
-            // Damage unit and increment modifier counter
-            const modifier = unit.modifiers[cardId]; 
-            if (modifier && !!Math.pow(modifier.quantity, 2) && !prediction) {
-                Unit.takeDamage(unit, Math.pow(modifier.quantity, 2), undefined, underworld, prediction);
-                FloatingText.default({
-                    coords: unit, 
-                    text: `${Math.pow(modifier.quantity, 2)} decay damage`,
-                    style: {fill: '#525863', strokeThickness: 1}
-                });
-                modifier.quantity++;
-            }
-            return false;
+  card: {
+    id: cardId,
+    category: CardCategory.Curses,
+    supportQuantity: true,
+    manaCost: 35,
+    healthCost: 0,
+    expenseScaling: 2,
+    probability: probabilityMap[CardRarity.RARE],
+    thumbnail: 'spellmasons-mods/Wodes_grimoire/graphics/icons/spelliconDecay.png',
+    sfx: 'poison',
+    description: [`Causes the target to take damage equal to the number of decay stacks squared at the start of their turn. The target then gains another stack.`],
+    effect: async (state, card, quantity, underworld, prediction) => {
+      //Only filter unit thats are alive
+      const targets = state.targetedUnits.filter(u => u.alive);
+      //Refund if targets no one that can attack
+      if (targets.length == 0) {
+        refundLastSpell(state, prediction, 'No target, mana refunded')
+      } else {
+        if (!prediction) {
+          playDefaultSpellSFX(card, prediction);
         }
+        for (let unit of targets) {
+          Unit.addModifier(unit, card.id, underworld, prediction, quantity);
+        }
+      }
+      if (!prediction && !globalThis.headless) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 100);
+        })
+      }
+      return state;
+    },
+  },
+  modifiers: {
+    add,
+  },
+  events: {
+    onTurnStart: async (unit, prediction, underworld) => {
+      // Damage unit and increment modifier counter
+      const modifier = unit.modifiers[cardId];
+      if (modifier && !!Math.pow(modifier.quantity, 2) && !prediction) {
+        Unit.takeDamage(unit, Math.pow(modifier.quantity, 2), undefined, underworld, prediction);
+        FloatingText.default({
+          coords: unit,
+          text: `${Math.pow(modifier.quantity, 2)} decay damage`,
+          style: { fill: '#525863', strokeThickness: 1 }
+        });
+        modifier.quantity++;
+      }
     }
+  }
 };
 function add(unit, underworld, prediction, quantity) {
-    cardsUtil.getOrInitModifier(unit, cardId, {
-        isCurse: true, quantity, persistBetweenLevels: false,
-    }, () => {
-        //Adds event
-        if (!unit.onTurnStartEvents.includes(cardId)) {
-            unit.onTurnStartEvents.push(cardId);
-        }
-        //Adds subsprite, also TODO
-        //JImage.addSubSprite(unit.image, imageName);
-    }); 
+  cardsUtil.getOrInitModifier(unit, cardId, {
+    isCurse: true, quantity, persistBetweenLevels: false,
+  }, () => {
+    //Adds event
+    if (!unit.onTurnStartEvents.includes(cardId)) {
+      unit.onTurnStartEvents.push(cardId);
+    }
+    //Adds subsprite, also TODO
+    //JImage.addSubSprite(unit.image, imageName);
+  });
 }
 export default spell;

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Grace.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Grace.ts
@@ -1,13 +1,13 @@
 /// <reference path="../../globalTypes.d.ts" />
 import type { Spell } from '../../types/cards/index';
 const {
-    cardUtils,
-    commonTypes,
-    cards,
-    cardsUtil,
-    JImage,
-    JAudio,
-    FloatingText
+  cardUtils,
+  commonTypes,
+  cards,
+  cardsUtil,
+  JImage,
+  JAudio,
+  FloatingText
 } = globalThis.SpellmasonsAPI;
 
 const { refundLastSpell } = cards;
@@ -18,88 +18,87 @@ const { CardCategory, probabilityMap, CardRarity } = commonTypes;
 const cardId = 'Grace';
 var healingAmount = -40;
 const spell: Spell = {
-    card: {
-        id: cardId,
-        category: CardCategory.Blessings,
-        supportQuantity: true,
-        manaCost: 20,
-        healthCost: 0,
-        expenseScaling: 1,
-        probability: probabilityMap[CardRarity.RARE],
-        thumbnail: 'spellmasons-mods/Wodes_grimoire/graphics/icons/spelliconGrace.png',
-        sfx: 'purify', //TODO
-        description: [`Heals the target for ${-healingAmount} after 3 turns. Stacks increase the amount, but do not change duration`],
-        effect: async (state, card, quantity, underworld, prediction) => {
-            //Only filter unit thats are alive
-            const targets = state.targetedUnits.filter(u => u.alive);
-            //Refund if targets no one that can attack
-            if (targets.length == 0) {
-                refundLastSpell(state, prediction, 'No target, mana refunded')
-            } else {
-                if (!prediction) {
-                    playDefaultSpellSFX(card, prediction);
-                }
-                for (let unit of targets) {
-                    Unit.addModifier(unit, card.id, underworld, prediction, 0, { amount: quantity }); //Duration is 5 rounds regardless of quantity
-                }
-            }
-            return state;
+  card: {
+    id: cardId,
+    category: CardCategory.Blessings,
+    supportQuantity: true,
+    manaCost: 20,
+    healthCost: 0,
+    expenseScaling: 1,
+    probability: probabilityMap[CardRarity.RARE],
+    thumbnail: 'spellmasons-mods/Wodes_grimoire/graphics/icons/spelliconGrace.png',
+    sfx: 'purify', //TODO
+    description: [`Heals the target for ${-healingAmount} after 3 turns. Stacks increase the amount, but do not change duration`],
+    effect: async (state, card, quantity, underworld, prediction) => {
+      //Only filter unit thats are alive
+      const targets = state.targetedUnits.filter(u => u.alive);
+      //Refund if targets no one that can attack
+      if (targets.length == 0) {
+        refundLastSpell(state, prediction, 'No target, mana refunded')
+      } else {
+        if (!prediction) {
+          playDefaultSpellSFX(card, prediction);
         }
-    },
-    modifiers: {
-        add,
-    },
-    events: {
-        onTurnStart: async (unit, prediction, underworld) => {
-            // Heal unit and decremit modifier
-            const modifier = unit.modifiers[cardId];
-            if (modifier) {
-                modifier.graceCountdown--;
-                updateTooltip(unit);
-                if (modifier.graceCountdown <= 0) {
-                    let healing = calculateGraceHealing(modifier.graceQuantity);
-                    Unit.takeDamage(unit, healing, undefined, underworld, prediction);
-                    if (!prediction) {
-                        FloatingText.default({
-                            coords: unit,
-                            text: `Grace +${-healing} health`,
-                            style: { fill: '#40a058', strokeThickness: 1 }
-                        });
-                        JImage.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, { animationSpeed: 0.3, loop: false });
-                        JAudio.playSFXKey('potionPickupHealth');
-                    }
-                    Unit.removeModifier(unit, cardId, underworld);
-                }
-            }
-            return false;
+        for (let unit of targets) {
+          Unit.addModifier(unit, card.id, underworld, prediction, 0, { amount: quantity }); //Duration is 5 rounds regardless of quantity
         }
+      }
+      return state;
     }
+  },
+  modifiers: {
+    add,
+  },
+  events: {
+    onTurnStart: async (unit, prediction, underworld) => {
+      // Heal unit and decremit modifier
+      const modifier = unit.modifiers[cardId];
+      if (modifier) {
+        modifier.graceCountdown--;
+        updateTooltip(unit);
+        if (modifier.graceCountdown <= 0) {
+          let healing = calculateGraceHealing(modifier.graceQuantity);
+          Unit.takeDamage(unit, healing, undefined, underworld, prediction);
+          if (!prediction) {
+            FloatingText.default({
+              coords: unit,
+              text: `Grace +${-healing} health`,
+              style: { fill: '#40a058', strokeThickness: 1 }
+            });
+            JImage.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, { animationSpeed: 0.3, loop: false });
+            JAudio.playSFXKey('potionPickupHealth');
+          }
+          Unit.removeModifier(unit, cardId, underworld);
+        }
+      }
+    }
+  }
 };
 function add(unit, underworld, prediction, quantity, extra) {
-    const modifier = cardsUtil.getOrInitModifier(unit, cardId, {
-        isCurse: false, quantity, persistBetweenLevels: false,
-    }, () => {
-        // Register onTurnStart event
-        if (!unit.onTurnStartEvents.includes(cardId)) {
-            unit.onTurnStartEvents.push(cardId);
-        }
-    });
+  const modifier = cardsUtil.getOrInitModifier(unit, cardId, {
+    isCurse: false, quantity, persistBetweenLevels: false,
+  }, () => {
+    // Register onTurnStart event
+    if (!unit.onTurnStartEvents.includes(cardId)) {
+      unit.onTurnStartEvents.push(cardId);
+    }
+  });
 
-    if (!modifier.graceCountdown) {
-        modifier.graceCountdown = 3;
-    }
-    modifier.graceQuantity = (modifier.graceQuantity || 0) + extra.amount;
-    if (!prediction) {
-        updateTooltip(unit);
-    }
+  if (!modifier.graceCountdown) {
+    modifier.graceCountdown = 3;
+  }
+  modifier.graceQuantity = (modifier.graceQuantity || 0) + extra.amount;
+  if (!prediction) {
+    updateTooltip(unit);
+  }
 }
 function updateTooltip(unit) {
-    const modifier = unit.modifiers && unit.modifiers[cardId];
-    if (modifier) {
-        modifier.tooltip = `${modifier.graceCountdown} turns until healed for ${-calculateGraceHealing(modifier.graceQuantity)}`
-    }
+  const modifier = unit.modifiers && unit.modifiers[cardId];
+  if (modifier) {
+    modifier.tooltip = `${modifier.graceCountdown} turns until healed for ${-calculateGraceHealing(modifier.graceQuantity)}`
+  }
 }
 function calculateGraceHealing(graceQuantity: number) {
-    return graceQuantity * healingAmount
+  return graceQuantity * healingAmount
 }
 export default spell;

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -29,8 +29,7 @@ export type onAgro = {
 const onAgroSource: { [name: string]: onAgro } = {};
 
 export type onTurnStart = {
-  // Return boolean skips the turn if true
-  (unit: IUnit, prediction: boolean, underworld: Underworld): Promise<boolean>;
+  (unit: IUnit, prediction: boolean, underworld: Underworld): Promise<void>;
 };
 const onTurnStartSource: { [name: string]: onTurnStart } = {};
 

--- a/src/HeadlessServer.ts
+++ b/src/HeadlessServer.ts
@@ -91,8 +91,11 @@ class HostApp implements IHostApp {
     // Automatically overridden when passed into pie.startServer
     sendData: (msg: string) => void = () => { };
     overworld: Overworld;
+    soloMode: boolean;
     constructor() {
         this.overworld = makeOverworld(this);
+        // HostApp is run on a server for multiplayer and therefore is never in soloMode.
+        this.soloMode = false;
         new Underworld(this.overworld, this.overworld.pie, Math.random().toString());
     }
     onData(data: any) {

--- a/src/Overworld.ts
+++ b/src/Overworld.ts
@@ -100,7 +100,12 @@ export function ensureAllClientsHaveAssociatedPlayers(overworld: Overworld, clie
             console.log(`Setup: Create a Player instance for ${clientId}`)
             for (let i = 0; i < globalThis.numberOfHotseatPlayers; i++) {
                 const config = globalThis.hotseatPlayerConfig?.[i];
-                const player = Player.create(clientId, underworld);
+                let nextClientId = clientId;
+                // Hotseat players should not share the same client id
+                if (globalThis.numberOfHotseatPlayers > 1 && i > 0) {
+                    nextClientId = `${clientId}_${i}`;
+                }
+                const player = Player.create(nextClientId, underworld);
                 player.lobbyReady = !!defaultLobbyReady;
                 if (config) {
                     player.name = config.name;

--- a/src/Overworld.ts
+++ b/src/Overworld.ts
@@ -104,6 +104,8 @@ export function ensureAllClientsHaveAssociatedPlayers(overworld: Overworld, clie
         console.log(`Setup: Create a Player instance for ${clientId}`)
         const config = globalThis.hotseatPlayerConfig?.[i];
         const player = Player.create(clientId, playerId, underworld);
+        // Assign created player to globalThis.player if they are the primary client player
+        if (i == 0) Player.updateGlobalRefToPlayerIfCurrentClient(player);
         player.lobbyReady = !!defaultLobbyReady;
         if (config) {
           player.name = config.name;

--- a/src/Overworld.ts
+++ b/src/Overworld.ts
@@ -122,7 +122,6 @@ export function ensureAllClientsHaveAssociatedPlayers(overworld: Overworld, clie
     const wasConnected = player.clientConnected;
     const isConnected = clients.includes(player.clientId);
 
-    // TODO - Change?
     Player.setClientConnected(player, isConnected, underworld);
     if (!wasConnected && isConnected) {
       clientsToSendGameState.push(player.clientId);

--- a/src/Overworld.ts
+++ b/src/Overworld.ts
@@ -100,7 +100,8 @@ export function ensureAllClientsHaveAssociatedPlayers(overworld: Overworld, clie
       console.log(`Setup: Create a Player instance for ${clientId}`)
       for (let i = 0; i < globalThis.numberOfHotseatPlayers; i++) {
         const config = globalThis.hotseatPlayerConfig?.[i];
-        const player = Player.create(clientId, underworld);
+        const hotseatId = clientId + "_" + i;
+        const player = Player.create(hotseatId, underworld);
         player.lobbyReady = !!defaultLobbyReady;
         if (config) {
           player.name = config.name;

--- a/src/Overworld.ts
+++ b/src/Overworld.ts
@@ -19,142 +19,137 @@ import registerAllMods from "./registerMod";
 import { upgradeCardsSource, upgradeMageClassSource, upgradeSourceWhenDead } from "./Upgrade";
 
 export interface Overworld {
-    pie: PieClient | IHostApp;
-    // a list of clientIds
-    clients: string[];
-    underworld?: Underworld;
+  pie: PieClient | IHostApp;
+  // a list of clientIds
+  clients: string[];
+  underworld?: Underworld;
 }
 // Overworld exists so that functions that need a reference to an underworld
 // can hold on to a persistant reference which CONTAINS the lastest underworld reference.
 // This allows Underworlds to be created and destroyed without invalidating functions
 // (like event listeners) that need to keep a reference to the current underworld
 export default function makeOverworld(pie: PieClient | IHostApp): Overworld {
-    const overworld: Overworld = {
-        pie,
-        clients: [],
-        underworld: undefined
-    };
+  const overworld: Overworld = {
+    pie,
+    clients: [],
+    underworld: undefined
+  };
 
-    // Initialize content
-    // Note: Units must be registered before cards so that summon_generic
-    // can access all the unit ids
-    Units.registerUnits();
-    // Note: Register mods before cards so that if any mods add a unit,
-    // that unit will be available in allCards (which is used by summon_generic to create a summon
-    // card for that monster)
-    registerAllMods(overworld);
-    Cards.registerCards(overworld);
+  // Initialize content
+  // Note: Units must be registered before cards so that summon_generic
+  // can access all the unit ids
+  Units.registerUnits();
+  // Note: Register mods before cards so that if any mods add a unit,
+  // that unit will be available in allCards (which is used by summon_generic to create a summon
+  // card for that monster)
+  registerAllMods(overworld);
+  Cards.registerCards(overworld);
 
-    addOverworldEventListeners(overworld);
-    // Setup global functions that need access to underworld:
-    setupNetworkHandlerGlobalFunctions(overworld);
-    setupDevGlobalFunctions(overworld);
+  addOverworldEventListeners(overworld);
+  // Setup global functions that need access to underworld:
+  setupNetworkHandlerGlobalFunctions(overworld);
+  setupDevGlobalFunctions(overworld);
 
-    // Setup UI event listeners
-    CardUI.setupCardUIEventListeners(overworld);
+  // Setup UI event listeners
+  CardUI.setupCardUIEventListeners(overworld);
 
 
-    // register Admin menu AFTER mods so that you can access mod content
-    // in the admin menu
-    registerAdminContextMenuOptions(overworld);
-    // When the game is ready to process wsPie messages, begin
-    // processing them
-    // The game is ready when the following have been loaded
-    // - wsPieConnection
-    // - wsPieRoomJoined 
-    // - pixiAssets 
-    // - content (register cards and untis)
-    // - underworld
+  // register Admin menu AFTER mods so that you can access mod content
+  // in the admin menu
+  registerAdminContextMenuOptions(overworld);
+  // When the game is ready to process wsPie messages, begin
+  // processing them
+  // The game is ready when the following have been loaded
+  // - wsPieConnection
+  // - wsPieRoomJoined 
+  // - pixiAssets 
+  // - content (register cards and untis)
+  // - underworld
 
-    // Check for duplicate upgrades on dev
-    if (location && location.href.includes('localhost')) {
-        const all_upgrades = [...upgradeCardsSource, ...upgradeSourceWhenDead, ...upgradeMageClassSource];
-        for (let upgrade of all_upgrades) {
-            if (all_upgrades.filter(u => u.title == upgrade.title).length > 1) {
-                console.error(`Multiple upgrades with the same title "${upgrade.title}"`);
-            }
-        }
+  // Check for duplicate upgrades on dev
+  if (location && location.href.includes('localhost')) {
+    const all_upgrades = [...upgradeCardsSource, ...upgradeSourceWhenDead, ...upgradeMageClassSource];
+    for (let upgrade of all_upgrades) {
+      if (all_upgrades.filter(u => u.title == upgrade.title).length > 1) {
+        console.error(`Multiple upgrades with the same title "${upgrade.title}"`);
+      }
     }
+  }
 
 
-    return overworld;
+  return overworld;
 }
 // Returns an array of newly created players
 export function ensureAllClientsHaveAssociatedPlayers(overworld: Overworld, clients: string[], defaultLobbyReady?: boolean) {
-    if (!overworld) {
-        console.error('Cannot sync clients, no overworld');
-        return;
-    }
-    const { underworld } = overworld;
-    if (!underworld) {
-        console.error('Cannot sync clients with players, no underworld exists.');
-        return;
-    }
-    overworld.clients = clients;
-    // Ensure all clients have players
-    for (let clientId of overworld.clients) {
-        const player = globalThis.numberOfHotseatPlayers > 1 ? underworld.players[underworld.hotseatCurrentPlayerIndex] : underworld.players.find(p => p.clientId == clientId);
-        if (!player) {
-            // If the client that joined does not have a player yet, make them one immediately
-            // since all clients should always have a player associated
-            console.log(`Setup: Create a Player instance for ${clientId}`)
-            for (let i = 0; i < globalThis.numberOfHotseatPlayers; i++) {
-                const config = globalThis.hotseatPlayerConfig?.[i];
-                let nextClientId = clientId;
-                // Hotseat players should not share the same client id
-                if (globalThis.numberOfHotseatPlayers > 1 && i > 0) {
-                    nextClientId = `${clientId}_${i}`;
-                }
-                const player = Player.create(nextClientId, underworld);
-                player.lobbyReady = !!defaultLobbyReady;
-                if (config) {
-                    player.name = config.name;
-                    player.color = config.color;
-                    player.colorMagic = config.colorMagic;
-                    setPlayerNameUI(player);
-                }
-            }
+  if (!overworld) {
+    console.error('Cannot sync clients, no overworld');
+    return;
+  }
+  const { underworld } = overworld;
+  if (!underworld) {
+    console.error('Cannot sync clients with players, no underworld exists.');
+    return;
+  }
+  overworld.clients = clients;
+  // Ensure all clients have players
+  for (let clientId of overworld.clients) {
+    const player = underworld.players.find(p => p.clientId == clientId);
+    if (!player) {
+      // If the client that joined does not have a player yet, make them one immediately
+      // since all clients should always have a player associated
+      console.log(`Setup: Create a Player instance for ${clientId}`)
+      for (let i = 0; i < globalThis.numberOfHotseatPlayers; i++) {
+        const config = globalThis.hotseatPlayerConfig?.[i];
+        const player = Player.create(clientId, underworld);
+        player.lobbyReady = !!defaultLobbyReady;
+        if (config) {
+          player.name = config.name;
+          player.color = config.color;
+          player.colorMagic = config.colorMagic;
+          setPlayerNameUI(player);
         }
+      }
     }
-    // Sync all players' connection statuses with the clients list
-    // This ensures that there are no players left that think they're connected
-    // but are not a part of the clients list
-    let clientsToSendGameState = [];
-    for (let player of underworld.players) {
-        const wasConnected = player.clientConnected;
-        const isConnected = clients.includes(player.clientId);
-        Player.setClientConnected(player, isConnected, underworld);
-        if (!wasConnected && isConnected) {
-            clientsToSendGameState.push(player.clientId);
-            player.endedTurn = false;
-        }
+  }
+  // Sync all players' connection statuses with the clients list
+  // This ensures that there are no players left that think they're connected
+  // but are not a part of the clients list
+  let clientsToSendGameState = [];
+  for (let player of underworld.players) {
+    const wasConnected = player.clientConnected;
+    const isConnected = clients.includes(player.clientId);
+    Player.setClientConnected(player, isConnected, underworld);
+    if (!wasConnected && isConnected) {
+      clientsToSendGameState.push(player.clientId);
+      player.endedTurn = false;
     }
-    // Since the player's array length has changed, recalculate all
-    // unit strengths.  This must happen BEFORE clients are given the gamestate
-    console.log('The number of players has changed');
-    recalculateGameDifficulty(underworld);
+  }
+  // Since the player's array length has changed, recalculate all
+  // unit strengths.  This must happen BEFORE clients are given the gamestate
+  console.log('The number of players has changed');
+  recalculateGameDifficulty(underworld);
 
-    // Send game state after units' strength has been recalculated
-    for (let clientId of clientsToSendGameState) {
-        // Send the lastest gamestate to that client so they can be up-to-date:
-        // Note: It is important that this occurs AFTER the player instance is created for the
-        // client who just joined
-        // If the game has already started (e.g. the host has already joined), send the initial state to the new 
-        // client only so they can load
-        hostGiveClientGameState(clientId, underworld, underworld.lastLevelCreated, MESSAGE_TYPES.INIT_GAME_STATE);
-    }
+  // Send game state after units' strength has been recalculated
+  for (let clientId of clientsToSendGameState) {
+    // Send the lastest gamestate to that client so they can be up-to-date:
+    // Note: It is important that this occurs AFTER the player instance is created for the
+    // client who just joined
+    // If the game has already started (e.g. the host has already joined), send the initial state to the new 
+    // client only so they can load
+    hostGiveClientGameState(clientId, underworld, underworld.lastLevelCreated, MESSAGE_TYPES.INIT_GAME_STATE);
+  }
 
-    if (globalThis.isHost(underworld.pie)) {
-        overworld.pie.sendData({
-            type: MESSAGE_TYPES.SYNC_PLAYERS,
-            units: underworld.units.map(Unit.serialize),
-            players: underworld.players.map(Player.serialize),
-            lastUnitId: underworld.lastUnitId
-        });
-    }
+  if (globalThis.isHost(underworld.pie)) {
+    overworld.pie.sendData({
+      type: MESSAGE_TYPES.SYNC_PLAYERS,
+      units: underworld.units.map(Unit.serialize),
+      players: underworld.players.map(Player.serialize),
+      lastUnitId: underworld.lastUnitId
+    });
+  }
 
-    // Resume turn loop if currently stalled but now a player is able to act:
-    underworld.tryRestartTurnPhaseLoop();
+  // Resume turn loop if currently stalled but now a player is able to act:
+  underworld.tryRestartTurnPhaseLoop();
 }
 // window.test_GC_underworld = () => {
 //     for (let i = 0; i < 1000; i++) {
@@ -162,14 +157,14 @@ export function ensureAllClientsHaveAssociatedPlayers(overworld: Overworld, clie
 //     }
 // }
 export function recalculateGameDifficulty(underworld: Underworld) {
-    const newDifficulty = calculateGameDifficulty(underworld);
-    underworld.units.forEach(unit => {
-        // Adjust npc unit strength when the number of players changes
-        // Do NOT adjust player unit strength
-        if (unit.unitType !== UnitType.PLAYER_CONTROLLED) {
-            Unit.adjustUnitDifficulty(unit, newDifficulty);
-        }
-    });
-    console.log('adjusting game difficulty to ', newDifficulty, ' for ', underworld.players.filter(p => p.clientConnected).length, ' connected players.');
+  const newDifficulty = calculateGameDifficulty(underworld);
+  underworld.units.forEach(unit => {
+    // Adjust npc unit strength when the number of players changes
+    // Do NOT adjust player unit strength
+    if (unit.unitType !== UnitType.PLAYER_CONTROLLED) {
+      Unit.adjustUnitDifficulty(unit, newDifficulty);
+    }
+  });
+  console.log('adjusting game difficulty to ', newDifficulty, ' for ', underworld.players.filter(p => p.clientConnected).length, ' connected players.');
 
 }

--- a/src/RemoteLogging.ts
+++ b/src/RemoteLogging.ts
@@ -1,3 +1,4 @@
+import type Underworld from "./Underworld";
 import { SERVER_HUB_URL } from "./config";
 
 const originalConsoleError = console.error;
@@ -32,6 +33,7 @@ interface EventGroupMessage {
     seed: string; // Required to identify EventGroup
     gameName: string; // Required to identify EventGroup
     startTime?: number;
+    endTime?: number;
     serverRegion?: string;
     events: Event[];
 }
@@ -40,12 +42,18 @@ interface Event {
     time: number;
     message: string;
 }
-export function sendEventToServerHub(eventG: EventGroupMessage) {
+export function sendEventToServerHub(eventG: Partial<EventGroupMessage>, underworld: Underworld) {
     if (globalThis.headless && globalThis.useEventLogger) {
+        const eventGroup = Object.assign({
+            seed: underworld.seed,
+            gameName: underworld.pie.currentRoomInfo?.name || 'default',
+            serverRegion: process.env.serverRegion || undefined,
+            events: [],
+        }, eventG)
         fetch(`${SERVER_HUB_URL}/event`, {
             method: "POST",
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(eventG)
+            body: JSON.stringify(eventGroup)
         }).catch(_ => {
             originalConsoleError('Remote Event Logging failed');
         });

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2581,7 +2581,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
     const connectedPlayers = this.players.filter(p => p.clientConnected);
     if (connectedPlayers.length == 0) {
-      console.log('[GAME] Can\'t Progress Level \nNo connected players in player list: ', this.players);
+      console.log('[GAME] Can\'t Progress Level \nNo connected players: ', this.players);
       return false;
     } else {
       console.log('[GAME] isLevelProgressable?\nConnected Players: ', connectedPlayers);
@@ -2590,9 +2590,9 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     // TODO - Remove this?
     // Progress game state should not be getting called before enemies are spawned anyway.
 
-    const spawnedPlayers = connectedPlayers.filter(p => p.isSpawned)
+    const spawnedPlayers = this.players.filter(p => p.isSpawned)
     if (spawnedPlayers.length == 0) {
-      console.log('[GAME] Can\'t Progress Level \nNo connected players have spawned in player list: ', this.players);
+      console.log('[GAME] Can\'t Progress Level \nNo players have spawned: ', this.players);
       return false;
     } else {
       console.log('[GAME] isLevelProgressable?\nSpawned Players: ', spawnedPlayers);
@@ -2687,7 +2687,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
         console.log('[GAME] Handling Level Progress...\nPortals have already been spawned: ', spawnedPortals);
       }
     } else {
-      console.log('[GAME] Handling Level Progress...\nNo players to spawn portals for in players list: ', this.players);
+      console.log('[GAME] Handling Level Progress...\nNo players to spawn portals for: ', this.players);
     }
 
     // Go To Next Level
@@ -2697,17 +2697,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       connectedPlayers.every(p => Player.inPortal(p) || this.hasCompletedTurn(p))
       || (numberOfHotseatPlayers > 1 && connectedPlayers.some(Player.inPortal));
     if (goToNextLevel) {
-      // Invoke initLevel within a timeout so that this function
-      // doesn't have to wait for level generation to complete before
-      // returning
-      setTimeout(() => {
-        // Prepare the next level
-        if (globalThis.isHost(this.pie)) {
-          this.generateLevelData(this.levelIndex + 1);
-        } else {
-          console.log('This instance is not host, host will trigger next level generation.');
-        }
-      }, 0);
+      if (globalThis.isHost(this.pie)) {
+        this.generateLevelData(this.levelIndex + 1);
+      } else {
+        console.log('This instance is not host, host will trigger next level generation.');
+      }
       console.log('[GAME] Level Progressed\nMoving to next level');
       return true;
     } else {
@@ -2717,7 +2711,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     //Level was not progressed
     return false;
   }
-  // TODO - What is this?
+  // TODO - What is this? Just a logger?
   syncTurnMessage() {
     console.log('syncTurnMessage: phase:', turn_phase[this.turn_phase]);
     let yourTurn = false;
@@ -2729,7 +2723,6 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     document.body?.classList.toggle('your-turn', yourTurn);
     Player.syncLobby(this);
   }
-
   // Sends a network message to end turn
   async endMyTurnButtonHandler() {
     if (globalThis.player) {

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -1467,18 +1467,20 @@ export default class Underworld {
     // If tutorial isn't complete, make this a tutorial run
     if (levelIndex == 0) {
       this.isTutorialRun = !isTutorialComplete();
-      console.log('Set gamemode to "tutorial" so that the first playthrough is easier');
-      this.gameMode = 'tutorial';
-      if (!isTutorialFirstStepsComplete(['portal'])) {
-        // Set the level index to -1 to spawn the first tutorial level
-        levelIndex = -1;
+      if (this.isTutorialRun) {
+        console.log('Set gamemode to "tutorial" so that the first playthrough is easier');
+        this.gameMode = 'tutorial';
+        if (!isTutorialFirstStepsComplete(['portal'])) {
+          // Set the level index to -1 to spawn the first tutorial level
+          levelIndex = -1;
 
-        // Give the player default tutorial cards
-        if (globalThis.player) {
-          for (let spell of [slashCardId, arrowCardId, pushId]) {
-            const upgrade = Upgrade.getUpgradeByTitle(spell);
-            if (upgrade) {
-              this.forceUpgrade(globalThis.player, upgrade, false);
+          // Give the player default tutorial cards
+          if (globalThis.player) {
+            for (let spell of [slashCardId, arrowCardId, pushId]) {
+              const upgrade = Upgrade.getUpgradeByTitle(spell);
+              if (upgrade) {
+                this.forceUpgrade(globalThis.player, upgrade, false);
+              }
             }
           }
         }

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2089,10 +2089,8 @@ export default class Underworld {
     // Game State should not progress if no players are connected
     const connectedPlayers = this.players.filter(p => p.clientConnected);
     if (connectedPlayers.length == 0) {
-      console.log('[GAME] Can\'t Progress Level \nNo connected players: ', this.players);
-      return false;
-    } else {
-      console.log('[GAME] isLevelProgressable?\nConnected Players: ', connectedPlayers);
+      console.log('[GAME] No connected players: ', this.players);
+      return;
     }
 
     // We should try progressing the level before ending the game

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -1965,16 +1965,7 @@ export default class Underworld {
       'white'
     );
     console.log('Setup: resetPlayerForNextLevel; reset all players')
-    if (numberOfHotseatPlayers > 1) {
-      // Reset current hotseat player to player 1
-      this.hotseatCurrentPlayerIndex = 0;
-      const currentPlayer = this.players[this.hotseatCurrentPlayerIndex];
-      if (currentPlayer) {
-        Player.updateGlobalRefToCurrentClientPlayer(currentPlayer, this);
-      } else {
-        console.error('Unexpected, no hotseat current player')
-      }
-    }
+
     for (let player of this.players) {
       Player.resetPlayerForNextLevel(player, this);
     }
@@ -2200,130 +2191,238 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
     return isOver;
   }
-  tryEndPlayerTurnPhase(): boolean {
-    let doEndPlayerTurnPhase = false;
-    // Only move on from the player turn phase if there are players in the game,
-    // otherwise, wait for players to be in the game so that the serve doesn't just 
-    // run cycles pointlessly
-    const activePlayers = this.players.filter(Player.ableToAct);
-    if (this.turn_phase === turn_phase.PlayerTurns && activePlayers.length > 0) {
-      // If all players that can act have ended their turns...
-      if (
-        activePlayers.every(p => p.endedTurn)
-      ) {
-        doEndPlayerTurnPhase = true;
-      } else {
-        console.log('PlayerTurn: Check end player turn phase; players havent ended turn yet:', activePlayers.filter(p => !p.endedTurn).map(p => p.clientId));
+
+  async updateTurnPhase() {
+    console.log("Current turn phase == ", this.turn_phase);
+
+    if (this.turn_phase === turn_phase.PlayerTurns) {
+      // If all hotseat players are ready, try end player turn
+      await this.handleNextHotseatPlayer();
+
+      // Moves to NPC.ALLY Phase if possible
+      await this.tryEndPlayerTurnPhase();
+    } else if (this.turn_phase === turn_phase.NPC_ALLY) {
+
+    } else if (this.turn_phase === turn_phase.NPC_ENEMY) {
+
+    } else if (this.turn_phase === turn_phase.Stalled) {
+
+    }
+
+    console.log("New turn phase == ", this.turn_phase);
+    // TODO - Full Turn Cycle
+    // this.endFullTurnCycle();
+  }
+
+  async handleNextHotseatPlayer() {
+    // If it's not a hotseat game, return
+    if (!(numberOfHotseatPlayers > 1)) return;
+
+    // If current player hasn't completed their turn, return
+    // We do this outside of the loop because we don't want to
+    // call changeToHotseatPlayer if that player is already set up
+    let currentPlayer = this.players[this.hotseatCurrentPlayerIndex];
+    if (currentPlayer && !this.hasCompletedTurn(currentPlayer)) {
+      return;
+    }
+
+    // Change to the next hotseat player that hasn't completed their turn
+    while (this.hotseatCurrentPlayerIndex < this.players.length - 1) {
+      this.hotseatCurrentPlayerIndex = (this.hotseatCurrentPlayerIndex + 1) % this.players.length;
+      const currentPlayer = this.players[this.hotseatCurrentPlayerIndex];
+      // Found a player that has not completed their turn, switch to them
+      if (currentPlayer && !this.hasCompletedTurn(currentPlayer)) {
+        console.log("PlayerTurn: Switching to hotseat player: ", currentPlayer.clientId);
+        await this.changeToHotseatPlayer(currentPlayer);
+        return;
+      }
+      // Player doesn't exist or already completed turn, continue looping
+    }
+
+    console.log("PlayerTurn: All remaining hotseat players have completed their turn");
+  }
+
+  async changeToHotseatPlayer(player: Player.IPlayer) {
+    // If the next player has already completed turn or can't act
+    // get the next hotseat player
+    if (this.hasCompletedTurn(player)) this.handleNextHotseatPlayer();
+
+    // Otherwise, set up hotseat player
+    Player.updateGlobalRefToCurrentClientPlayer(player, this);
+    CardUI.recalcPositionForCards(globalThis.player, this);
+    CardUI.syncInventory(undefined, this);
+    await runPredictions(this);
+    this.checkIfShouldSpawnPortal();
+
+    // For hotseat, whenever a player ends their turn, check if the current player
+    // has upgrades to choose and if so, show the upgrade button
+    if (globalThis.player && this.upgradesLeftToChoose(globalThis.player)) {
+      elEndTurnBtn?.classList.toggle('upgrade', true);
+    }
+
+    // Announce new players' turn
+    if (globalThis.player && globalThis.player.name) {
+      queueCenteredFloatingText(globalThis.player.name);
+    }
+    // Turn on auto follow if they are spawned, and off if they are not
+    cameraAutoFollow(!!globalThis.player?.isSpawned);
+  }
+
+  hasCompletedTurn(player: Player.IPlayer) {
+    // Return false if the player
+    // - Has not spawned
+    // - Can act and has not ended turn (alive, not frozen, etc.)
+    if (!player.isSpawned) {
+      console.log('PlayerTurn: player has not spawned yet: ', player.clientId);
+      return false;
+    }
+    if (Unit.canAct(player.unit) && !player.endedTurn) {
+      console.log('PlayerTurn: player can act and has not ended turn yet: ', player.clientId);
+      return false;
+    }
+    return true;
+  }
+
+  async tryEndPlayerTurnPhase(): Promise<Boolean> {
+    // We care about the state of all connected players
+    // We do not care about players without a connected client
+    const connectedPlayers = this.players.filter(p => p.clientConnected);
+
+    // Only move on if there are connected players in the game,
+    // so that the server doesn't run cycles pointlessly
+    if (!(connectedPlayers.length > 0)) {
+      console.error("PlayerTurn: tryEndPlayerTurnPhase = false; No active players found");
+      return false;
+    }
+
+    // Return false if any players have not completed their turn
+    for (let player of connectedPlayers) {
+      if (!this.hasCompletedTurn(player)) {
+        return false;
       }
     }
-    // If all connected players are dead
-    if (this.players.filter(p => p.clientConnected).every(p => !p.unit.alive)) {
-      // end the player turn phase to let the AI hash it out
-      doEndPlayerTurnPhase = true;
-    }
-    if (doEndPlayerTurnPhase) {
-      console.log('Underworld: TurnPhase: End player turn phase');
-      for (let player of this.players) {
-        // Decrement cooldowns of spells
-        for (let spellState of Object.values(player.spellState)) {
-          if (spellState.cooldown) {
-            spellState.cooldown--;
-            // Update cooldown in UI
-            CardUI.recalcPositionForCards(globalThis.player, this);
-          }
-        }
-      }
-      // Safety, force die any units that are out of bounds (this should never happen)
-      // Note: Player Controlled units are out of bounds when they are inPortal so that they don't collide,
-      // this filters out PLAYER_CONTROLLED so that they don't get die()'d when they are inPortal
-      for (let u of this.units.filter(u => u.alive)) {
-        if (this.lastLevelCreated) {
+    await this.endPlayerTurnCleanup();
+    return true;
+  }
 
-          // Don't kill out of bound units if they are already flagged for removal
-          // (Note: flaggedForRemoval units are set to NaN,NaN;  thus they are out of bounds, but 
-          // they will be cleaned up so they shouldn't be killed here as this check is just to ensure
-          // no living units that are unreachable hinder progressing through the game)
-          if (!u.flaggedForRemoval) {
-            // TODO ensure that this works on headless
-            const originalTile = this.lastLevelCreated.imageOnlyTiles[vec2ToOneDimentionIndexPreventWrap({ x: Math.round(u.x / config.OBSTACLE_SIZE), y: Math.round(u.y / config.OBSTACLE_SIZE) }, this.lastLevelCreated.width)];
-            if (!originalTile || originalTile.image == '') {
+  async endPlayerTurnCleanup() {
+    console.log('Underworld: TurnPhase: End player turn phase');
 
-              if (u.unitType == UnitType.PLAYER_CONTROLLED) {
-                const player = this.players.find(p => p.unit == u);
-                if (player && !Player.inPortal(player)) {
-                  console.error('Player was reset because they ended up out of bounds');
-                  Player.resetPlayerForNextLevel(player, this);
-                } else {
-                  console.error("Unexpected: Tried to reset out of bounds player but player unit matched no player object.");
-                }
-              } else {
-                console.error('Unit was force killed because they ended up out of bounds', u.unitSubType)
-                Unit.die(u, this, false);
-              }
-            }
-          }
-        }
-      }
+    for (let p of this.players) {
       // Decrement card usage counts,
       // This makes spells less expensive
-      for (let p of this.players) {
-        for (let cardId of p.inventory) {
-          // Decrement, cap at 0
-          const cardUsage = p.cardUsageCounts[cardId];
-          if (cardUsage !== undefined) {
-            p.cardUsageCounts[cardId] = Math.max(0, cardUsage - 1);
-          }
+      for (let cardId of p.inventory) {
+        // Decrement, cap at 0
+        const cardUsage = p.cardUsageCounts[cardId];
+        if (cardUsage !== undefined) {
+          p.cardUsageCounts[cardId] = Math.max(0, cardUsage - 1);
         }
       }
-      CardUI.updateCardBadges(this);
-      // At the end of the player turn, deal damage if still in liquid
-      for (let player of this.players) {
-        if (player.unit.inLiquid && player.unit.alive) {
-          doLiquidEffect(this, player.unit, false);
-          floatingText({ coords: player.unit, text: 'Liquid damage', style: { fill: 'red' } });
+
+      // Decrement cooldowns of spells
+      for (let spellState of Object.values(p.spellState)) {
+        if (spellState.cooldown) {
+          spellState.cooldown--;
+          // Update cooldown in UI
+          CardUI.recalcPositionForCards(globalThis.player, this);
         }
       }
-      // Move onto next phase
-      // Note: BroadcastTurnPhase should happen last because it
-      // queues up a unitsync, so if changes to the units
-      // were to happen AFTER broadcastTurnPhase they would be
-      // overwritten when the sync occurred
-      // ---
-      // If there are ally units move to NPC_ALLY, if not just move to NPC_ENEMY
-      if (this.units.filter(u => u.alive && u.faction == Faction.ALLY && u.unitType == UnitType.AI).length !== 0) {
+    }
+
+    CardUI.updateCardBadges(this);
+
+    await Unit.endTurnForUnits(this.players.map(p => p.unit), this);
+
+    // Move to next phase depending on remaining units
+    // NPC_ALLY, NPC_ENEMY, or portal state
+    const aiUnits = this.units.filter(u => u.alive && u.unitType == UnitType.AI);
+    if (aiUnits.length != 0) {
+      if (aiUnits.find(u => u.faction == Faction.ALLY)) {
         this.broadcastTurnPhase(turn_phase.NPC_ALLY);
       } else {
         this.broadcastTurnPhase(turn_phase.NPC_ENEMY);
       }
-      return true;
     }
-    return false;
+    else {
+      this.checkIfShouldSpawnPortal();
+      //this.broadcastTurnPhase(turn_phase.PlayerTurns);
+    }
+    return true;
+  }
+
+  async executeFactionTurn(faction: Faction) {
+    cleanUpEmitters(true);
+    // Clear unit attentionMarkers since it's not the player's turn
+    globalThis.attentionMarkers = [];
+    this.redPortalBehavior(faction);
+
+    const units = this.units.filter(u => u.unitType == UnitType.AI && u.faction == faction);
+
+    // Only execute turn if there are units to take the turn:
+    if (units.filter(u => Unit.canAct(u)).length) {
+      // Run AI unit actions
+      await this.executeNPCTurn(faction);
+    } else {
+      console.log('Turn Management: Skipping executingNPCTurn for ', faction);
+    }
+
+    // End turn events, liquid damage, mana regen, etc.
+    await Unit.endTurnForUnits(units, this);
   }
 
   // This function is invoked when all factions have finished their turns
   async endFullTurnCycle() {
-    // Move onto next phase
     // --
     // Note: The reason this logic happens here instead of in initializeTurnPhase
     // is because initializeTurnPhase needs to be called on game load to put everything
     // in a good state when updating to the canonical client's game state. (this 
     // happens when one client disconnects and rejoins).
     // --
-    // Trigger onTurnEnd Events
-    for (let unit of this.units.filter(u => u.unitType === UnitType.AI)) {
-      await Promise.all(unit.onTurnEndEvents.map(
-        async (eventName) => {
-          const fn = Events.onTurnEndSource[eventName];
-          return fn ? await fn(unit, false, this) : false;
-        },
-      ));
-    }
+
     // Increment the turn number now that it's starting over at the first phase
     this.turn_number++;
 
+    // Failsafe: Force die any units that are out of bounds
+    // Note: Player Controlled units are out of bounds when they are inPortal so that they don't collide,
+    // this filters out PLAYER_CONTROLLED so that they don't get die()'d when they are inPortal
+    for (let u of this.units.filter(u => u.alive)) {
+      if (this.lastLevelCreated) {
+
+        // Don't kill out of bound units if they are already flagged for removal
+        // (Note: flaggedForRemoval units are set to NaN,NaN;  thus they are out of bounds, but 
+        // they will be cleaned up so they shouldn't be killed here as this check is just to ensure
+        // no living units that are unreachable hinder progressing through the game)
+        if (!u.flaggedForRemoval) {
+          // TODO ensure that this works on headless
+          const originalTile = this.lastLevelCreated.imageOnlyTiles[vec2ToOneDimentionIndexPreventWrap({ x: Math.round(u.x / config.OBSTACLE_SIZE), y: Math.round(u.y / config.OBSTACLE_SIZE) }, this.lastLevelCreated.width)];
+          if (!originalTile || originalTile.image == '') {
+
+            if (u.unitType == UnitType.PLAYER_CONTROLLED) {
+              const player = this.players.find(p => p.unit == u);
+              if (player && !Player.inPortal(player)) {
+                console.error('Player was reset because they ended up out of bounds');
+                Player.resetPlayerForNextLevel(player, this);
+              } else {
+                console.error("Unexpected: Tried to reset out of bounds player but player unit matched no player object.");
+              }
+            } else {
+              console.error('Unit was force killed because they ended up out of bounds', u.unitSubType)
+              Unit.die(u, this, false);
+            }
+          }
+        }
+      }
+    }
+
+    // Pickups - Turns left to grab
     for (let p of this.pickups) {
       if (p.turnsLeftToGrab !== undefined) {
         p.turnsLeftToGrab--;
+        if (p.turnsLeftToGrab < 0) {
+          // Remove pickup
+          Pickup.removePickup(p, this, false);
+          continue;
+        }
         if (p.text) {
           p.text.text = `${p.turnsLeftToGrab}`;
         }
@@ -2339,31 +2438,15 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
               0.1
             );
             if (!timeCircleSprite.filters) {
-
               timeCircleSprite.filters = [];
             }
             timeCircleSprite.filters.push(timeCircleColorFilter);
-
           }
-
         }
       }
-      if (p.turnsLeftToGrab !== undefined && p.turnsLeftToGrab < 0) {
-        if (p.name == Pickup.CARDS_PICKUP_NAME) {
-          playSFXKey('scroll_disappear');
-          makeScrollDissapearParticles(p, false);
-        }
-        // Remove pickup
-        Pickup.removePickup(p, this, false);
-      }
-    }
-    // Add mana to AI units
-    for (let unit of this.units.filter((u) => u.unitType === UnitType.AI && u.alive)) {
-      unit.mana += unit.manaPerTurn;
-      // Cap manaPerTurn at manaMax
-      unit.mana = Math.min(unit.mana, unit.manaMax);
     }
   }
+
   syncTurnMessage() {
     console.log('syncTurnMessage: phase:', turn_phase[this.turn_phase]);
     let yourTurn = false;
@@ -2374,29 +2457,15 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
     document.body?.classList.toggle('your-turn', yourTurn);
     Player.syncLobby(this);
-
   }
+
+  // TODO - Move whole function
   async initializePlayerTurns() {
     // Prevent possible desynce where portals don't spawn when unit dies
     // so it must spawn here to ensure players can move on
     this.checkIfShouldSpawnPortal();
     for (let player of this.players) {
-      // Reset player.endedTurn
-      // --
-      // Important: This must be set for ALL players
-      // before the rest of player initialization happens because
-      // players that cannot start their turn (for various reasons)
-      // will have their turn ended during initialization
-      // and when a turn is ended it checks if it should move on to the
-      // next phase and that check considers if all players are either
-      // unable to act or have already ended their turns. and so if the
-      // first player has their turn auto ended before the other players
-      // have had their .endedTurn property reset to false, then the game
-      // would go to the next phase thinking all players had ended their turns
-      // or been unable to act.
       player.endedTurn = false;
-    }
-    for (let player of this.players) {
       if (player.unit.alive) {
         // Restore player to max mana at start of turn
         // Let mana remain above max if it already is (due to other influences that may
@@ -2404,18 +2473,6 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
         player.unit.mana = Math.max(player.unit.manaMax, player.unit.mana);
       }
 
-      // If this current player is NOT able to take their turn...
-      if (!Player.ableToAct(player)) {
-        // Prevents bug that caused skipping turns in hotseat multiplayer when a player dies
-        if (numberOfHotseatPlayers > 1 && player !== globalThis.player) {
-          console.log('Hotseat: Skip ending turn for a hotseat player because it is not currently their turn');
-          continue;
-        }
-        // Skip them
-        this.endPlayerTurn(player.clientId);
-        // Do not continue with initialization
-        continue;
-      }
       if (player == globalThis.player && globalThis.player.isSpawned) {
         // Notify the current player that their turn is starting
         queueCenteredFloatingText(`Your Turn`);
@@ -2424,6 +2481,8 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           playSFXKey('yourTurn');
         }
       }
+
+      // TODO - Why is this here?
       // Trigger attributePerks
       const perkRandomGenerator = seedrandom(getUniqueSeedString(this, player));
       for (let i = 0; i < player.attributePerks.length; i++) {
@@ -2432,6 +2491,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           tryTriggerPerk(perk, player, 'everyTurn', perkRandomGenerator, this, 700 * i);
         }
       }
+
       // Trigger onTurnStart Events
       const onTurnStartEventResults: boolean[] = await Promise.all(player.unit.onTurnStartEvents.map(
         async (eventName) => {
@@ -2439,21 +2499,6 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           return fn ? await fn(player.unit, false, this) : false;
         },
       ));
-      if (onTurnStartEventResults.some((b) => b)) {
-        // If any onTurnStartEvents return true, skip the player
-        console.log(`Force end player turn, player ${player.clientId} due to onTurnStartEvent`)
-        this.endPlayerTurn(player.clientId);
-        // Do not continue with initialization for this player
-        continue;
-      }
-      // If player is killed at the start of their turn (for example, due to poison)
-      // end their turn
-      if (!player.unit.alive) {
-        console.log(`Force end player turn, player ${player.clientId} died when their turn started`)
-        this.endPlayerTurn(player.clientId);
-        // Do not continue with initialization for this player
-        continue;
-      }
     }
     this.syncTurnMessage();
     // Update unit health / mana bars, etc
@@ -2476,13 +2521,18 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     if (globalThis.saveASAP && globalThis.save) {
       globalThis.save(globalThis.saveASAP);
     }
-    // Hotseat: Previous player turn ended on last player in queue, switch back to first player
-    if (globalThis.player?.isSpawned) {
-      this.changeToNextHotseatPlayer();
+
+    const firstPlayer = this.players[0];
+    if (firstPlayer) {
+      this.hotseatCurrentPlayerIndex = 0;
+      this.changeToHotseatPlayer(firstPlayer)
     }
-
-
+    else {
+      console.error("Unexpected: Hotseat player doesn't exist");
+    }
+    this.updateTurnPhase();
   }
+
   // Sends a network message to end turn
   async endMyTurnButtonHandler() {
     if (globalThis.player) {
@@ -2567,42 +2617,17 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
     // Ensure players can only end the turn when it IS their turn
     if (this.turn_phase === turn_phase.PlayerTurns) {
-      // Don't trigger onTurnEndEvents more than once
-      if (!player.endedTurn) {
-        player.endedTurn = true;
-        // Trigger onTurnEnd Events
-        await Promise.all(player.unit.onTurnEndEvents.map(
-          async (eventName) => {
-            const fn = Events.onTurnEndSource[eventName];
-            return fn ? await fn(player.unit, false, this) : false;
-          },
-        ));
-      }
-      // Extra guard to protect against unexpected state
-      // where a player is dead but their turn is not ended
-      // Ensure that dead players are set to "turn ended"
-      for (let player of this.players) {
-        const unit = player.unit;
-        // If player is dead,
-        if (unit && !unit.alive) {
-          // and their turn has not been ended yet,
-          // set their endedTurn to true
-          if (!player.endedTurn) {
-            player.endedTurn = true;
-          }
-        }
-      }
+      player.endedTurn = true;
       console.log('PlayerTurn: End player turn', clientId);
       this.syncTurnMessage();
 
-      // If all enemies are dead, make dead, non portaled players portal
-      // so the game can continue
+      // If all enemies are dead, make dead, non portaled players
+      // enter the portal so the game can continue
       const allEnemiesAreDead = this.units.filter(u => u.faction == Faction.ENEMY && u.unitSubType !== UnitSubType.DOODAD).every(u => !u.alive);
       const deadNonPortaledPlayers = this.players.filter(p => !Player.inPortal(p) && !p.unit.alive);
       if (allEnemiesAreDead) {
         console.log('Make dead, non-portaled players enter portal');
         deadNonPortaledPlayers.forEach(p => {
-          Unit.resurrect(p.unit, this);
           Player.enterPortal(p, this);
         });
       }
@@ -2614,50 +2639,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
         // the game if it didn't early return here
         return;
       }
-      const wentToNextPhase = this.tryEndPlayerTurnPhase();
-      if (wentToNextPhase) {
-        return;
-      }
-      await this.changeToNextHotseatPlayer();
+      this.updateTurnPhase();
     } else {
       console.error("turn_phase must be PlayerTurns to end turn.  Cannot be ", this.turn_phase);
     }
     Player.syncLobby(this);
-  }
-  async changeToNextHotseatPlayer() {
-    // If player hotseat multiplayer, change players
-    if (numberOfHotseatPlayers > 1) {
-      // Change to next hotseat player
-      this.hotseatCurrentPlayerIndex = (this.hotseatCurrentPlayerIndex + 1) % this.players.length;
-      const currentPlayer = this.players[this.hotseatCurrentPlayerIndex];
-      if (currentPlayer) {
-        Player.updateGlobalRefToCurrentClientPlayer(currentPlayer, this);
-      } else {
-        console.error('Unexpected, no hotseat current player')
-      }
-      if (globalThis.player && !Player.ableToAct(globalThis.player)) {
-        this.endPlayerTurn(globalThis.player.clientId);
-        return;
-      }
-      CardUI.recalcPositionForCards(globalThis.player, this);
-      CardUI.syncInventory(undefined, this);
-      await runPredictions(this);
-      this.checkIfShouldSpawnPortal();
-      // For hotseat, whenever a player ends their turn, check if the current player
-      // has upgrades to choose and if so, show the upgrade button
-      if (globalThis.player && this.upgradesLeftToChoose(globalThis.player)) {
-        elEndTurnBtn?.classList.toggle('upgrade', true);
-      }
-
-      // Announce new players' turn
-      if (globalThis.player && globalThis.player.name) {
-        queueCenteredFloatingText(globalThis.player.name);
-      }
-
-      // Turn on auto follow if they are spawned, and off if they are not
-      cameraAutoFollow(!!globalThis.player?.isSpawned);
-    }
-
   }
   getFreeUpgrade(player: Player.IPlayer, upgrade: Upgrade.IUpgrade) {
     player.freeSpells.push(upgrade.title);
@@ -3187,60 +3173,12 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           // not.
           break;
         case turn_phase[turn_phase.NPC_ALLY]:
-          // Now that player's turn is over, clear any emitters that failed to clean up themselves
-          // that are marked as "turn lifetime" 
-          cleanUpEmitters(true);
-          // Clear enemy attentionMarkers since it's now their turn
-          globalThis.attentionMarkers = [];
-          this.redPortalBehavior(Faction.ALLY);
-          // Only execute turn if there are units to take the turn:
-          if (this.units.filter(u => u.unitType == UnitType.AI && u.faction == Faction.ALLY && u.alive).length) {
-            // Count the number of ally turns
-            this.allyNPCAttemptWinKillSwitch++;
-            // Run AI unit actions
-            await this.executeNPCTurn(Faction.ALLY);
-          } else {
-            console.log('Turn Management: Skipping executingNPCTurn for Faction.ALLY');
-          }
-          // At the end of their turn, deal damage if still in liquid
-          for (let unit of this.units.filter(u => u.unitType == UnitType.AI && u.faction == Faction.ALLY)) {
-            if (unit.inLiquid && unit.alive) {
-              doLiquidEffect(this, unit, false);
-              floatingText({ coords: unit, text: 'Liquid damage', style: { fill: 'red' } });
-            }
-          }
-          // Now that allies are done taking their turn, change to NPC Enemy turn phase
-          this.broadcastTurnPhase(turn_phase.NPC_ENEMY)
+          await this.executeFactionTurn(Faction.ALLY);
+          this.broadcastTurnPhase(turn_phase.NPC_ENEMY);
           break;
         case turn_phase[turn_phase.NPC_ENEMY]:
-          // Now that player's turn is over (player turn can go directly to NPC_ENEMY if there are no Allies),
-          // clear any emitters that failed to clean up themselves
-          // that are marked as "turn lifetime" 
-          cleanUpEmitters(true);
-          // Clear enemy attentionMarkers since it's now their turn
-          globalThis.attentionMarkers = [];
-          this.redPortalBehavior(Faction.ENEMY);
-          // Only execute turn if there are units to take the turn:
-          if (this.units.filter(u => u.unitType == UnitType.AI && u.faction == Faction.ENEMY && u.alive).length) {
-            // Run AI unit actions
-            await this.executeNPCTurn(Faction.ENEMY);
-          } else {
-            console.log('Turn Management: Skipping executingNPCTurn for Faction.ENEMY');
-          }
+          await this.executeFactionTurn(Faction.ENEMY);
           await this.endFullTurnCycle();
-          // At the end of their turn, deal damage if still in liquid
-          for (let unit of this.units.filter(u => u.unitType == UnitType.AI && u.faction == Faction.ENEMY)) {
-            if (unit.inLiquid && unit.alive) {
-              doLiquidEffect(this, unit, false);
-              floatingText({ coords: unit, text: 'Liquid damage', style: { fill: 'red' } });
-            }
-          }
-          // Remove all Immune modifiers (they only last through one enemy turn)
-          this.units.forEach(u => {
-            Unit.removeModifier(u, immune.id, this);
-          });
-
-          // Loop: go back to the player turn
           this.broadcastTurnPhase(turn_phase.PlayerTurns);
           break;
         default:

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -705,7 +705,6 @@ export default class Underworld {
           // Once the unit reaches the target, shift so the next point in the path is the next target
           u.path.points.shift();
         }
-
       }
 
       // check for collisions with pickups in new location
@@ -2389,16 +2388,6 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
         // Don't play turn sfx when recording
         if (!globalThis.isHUDHidden && !document.body?.classList.contains('hide-card-holders')) {
           playSFXKey('yourTurn');
-        }
-      }
-
-      // TODO - Why is this here?
-      // Trigger attributePerks
-      const perkRandomGenerator = seedrandom(getUniqueSeedString(this, player));
-      for (let i = 0; i < player.attributePerks.length; i++) {
-        const perk = player.attributePerks[i];
-        if (perk) {
-          tryTriggerPerk(perk, player, 'everyTurn', perkRandomGenerator, this, 700 * i);
         }
       }
     }

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -647,6 +647,8 @@ export default class Underworld {
   }
 
   // TODO - Examine this for state machine refactor
+  // Issue: https://github.com/jdoleary/Spellmasons/issues/388
+
   // returns true if there is more processing yet to be done on the next game loop
   gameLoopUnit = (u: Unit.IUnit, aliveNPCs: Unit.IUnit[], deltaTime: number): boolean => {
     if (u) {

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2259,6 +2259,7 @@ export default class Underworld {
       connectedPlayers.every(p => Player.inPortal(p) || this.hasCompletedTurn(p))
       || (numberOfHotseatPlayers > 1 && connectedPlayers.some(Player.inPortal));
     if (goToNextLevel) {
+      tutorialCompleteTask('portal');
       if (globalThis.isHost(this.pie)) {
         this.generateLevelData(this.levelIndex + 1);
       } else {

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2273,7 +2273,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     if (this.hasCompletedTurn(player)) this.handleNextHotseatPlayer();
 
     // Otherwise, set up hotseat player
-    Player.updateGlobalRefToPlayer(player);
+    Player.updateGlobalRefToPlayerIfCurrentClient(player);
     CardUI.recalcPositionForCards(globalThis.player, this);
     CardUI.syncInventory(undefined, this);
     await runPredictions(this);
@@ -2676,7 +2676,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     // Ensure players can only end the turn when it IS their turn
     if (this.turn_phase == turn_phase.PlayerTurns) {
       player.endedTurn = true;
-      console.log('[GAME] Turn Phase\nEnd player turn', clientId);
+      console.log('[GAME] Turn Phase\nPlayer ended turn: ', player);
       this.syncTurnMessage();
       this.progressGameState();
     } else {

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -103,9 +103,9 @@ import { PRIEST_ID } from './entity/units/priest';
 import { getSyncActions } from './Syncronization';
 import { EXPECTED_MILLIS_PER_GAMELOOP, forcePushAwayFrom } from './effects/force_move';
 import { playThrottledEndTurnSFX } from './Audio';
+import { targetConeId } from './cards/target_cone';
 import { slashCardId } from './cards/slash';
 import { pushId } from './cards/push';
-import { arrowCardId } from './cards/arrow';
 
 const loopCountLimit = 10000;
 export enum turn_phase {
@@ -1478,7 +1478,7 @@ export default class Underworld {
 
           // Give the player default tutorial cards
           if (globalThis.player) {
-            for (let spell of [slashCardId, arrowCardId, pushId]) {
+            for (let spell of [targetConeId, slashCardId, pushId]) {
               const upgrade = Upgrade.getUpgradeByTitle(spell);
               if (upgrade) {
                 this.forceUpgrade(globalThis.player, upgrade, false);

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2084,12 +2084,7 @@ export default class Underworld {
       // setTimeout allows the UI to refresh before locking up the CPU with
       // heavy level generation code
       setTimeout(() => {
-        if (this.lastLevelCreated?.levelIndex == levelIndex) {
-          resolve(this.lastLevelCreated);
-          console.warn('Setup: Shortcircuit generateLevelData; returning already generated level data');
-        } else {
-          resolve(this.generateLevelDataSyncronous(levelIndex, this.gameMode));
-        }
+        resolve(this.generateLevelDataSyncronous(levelIndex, this.gameMode));
       }, 10);
     }).then(() => {
       this.generatingLevel = false;

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -638,7 +638,6 @@ export default class Underworld {
   }
 
   // TODO - Refactor / Remove this
-
   // returns true if there is more processing yet to be done on the next game loop
   gameLoopUnit = (u: Unit.IUnit, aliveNPCs: Unit.IUnit[], deltaTime: number): boolean => {
     if (u) {
@@ -2220,7 +2219,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
       }
 
-      // TODO - Full Turn Cycle
+      // TODO - Full Turn Cycle? Handled in initializeTurnPhase()?
       // this.endFullTurnCycle();
     }
 

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -255,6 +255,11 @@ export default class Underworld {
 
     this.random = this.syncronizeRNG(RNGState);
   }
+  clientIdToPlayer(clientId: string): Player.IPlayer | undefined {
+    const playerId = clientId + "_" + this.hotseatCurrentPlayerIndex;
+    const player = this.players.find(p => p.playerId == playerId);
+    return player;
+  }
   // Returns all potentially targetable entities
   // See cards/index.ts's getCurrentTargets() for the function that returns 
   // the current targets of a spell.
@@ -1112,10 +1117,9 @@ export default class Underworld {
     if (globalThis.thinkingPlayerGraphics) {
       containerPlayerThinking?.addChild(globalThis.thinkingPlayerGraphics);
     }
-    for (let [thinkerClientId, thought] of Object.entries(this.playerThoughts)) {
+    for (let [thinkerId, thought] of Object.entries(this.playerThoughts)) {
       const { target, cardIds, ellipsis } = thought;
-      const thinkingPlayerIndex = this.players.findIndex(p => p.clientId == thinkerClientId);
-      const thinkingPlayer = this.players[thinkingPlayerIndex];
+      const thinkingPlayer = this.players.find(p => p.playerId == thinkerId);
       if (thinkingPlayer && thinkingPlayer.isSpawned) {
         // Leave room for name tag
         const yMargin = 10;
@@ -1354,7 +1358,6 @@ export default class Underworld {
       this
     );
     unit.originalLife = true;
-
   }
   testLevelData(): LevelData {
     const baseTileValues = Object.values(baseTiles);
@@ -2142,85 +2145,77 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
   }
 
-  // TODO - Move to update turn phase
-  tryGameOver(): boolean {
-    // Clear previous timeout that would toggle game over state
-    if (gameOverModalTimeout !== undefined) {
-      clearTimeout(gameOverModalTimeout);
-    }
-    const isOver = this.isGameOver();
-    if (!isOver) {
-      // If clearing the game-over modal, clear it immediately
-      document.body.classList.toggle('game-over', isOver);
-    } else {
-      // Show game over modal after a delay
-      gameOverModalTimeout = setTimeout(() => {
-        document.body.classList.toggle('game-over', isOver);
-        // allowForceInitGameState so that when the game restarts it will get the full
-        // newly created underworld
-        this.allowForceInitGameState = true;
-      }, 3000);
-    }
+  doGameOver() {
+    console.log("- - -\nGame Over\n- - -");
+    // Show game over modal after a delay
+    gameOverModalTimeout = setTimeout(() => {
+      document.body.classList.toggle('game-over', true);
+      // allowForceInitGameState so that when the game restarts
+      // it will get the full newly created underworld
+      this.allowForceInitGameState = true;
+    }, 2000);
+
     this.updateGameOverModal();
     if (globalThis.headless) {
-      if (isOver) {
-        const overworld = this.overworld;
-        const pie = this.pie;
-        // Only allow it to start the process of creating a new underworld once
-        // because this function tryGameOver should be able to be called any number
-        // of times and only the first time that it detects game over should it trigger
-        // a new game
-        if (!this.isRestarting) {
-          const millisTillRestart = 10000;
-          console.log('-------------------Host app game over', isOver, `restarting in ${Math.floor(millisTillRestart / 1000)} seconds`);
-          this.isRestarting = setTimeout(() => {
-            const newUnderworld = new Underworld(overworld, pie, Math.random().toString());
-            // Add players back to underworld
-            // defaultLobbyReady: Since they are still in the game, set them to lobbyReady
-            ensureAllClientsHaveAssociatedPlayers(overworld, overworld.clients, true);
-            // Generate the level data
-            newUnderworld.lastLevelCreated = newUnderworld.generateLevelDataSyncronous(0, this.gameMode);
-            // Actually create the level 
-            newUnderworld.createLevelSyncronous(newUnderworld.lastLevelCreated);
-            this.overworld.clients.forEach(clientId => {
-              hostGiveClientGameState(clientId, newUnderworld, newUnderworld.lastLevelCreated, MESSAGE_TYPES.INIT_GAME_STATE);
-            });
-          }, millisTillRestart);
-        }
-      } else {
-        // If no longer game over, clear restarting timer
-        if (this.isRestarting) {
-          clearTimeout(this.isRestarting);
-        }
+      const overworld = this.overworld;
+      const pie = this.pie;
+      if (!this.isRestarting) {
+        const millisTillRestart = 10000;
+        console.log('-------------------Host app game over', true, `restarting in ${Math.floor(millisTillRestart / 1000)} seconds`);
+        this.isRestarting = setTimeout(() => {
+          const newUnderworld = new Underworld(overworld, pie, Math.random().toString());
+          // Add players back to underworld
+          // defaultLobbyReady: Since they are still in the game, set them to lobbyReady
+          ensureAllClientsHaveAssociatedPlayers(overworld, overworld.clients, true);
+          // Generate the level data
+          newUnderworld.lastLevelCreated = newUnderworld.generateLevelDataSyncronous(0, this.gameMode);
+          // Actually create the level 
+          newUnderworld.createLevelSyncronous(newUnderworld.lastLevelCreated);
+          this.overworld.clients.forEach(clientId => {
+            hostGiveClientGameState(clientId, newUnderworld, newUnderworld.lastLevelCreated, MESSAGE_TYPES.INIT_GAME_STATE);
+          });
+        }, millisTillRestart);
       }
     }
-    return isOver;
   }
 
   // Handles level completion, game over, turn phases, and hotseat
   async progressGameState() {
-    console.log("Current turn phase == ", this.turn_phase);
+    console.log("ProgressGameState:\nTurn Phase before progress == ", turn_phase[this.turn_phase]);
 
-    if (this.tryProgressLevelState()) return;
-    else if (this.tryGameOver()) return;
+    // try game over
+    // else try next level
+    // else try level progress
+    // else cycle turn phase
 
-    if (this.turn_phase == turn_phase.PlayerTurns) {
-      // If all hotseat players are ready, try end player turn
-      await this.handleNextHotseatPlayer();
+    if (this.isGameOver()) {
+      console.log("ProgressGameState:\nGame is over");
+      this.doGameOver();
+    }
+    else if (this.handleLevelProgress()) {
+      console.log("ProgressGameState:\nLevel Progressed");
+    }
+    else {
+      if (this.turn_phase == turn_phase.PlayerTurns) {
+        // If all hotseat players are ready, try end player turn
+        await this.handleNextHotseatPlayer();
 
-      // Moves to NPC.ALLY Phase if possible
-      await this.tryEndPlayerTurnPhase();
-    } else if (this.turn_phase == turn_phase.NPC_ALLY) {
+        // Moves to NPC.ALLY Phase if possible
+        await this.tryEndPlayerTurnPhase();
+      } else if (this.turn_phase == turn_phase.NPC_ALLY) {
 
-    } else if (this.turn_phase == turn_phase.NPC_ENEMY) {
+      } else if (this.turn_phase == turn_phase.NPC_ENEMY) {
 
-    } else if (this.turn_phase == turn_phase.Stalled) {
+      } else if (this.turn_phase == turn_phase.Stalled) {
 
+      }
+
+      // TODO - Full Turn Cycle
+      // this.endFullTurnCycle();
     }
 
-    console.log("New turn phase == ", this.turn_phase);
-    // TODO - Full Turn Cycle
-    // this.endFullTurnCycle();
+    console.log("ProgressGameState:\nTurn Phase after progress == ", turn_phase[this.turn_phase]);
+    return;
   }
 
   async handleNextHotseatPlayer() {
@@ -2266,12 +2261,14 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
   }
 
   async changeToHotseatPlayer(player: Player.IPlayer) {
+    console.log("Change to hotseat player: " + player.playerId);
+
     // If the next player has already completed turn or can't act
     // get the next hotseat player
     if (this.hasCompletedTurn(player)) this.handleNextHotseatPlayer();
 
     // Otherwise, set up hotseat player
-    Player.updateGlobalRefToCurrentClientPlayer(player, this);
+    Player.updateGlobalRefToPlayer(player);
     CardUI.recalcPositionForCards(globalThis.player, this);
     CardUI.syncInventory(undefined, this);
     await runPredictions(this);
@@ -2366,7 +2363,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       }
     }
     else {
-      this.tryProgressLevelState();
+      this.progressGameState();
       //this.broadcastTurnPhase(turn_phase.PlayerTurns);
     }
     return true;
@@ -2583,10 +2580,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
   }
 
+  // TODO - What is this?
   syncTurnMessage() {
     console.log('syncTurnMessage: phase:', turn_phase[this.turn_phase]);
     let yourTurn = false;
-    if (!this.tryGameOver() && this.turn_phase === turn_phase.PlayerTurns) {
+    if (!this.isGameOver() && this.turn_phase === turn_phase.PlayerTurns) {
       if (!globalThis.player?.endedTurn) {
         yourTurn = true;
       }
@@ -2649,15 +2647,10 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       }
     }
   }
-  async endPlayerTurn(clientId: string) {
+  async endPlayerTurn(player: Player.IPlayer) {
     if (this.turn_phase == turn_phase.Stalled) {
       // Do not end a players turn while game is Stalled or it will trigger
       // an exit of the Stalled phase and that should ONLY happen when a player reconnects
-      return;
-    }
-    const player = this.players.find(p => p.clientId == clientId);
-    if (!player) {
-      console.error('Cannot end turn, player with clientId:', clientId, 'does not exist');
       return;
     }
     if (this.turn_phase != turn_phase.PlayerTurns) {
@@ -2774,13 +2767,15 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       }
 
       switch (player.mageType) {
-        case 'Timemason':
+        case 'Timemason': {
           statBumpAmount.manaMax *= 2;
           break;
-        case 'Far Gazer':
+        }
+        case 'Far Gazer': {
           statBumpAmount.attackRange *= 2;
           statBumpAmount.staminaMax = Math.floor(statBumpAmount.staminaMax as number / 2);
           break;
+        }
       }
 
       if (stat && player.unit[stat as keyof Unit.IUnit]) {
@@ -2834,6 +2829,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
   }
 
+  // TODO - Somehow if two hotseat players are dead
+  // p1 has chosen upgrades, p2 hasn't
+  // it shows p1 the upgrade screen and gives error
+  // pick upgrades without being able to
+  // likely something to do with globalThis.player and the hotseat index
   showUpgrades() {
     // Remove additional pickups once upgrades are shown because it will allow players to pick all upgrades on map
     for (let p of this.pickups) {
@@ -3048,44 +3048,6 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       elUpgradePickerContent.appendChild(elRerollPerks);
     }
   }
-
-  // Returns true if it goes to the next level
-  checkForEndOfLevel(): boolean {
-    // All living (and client connected) players
-    // Also check if they are spawned, otherwise in multiplayer,
-    // it will cycle through level after level quickly and infinitely
-    // because all players are in the portal and alive.  Adding the isSpawned
-    // check ensures that it will only move on once all connected players have
-    // spawned and are in the portal
-    const livingSpawnedPlayers = this.players.filter(
-      (p) => p.unit.alive && p.clientConnected && p.isSpawned,
-    );
-    const areAllLivingPlayersInPortal =
-      livingSpawnedPlayers.filter(Player.inPortal).length === livingSpawnedPlayers.length;
-
-    // If any player enters a portal during hotseat multiplayer just go to the next level, don't make all players
-    // enter the portal.  This prevents a LOT of weird conditions that would make the game get stuck in a state it
-    // can't get out of
-    const hotseatOverride = numberOfHotseatPlayers > 1 && livingSpawnedPlayers.some(Player.inPortal);
-    // Advance the level if there are living players and they all are in the portal:
-    if (hotseatOverride || (livingSpawnedPlayers.length && areAllLivingPlayersInPortal)) {
-      console.log('All living, spawned players are inPortal, go to the next level');
-      // Invoke initLevel within a timeout so that this function
-      // doesn't have to wait for level generation to complete before
-      // returning
-      setTimeout(() => {
-        // Prepare the next level
-        if (globalThis.isHost(this.pie)) {
-          this.generateLevelData(this.levelIndex + 1);
-        } else {
-          console.log('This instance is not host, host will trigger next level generation.');
-        }
-      }, 0);
-      // Return of true signifies it went to the next level
-      return true;
-    }
-    return false;
-  }
   getRandomCoordsWithinBounds(bounds: Limits, seed?: prng): Vec2 {
     const x = randInt(bounds.xMin || 0, bounds.xMax || 0, seed || this.random);
     const y = randInt(bounds.yMin || 0, bounds.yMax || 0, seed || this.random);
@@ -3193,49 +3155,54 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     this.pickups = keepPickups;
 
     const phase = turn_phase[this.turn_phase];
-    if (phase) {
-      switch (phase) {
-        case turn_phase[turn_phase.PlayerTurns]:
-          if (this.players.every(p => !p.clientConnected)) {
-            // This is the only place where the turn_phase can become Stalled, when it is supposed
-            // to be player turns but there are no players connected.
-            // Note: the Stalled turn_phase should be set immediately, not broadcast
-            // This is an exception because if the game is stalled, by definition, there
-            // are no players to broadcast to.
-            // Setting it immediately ensures that any following messages in the queue won't reengage
-            // the turn_phase loop, causing an infinite loop
-            this.turn_phase = turn_phase.Stalled;
-            console.log('Turn Management: Skipping initializingPlayerTurns, no players connected. Setting turn_phase to "Stalled"');
-          } else {
-            // Initialize the player turns.
-            // Note, it is possible that calling this will immediately end
-            // the player phase (if there are no players to take turns)
-            await this.executePlayerTurn();
-          }
-          // Note: The player turn occurs asyncronously because it depends on player input so the call to
-          // `broadcastTurnPhase(turn_phase.NPC_ALLY)` happens inside tryEndPlayerTurnPhase(); whereas the other blocks in
-          // this switch statement always move to the next faction turn on their last line before the break, but this one does
-          // not.
-          break;
-        case turn_phase[turn_phase.NPC_ALLY]:
-          await this.executeNPCTurn(Faction.ALLY);
-          this.broadcastTurnPhase(turn_phase.NPC_ENEMY);
-          break;
-        case turn_phase[turn_phase.NPC_ENEMY]:
-          await this.executeNPCTurn(Faction.ENEMY);
-          await this.endFullTurnCycle();
-          this.broadcastTurnPhase(turn_phase.PlayerTurns);
-          break;
-        default:
-          break;
-      }
-      // Sync player health, mana, stamina bars to ensure that it's up to date
-      // at the start of any turn_phase so there's no suprises
-      this.syncPlayerPredictionUnitOnly();
-      Unit.syncPlayerHealthManaUI(this);
-    } else {
-      console.error('Invalid turn phase', this.turn_phase)
+    if (!phase) {
+      console.error('Invalid turn phase', this.turn_phase);
+      return;
     }
+
+    switch (phase) {
+      case turn_phase[turn_phase.PlayerTurns]: {
+        if (this.players.every(p => !p.clientConnected)) {
+          // This is the only place where the turn_phase can become Stalled, when it is supposed
+          // to be player turns but there are no players connected.
+          // Note: the Stalled turn_phase should be set immediately, not broadcast
+          // This is an exception because if the game is stalled, by definition, there
+          // are no players to broadcast to.
+          // Setting it immediately ensures that any following messages in the queue won't reengage
+          // the turn_phase loop, causing an infinite loop
+          this.turn_phase = turn_phase.Stalled;
+          console.log('Turn Management: Skipping initializingPlayerTurns, no players connected. Setting turn_phase to "Stalled"');
+        } else {
+          // Initialize the player turns.
+          // Note, it is possible that calling this will immediately end
+          // the player phase (if there are no players to take turns)
+          await this.executePlayerTurn();
+        }
+        // Note: The player turn occurs asyncronously because it depends on player input so the call to
+        // `broadcastTurnPhase(turn_phase.NPC_ALLY)` happens inside tryEndPlayerTurnPhase(); whereas the other blocks in
+        // this switch statement always move to the next faction turn on their last line before the break, but this one does
+        // not.
+        break;
+      }
+      case turn_phase[turn_phase.NPC_ALLY]: {
+        await this.executeNPCTurn(Faction.ALLY);
+        this.broadcastTurnPhase(turn_phase.NPC_ENEMY);
+        break;
+      }
+      case turn_phase[turn_phase.NPC_ENEMY]: {
+        await this.executeNPCTurn(Faction.ENEMY);
+        await this.endFullTurnCycle();
+        this.broadcastTurnPhase(turn_phase.PlayerTurns);
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+    // Sync player health, mana, stamina bars to ensure that it's up to date
+    // at the start of any turn_phase so there's no suprises
+    this.syncPlayerPredictionUnitOnly();
+    Unit.syncPlayerHealthManaUI(this);
   }
   // Smart Targeting, fn 1
   clearPredictedNextTurnDamage() {
@@ -3635,9 +3602,14 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
     return effectState;
   }
-  tryProgressLevelState(): boolean {
+  handleLevelProgress(): boolean {
+    // Returns true if this function progresses the level state
+    // - Spawns the next wave of enemies
+    // - Spawns Purple Portals
+    // - Sends Players to Next Level
+
     // If all enemy units are dead and at least one player is spawned and connected
-    const shouldProgressLevelState = this.units.filter(u =>
+    const canProgress = this.units.filter(u =>
       u.faction == Faction.ENEMY &&
       !u.flaggedForRemoval &&
       u.unitSubType !== UnitSubType.DOODAD)
@@ -3648,8 +3620,9 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           p.isSpawned &&
           p.clientConnected)
 
-    if (!shouldProgressLevelState) return false;
+    if (!canProgress) return false;
 
+    // Should another wave of enemies be spawned?
     const loopIndex = Math.max(0, (this.levelIndex - config.LAST_LEVEL_INDEX));
     if (loopIndex > this.wave) {
       this.wave++;
@@ -3658,13 +3631,13 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       this.units.filter(u => u.unitType == UnitType.AI && !u.alive).forEach(u => {
         Unit.addModifier(u, corpseDecayId, this, false);
       });
-      const unitIds = getEnemiesForAltitude(this, this.levelIndex);
-      const numberOfMinibossesAllowed = Math.ceil(Math.max(0, (this.levelIndex - 4) / 4));
-      let numberOfMinibossesMade = 0;
       // Trick for finding valid spawnable tiles
       const validSpawnCoords = this.lastLevelCreated?.imageOnlyTiles.filter(x => x.image.endsWith('all_ground.png')) || [];
 
       // Copied from generateRandomLevelData
+      const unitIds = getEnemiesForAltitude(this, this.levelIndex);
+      const numberOfMinibossesAllowed = Math.ceil(Math.max(0, (this.levelIndex - 4) / 4));
+      let numberOfMinibossesMade = 0;
       for (let id of unitIds) {
         if (validSpawnCoords.length == 0) { break; }
         const validSpawnCoordsIndex = randInt(0, validSpawnCoords.length - 1, this.random);
@@ -3678,33 +3651,87 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           if (isMiniboss) {
             numberOfMinibossesMade++;
           }
-          const sourceUnit = allUnits[id];
-          if (sourceUnit) {
-            Unit.create(
-              sourceUnit.id,
-              // Start the unit at the summoners location
-              coord.x,
-              coord.y,
-              // A unit always summons units in their own faction
-              Faction.ENEMY,
-              sourceUnit.info.image,
-              UnitType.AI,
-              sourceUnit.info.subtype,
-              sourceUnit.unitProps,
-              this
-            );
-            skyBeam(coord);
-          } else {
-            console.error('Cannot create unit, missing source unit for', id)
-          }
+          this.spawnEnemy(id, coord, isMiniboss)
         }
       }
       // end Copied from generateRandomLevelData
+
+      // Spawned enemies and progressed the level, return true
+      return true;
     }
 
-    return true;
-  }
+    // No wave to spawn, so spawn portals
+    const portalsAlreadySpawned = !!this.pickups.filter(p => !p.flaggedForRemoval && !isNaN(p.x) && !isNaN(p.x)).find(p => p.name === Pickup.PORTAL_PURPLE_NAME);
+    if (!portalsAlreadySpawned) {
+      // Make all potion pickups disappear so as to not compell players
+      // to waste time walking around picking them all up
+      // Also do not remove portals
+      this.pickups.filter(p => p.name !== Pickup.CARDS_PICKUP_NAME && p.name !== Pickup.PORTAL_PURPLE_NAME).forEach(p => {
+        makeScrollDissapearParticles(p, false);
+        Pickup.removePickup(p, this, false);
+      });
+      // Spawn portal near each player
+      const portalPickup = Pickup.pickups.find(p => p.name == Pickup.PORTAL_PURPLE_NAME);
+      if (portalPickup) {
+        const portalsAlreadySpawned = !!this.pickups.filter(p => !p.flaggedForRemoval && !isNaN(p.x) && !isNaN(p.x)).find(p => p.name === Pickup.PORTAL_PURPLE_NAME)
+        if (!portalsAlreadySpawned) {
+          for (let playerUnit of this.units.filter(u => u.unitType == UnitType.PLAYER_CONTROLLED && u.alive)) {
+            const portalSpawnLocation = this.findValidSpawn(playerUnit, 4) || playerUnit;
+            if (!isOutOfBounds(portalSpawnLocation, this)) {
+              Pickup.create({ pos: portalSpawnLocation, pickupSource: portalPickup, logSource: 'Portal' }, this, false);
+            } else {
+              // If a pickup is attempted to be spawned for an unspawned player this if check prevents it from being spawned out of bounds
+              // and the next invokation of checkIfShouldSpawnPortal will spawn it instead.
+            }
+            // Give all player units infinite stamina when portal spawns for convenience.
+            playerUnit.stamina = Number.POSITIVE_INFINITY;
+            // Give all players max health and mana (it will be reset anyway when they are reset for the next level
+            // but this disswades them from going around to pickup potions)
+            playerUnit.health = playerUnit.healthMax;
+            playerUnit.mana = playerUnit.manaMax;
+            // Since playerUnit's health and mana is reset, we need to immediately sync the prediction unit
+            // so that it doesn't inncorrectly warn "self damage due to spell" by seeing that the prediction unit
+            // has less health than the current player unit.
+            this.syncPlayerPredictionUnitOnly();
 
+          }
+        } else {
+          console.log('Portals have already been spawned, do not spawn additional');
+        }
+      } else {
+        console.error('Portal pickup not found')
+      }
+
+      // Spawned portals and progressed the level, return true
+      return true;
+    }
+
+    // Go To Next Level
+    // - If all connected players are in portal or done with turn
+    // - If in hotseat and at least one player is in portal
+    const connectedPlayers = this.players.filter(p => p.clientConnected);
+    const goToNextLevel =
+      connectedPlayers.every(p => Player.inPortal(p) || this.hasCompletedTurn(p))
+      || (numberOfHotseatPlayers > 1 && connectedPlayers.some(Player.inPortal));
+    if (goToNextLevel) {
+      console.log('All living, spawned players are inPortal, go to the next level');
+      // Invoke initLevel within a timeout so that this function
+      // doesn't have to wait for level generation to complete before
+      // returning
+      setTimeout(() => {
+        // Prepare the next level
+        if (globalThis.isHost(this.pie)) {
+          this.generateLevelData(this.levelIndex + 1);
+        } else {
+          console.log('This instance is not host, host will trigger next level generation.');
+        }
+      }, 0);
+      // Return of true signifies it went to the next level
+      return true;
+    }
+
+    return false;
+  }
   // hasLineOfSight returns true if there are no walls interrupting
   // a line from seer to target
   // Note: if you want a function like this that returns a Vec2, try
@@ -3798,7 +3825,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     sendPlayerThinkingThrottled(thoughts, this);
   }
   syncPlayers(players: Player.IPlayerSerialized[], isClientPlayerSourceOfTruth: boolean) {
-    console.log('sync: Syncing players', JSON.stringify(players.map(p => p.clientId)));
+    console.log('sync: Syncing players', JSON.stringify(players.map(p => p.playerId)));
     // Clear previous players array
     const previousPlayersLength = this.players.length;
     players.forEach((p, i) => Player.load(p, i, this, isClientPlayerSourceOfTruth));

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2651,7 +2651,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     // It's possible that all players are dead, frozen, etc.
     // When the level is completed, and in that case,
     // we can skip spawning portals and go to next levlel
-    const remainingPlayers = this.players.filter(p => !this.hasCompletedTurn(p));
+    const remainingPlayers = this.players.filter(p => p.isSpawned && !this.hasCompletedTurn(p));
     if (remainingPlayers.length > 0) {
       const spawnedPortals = this.pickups.filter(p => !p.flaggedForRemoval && p.name === Pickup.PORTAL_PURPLE_NAME);
       if (spawnedPortals.length <= 0) {
@@ -2670,7 +2670,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           for (let playerUnit of remainingPlayers.map(p => p.unit)) {
             const portalSpawnLocation = this.findValidSpawn(playerUnit, 4) || playerUnit;
             if (!isOutOfBounds(portalSpawnLocation, this)) {
-              Pickup.create({ pos: portalSpawnLocation, pickupSource: portalPickup, logSource: 'Portal' }, this, false);
+              spawnedPortals.push(Pickup.create({ pos: portalSpawnLocation, pickupSource: portalPickup, logSource: 'Portal' }, this, false));
             }
             // Give all player units infinite stamina when portal spawns for convenience.
             playerUnit.stamina = Number.POSITIVE_INFINITY;
@@ -2683,7 +2683,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
             // has less health than the current player unit.
             this.syncPlayerPredictionUnitOnly();
           }
-          console.log('[GAME] Level Progressed\nSpawned portals');
+          console.log('[GAME] Level Progressed\nSpawned portals: ', spawnedPortals);
           return true;
         } else {
           console.error('[GAME] Handling Level Progress...\nPortal pickup not found')

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -645,9 +645,12 @@ export default class Underworld {
     }
     return !finishedForceMoves;
   }
+
+  // TODO - Refactor / Remove this
+
   // returns true if there is more processing yet to be done on the next game loop
   gameLoopUnit = (u: Unit.IUnit, aliveNPCs: Unit.IUnit[], deltaTime: number): boolean => {
-    if (u.alive) {
+    if (u) {
       while (u.path && u.path.points[0] && Vec.equal(Vec.round(u), Vec.round(u.path.points[0]))) {
         // Remove next points until the next point is NOT equal to the unit's current position
         // This prevent's "jittery" "slow" movement where it's moving less than {x:1.0, y:1.0}
@@ -655,9 +658,10 @@ export default class Underworld {
         // moving when it reaches the target which may be less than 1.0 and 1.0 away.
         u.path.points.shift();
       }
-      // Only allow movement if the unit has stamina and it is their turn
-      const isUnitsTurn = Unit.isUnitsTurnPhase(u, this);
-      if (u.path && u.path.points[0] && u.stamina > 0 && isUnitsTurn) {
+
+      // Only allow if the unit can act and it is their turn
+      const takeAction = Unit.canAct(u) && Unit.isUnitsTurnPhase(u, this);
+      if (u.path && u.path.points[0] && u.stamina > 0 && takeAction) {
         // Move towards target
         const stepTowardsTarget = math.getCoordsAtDistanceTowardsTarget(u, u.path.points[0], u.moveSpeed * deltaTime)
         let moveDist = 0;
@@ -719,10 +723,6 @@ export default class Underworld {
         }
         // done processing this unit for this unit's turn
         return false;
-      } else {
-        if (!isUnitsTurn) {
-          u.stamina = 0;
-        }
       }
     } else {
       // Unit is dead, no processing to be done
@@ -1964,11 +1964,12 @@ export default class Underworld {
       ['Level', this.getLevelText()],
       'white'
     );
-    console.log('Setup: resetPlayerForNextLevel; reset all players')
 
+    console.log('Setup: resetPlayerForNextLevel; reset all players')
     for (let player of this.players) {
       Player.resetPlayerForNextLevel(player, this);
     }
+    this.changeToFirstHotseatPlayer();
 
     // Give players stat points to spend:
     // For first play session don't show stat upgrades too early, it's information overload
@@ -1992,6 +1993,8 @@ export default class Underworld {
     // be set BEFORE postSetupLevel is invoked because postSetupLevel will send a sync message
     // that will override the clientside data.
     this.postSetupLevel();
+
+
   }
   _getLevelText(levelIndex: number): string {
     if (levelIndex > LAST_LEVEL_INDEX) {
@@ -2138,6 +2141,8 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
 
   }
+
+  // TODO - Move to update turn phase
   tryGameOver(): boolean {
     // Clear previous timeout that would toggle game over state
     if (gameOverModalTimeout !== undefined) {
@@ -2192,20 +2197,24 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     return isOver;
   }
 
-  async updateTurnPhase() {
+  // Handles level completion, game over, turn phases, and hotseat
+  async progressGameState() {
     console.log("Current turn phase == ", this.turn_phase);
 
-    if (this.turn_phase === turn_phase.PlayerTurns) {
+    if (this.tryProgressLevelState()) return;
+    else if (this.tryGameOver()) return;
+
+    if (this.turn_phase == turn_phase.PlayerTurns) {
       // If all hotseat players are ready, try end player turn
       await this.handleNextHotseatPlayer();
 
       // Moves to NPC.ALLY Phase if possible
       await this.tryEndPlayerTurnPhase();
-    } else if (this.turn_phase === turn_phase.NPC_ALLY) {
+    } else if (this.turn_phase == turn_phase.NPC_ALLY) {
 
-    } else if (this.turn_phase === turn_phase.NPC_ENEMY) {
+    } else if (this.turn_phase == turn_phase.NPC_ENEMY) {
 
-    } else if (this.turn_phase === turn_phase.Stalled) {
+    } else if (this.turn_phase == turn_phase.Stalled) {
 
     }
 
@@ -2219,27 +2228,41 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     if (!(numberOfHotseatPlayers > 1)) return;
 
     // If current player hasn't completed their turn, return
-    // We do this outside of the loop because we don't want to
-    // call changeToHotseatPlayer if that player is already set up
+    // We don't want to change hotseat players unless current player is done
     let currentPlayer = this.players[this.hotseatCurrentPlayerIndex];
     if (currentPlayer && !this.hasCompletedTurn(currentPlayer)) {
       return;
     }
 
     // Change to the next hotseat player that hasn't completed their turn
-    while (this.hotseatCurrentPlayerIndex < this.players.length - 1) {
-      this.hotseatCurrentPlayerIndex = (this.hotseatCurrentPlayerIndex + 1) % this.players.length;
-      const currentPlayer = this.players[this.hotseatCurrentPlayerIndex];
+    for (let i = 0; i < this.players.length; i++) {
+      // TODO - Remove hotseat current player index?
+      this.hotseatCurrentPlayerIndex = i;
+      const currentPlayer = this.players[i];
       // Found a player that has not completed their turn, switch to them
       if (currentPlayer && !this.hasCompletedTurn(currentPlayer)) {
-        console.log("PlayerTurn: Switching to hotseat player: ", currentPlayer.clientId);
+        console.log("PlayerTurn: Switching to hotseat player: ", currentPlayer);
         await this.changeToHotseatPlayer(currentPlayer);
         return;
       }
-      // Player doesn't exist or already completed turn, continue looping
     }
 
+    // TODO - Switch back to player 1 in prep for next turn?
     console.log("PlayerTurn: All remaining hotseat players have completed their turn");
+  }
+
+  async changeToFirstHotseatPlayer() {
+    if (!(numberOfHotseatPlayers > 1)) return;
+
+    console.log("Change to first hotseat player");
+    const firstPlayer = this.players[0];
+    if (firstPlayer) {
+      this.hotseatCurrentPlayerIndex = 0;
+      this.changeToHotseatPlayer(firstPlayer)
+    }
+    else {
+      console.error("Unexpected: Hotseat player doesn't exist");
+    }
   }
 
   async changeToHotseatPlayer(player: Player.IPlayer) {
@@ -2252,7 +2275,6 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     CardUI.recalcPositionForCards(globalThis.player, this);
     CardUI.syncInventory(undefined, this);
     await runPredictions(this);
-    this.checkIfShouldSpawnPortal();
 
     // For hotseat, whenever a player ends their turn, check if the current player
     // has upgrades to choose and if so, show the upgrade button
@@ -2273,11 +2295,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     // - Has not spawned
     // - Can act and has not ended turn (alive, not frozen, etc.)
     if (!player.isSpawned) {
-      console.log('PlayerTurn: player has not spawned yet: ', player.clientId);
+      console.log('PlayerTurn: player has not spawned yet: ', player);
       return false;
     }
     if (Unit.canAct(player.unit) && !player.endedTurn) {
-      console.log('PlayerTurn: player can act and has not ended turn yet: ', player.clientId);
+      console.log('PlayerTurn: player can act and has not ended turn yet: ', player);
       return false;
     }
     return true;
@@ -2331,7 +2353,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
     CardUI.updateCardBadges(this);
 
-    await Unit.endTurnForUnits(this.players.map(p => p.unit), this);
+    await Unit.endTurnForUnits(this.players.map(p => p.unit), this, false);
 
     // Move to next phase depending on remaining units
     // NPC_ALLY, NPC_ENEMY, or portal state
@@ -2344,13 +2366,64 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       }
     }
     else {
-      this.checkIfShouldSpawnPortal();
+      this.tryProgressLevelState();
       //this.broadcastTurnPhase(turn_phase.PlayerTurns);
     }
     return true;
   }
 
-  async executeFactionTurn(faction: Faction) {
+  async executePlayerTurn() {
+    await Unit.startTurnForUnits(this.players.map(p => p.unit), this, false);
+
+    for (let player of this.players) {
+      player.endedTurn = false;
+
+      if (player == globalThis.player && globalThis.player.isSpawned) {
+        // Notify the current player that their turn is starting
+        queueCenteredFloatingText(`Your Turn`);
+        // Don't play turn sfx when recording
+        if (!globalThis.isHUDHidden && !document.body?.classList.contains('hide-card-holders')) {
+          playSFXKey('yourTurn');
+        }
+      }
+
+      // TODO - Why is this here?
+      // Trigger attributePerks
+      const perkRandomGenerator = seedrandom(getUniqueSeedString(this, player));
+      for (let i = 0; i < player.attributePerks.length; i++) {
+        const perk = player.attributePerks[i];
+        if (perk) {
+          tryTriggerPerk(perk, player, 'everyTurn', perkRandomGenerator, this, 700 * i);
+        }
+      }
+    }
+    this.syncTurnMessage();
+    // Update unit health / mana bars, etc
+    await runPredictions(this);
+
+    // Quicksave at the beginning of player's turn
+    // Check globalThis.player.isSpawned to prevent quicksaving an invalid underworld file
+    if (globalThis.save && globalThis.player && globalThis.player.isSpawned) {
+      // For now, only save if in a singleplayer game
+      // because save support hasn't been added to multiplayer yet
+      if (isSinglePlayer()) {
+        console.info(`Dev: quick saving game as "${globalThis.quicksaveKey}"`);
+        // Force overwrite for quicksave, never prompt "are you sure?" when auto saving a quicksave
+        globalThis.save(globalThis.quicksaveKey, true);
+      }
+    }
+
+    // If there was an attempted save during the enemy turn, save now
+    // that the player's turn has started
+    if (globalThis.saveASAP && globalThis.save) {
+      globalThis.save(globalThis.saveASAP);
+    }
+
+    this.changeToFirstHotseatPlayer();
+    this.progressGameState();
+  }
+
+  async executeNPCTurn(faction: Faction) {
     cleanUpEmitters(true);
     // Clear unit attentionMarkers since it's not the player's turn
     globalThis.attentionMarkers = [];
@@ -2358,16 +2431,79 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
     const units = this.units.filter(u => u.unitType == UnitType.AI && u.faction == faction);
 
-    // Only execute turn if there are units to take the turn:
-    if (units.filter(u => Unit.canAct(u)).length) {
-      // Run AI unit actions
-      await this.executeNPCTurn(faction);
-    } else {
-      console.log('Turn Management: Skipping executingNPCTurn for ', faction);
+    console.log('game: executeNPCTurn', Faction[faction]);
+    const cachedTargets: { [id: number]: { targets: Unit.IUnit[], canAttack: boolean } } = {};
+    this.clearPredictedNextTurnDamage();
+    await Unit.startTurnForUnits(units, this, false);
+
+    // Loop through planned unit actions for smart targeting
+    for (let u of units.filter(u => Unit.canAct(u))) {
+      const unitSource = allUnits[u.unitSourceId];
+      if (unitSource) {
+        const targets = unitSource.getUnitAttackTargets(u, this);
+        const canAttack = this.canUnitAttackTarget(u, targets && targets[0])
+        cachedTargets[u.id] = { targets, canAttack };
+        this.incrementTargetsNextTurnDamage(targets, u.damage, canAttack);
+        if (unitSource.id == PRIEST_ID) {
+          // Signal to other priests that this one is targeted for resurrection
+          // so multiple priests don't try to ressurect the same target
+          this.incrementTargetsNextTurnDamage(targets, -u.healthMax, true);
+        }
+      }
+      u.stamina = 0;
+    }
+
+    // TODO - Remove stamina workaround
+
+    // TODO - Don't control actions directly in gameLoopUnit / Refactor
+
+    // which causes issues with turn order
+    // i.e. melee units moving during the ranged units' turn
+    for (let subTypes of [[UnitSubType.RANGED_LOS, UnitSubType.RANGED_RADIUS, UnitSubType.SUPPORT_CLASS], [UnitSubType.MELEE], [UnitSubType.SPECIAL_LOS], [UnitSubType.DOODAD]]) {
+      const actionPromises: Promise<void>[] = [];
+      const readyToTakeTurnUnits = units.filter(u => Unit.canAct(u) && subTypes.includes(u.unitSubType));
+
+      for (let u of readyToTakeTurnUnits) {
+        u.stamina = u.staminaMax;
+        // Units should have their previous path cleared so that their .action can set their path if 
+        // they should move this turn.
+        // Note: This resolves a headless server desync where units go through a complete gameloop before their
+        // .action sets moveTowards, so if they had an existing path, they move on the server but not on the client
+        u.path = undefined;
+
+        const unitSource = allUnits[u.unitSourceId];
+        if (unitSource) {
+          const { targets, canAttack } = cachedTargets[u.id] || { targets: [], canAttack: false };
+          // Add unit action to the array of promises to wait for
+          let promise = raceTimeout(5000, `Unit.action; unitSourceId: ${u.unitSourceId}; subType: ${u.unitSubType}`, unitSource.action(u, targets, this, canAttack).then(async (actionResult) => {
+            // Ensure ranged units get out of liquid so they don't take DOT
+            // This doesn't apply to melee units since they will automatically move towards you to attack,
+            // whereas without this ranged units would be content to just sit in liquid and die from the DOT
+            if (u.unitSubType !== UnitSubType.MELEE && u.inLiquid) {
+
+              const seed = seedrandom(`${this.seed}-${this.turn_number}-${u.id}`);
+              const coords = findRandomGroundLocation(this, u, seed);
+              if (coords) {
+                await Unit.moveTowards(u, coords, this);
+              }
+            }
+            return actionResult;
+          }));
+          actionPromises.push(promise);
+        } else {
+          console.error(
+            'Could not find unit source data for',
+            u.unitSourceId,
+          );
+        }
+      }
+      console.log(actionPromises);
+      this.triggerGameLoopHeadless();
+      await Promise.all(actionPromises);
     }
 
     // End turn events, liquid damage, mana regen, etc.
-    await Unit.endTurnForUnits(units, this);
+    await Unit.endTurnForUnits(units, this, false);
   }
 
   // This function is invoked when all factions have finished their turns
@@ -2459,80 +2595,6 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     Player.syncLobby(this);
   }
 
-  // TODO - Move whole function
-  async initializePlayerTurns() {
-    // Prevent possible desynce where portals don't spawn when unit dies
-    // so it must spawn here to ensure players can move on
-    this.checkIfShouldSpawnPortal();
-    for (let player of this.players) {
-      player.endedTurn = false;
-      if (player.unit.alive) {
-        // Restore player to max mana at start of turn
-        // Let mana remain above max if it already is (due to other influences that may
-        // make it go above max like mana potions, spells, perks, etc);
-        player.unit.mana = Math.max(player.unit.manaMax, player.unit.mana);
-      }
-
-      if (player == globalThis.player && globalThis.player.isSpawned) {
-        // Notify the current player that their turn is starting
-        queueCenteredFloatingText(`Your Turn`);
-        // Don't play turn sfx when recording
-        if (!globalThis.isHUDHidden && !document.body?.classList.contains('hide-card-holders')) {
-          playSFXKey('yourTurn');
-        }
-      }
-
-      // TODO - Why is this here?
-      // Trigger attributePerks
-      const perkRandomGenerator = seedrandom(getUniqueSeedString(this, player));
-      for (let i = 0; i < player.attributePerks.length; i++) {
-        const perk = player.attributePerks[i];
-        if (perk) {
-          tryTriggerPerk(perk, player, 'everyTurn', perkRandomGenerator, this, 700 * i);
-        }
-      }
-
-      // Trigger onTurnStart Events
-      const onTurnStartEventResults: boolean[] = await Promise.all(player.unit.onTurnStartEvents.map(
-        async (eventName) => {
-          const fn = Events.onTurnStartSource[eventName];
-          return fn ? await fn(player.unit, false, this) : false;
-        },
-      ));
-    }
-    this.syncTurnMessage();
-    // Update unit health / mana bars, etc
-    await runPredictions(this);
-
-    // Quicksave at the beginning of player's turn
-    // Check globalThis.player.isSpawned to prevent quicksaving an invalid underworld file
-    if (globalThis.save && globalThis.player && globalThis.player.isSpawned) {
-      // For now, only save if in a singleplayer game
-      // because save support hasn't been added to multiplayer yet
-      if (isSinglePlayer()) {
-        console.info(`Dev: quick saving game as "${globalThis.quicksaveKey}"`);
-        // Force overwrite for quicksave, never prompt "are you sure?" when auto saving a quicksave
-        globalThis.save(globalThis.quicksaveKey, true);
-      }
-    }
-
-    // If there was an attempted save during the enemy turn, save now
-    // that the player's turn has started
-    if (globalThis.saveASAP && globalThis.save) {
-      globalThis.save(globalThis.saveASAP);
-    }
-
-    const firstPlayer = this.players[0];
-    if (firstPlayer) {
-      this.hotseatCurrentPlayerIndex = 0;
-      this.changeToHotseatPlayer(firstPlayer)
-    }
-    else {
-      console.error("Unexpected: Hotseat player doesn't exist");
-    }
-    this.updateTurnPhase();
-  }
-
   // Sends a network message to end turn
   async endMyTurnButtonHandler() {
     if (globalThis.player) {
@@ -2593,8 +2655,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       // an exit of the Stalled phase and that should ONLY happen when a player reconnects
       return;
     }
-    const playerIndex = numberOfHotseatPlayers > 1 ? this.hotseatCurrentPlayerIndex : this.players.findIndex((p) => p.clientId === clientId);
-    const player = this.players[playerIndex];
+    const player = this.players.find(p => p.clientId == clientId);
     if (!player) {
       console.error('Cannot end turn, player with clientId:', clientId, 'does not exist');
       return;
@@ -2616,7 +2677,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       }
     }
     // Ensure players can only end the turn when it IS their turn
-    if (this.turn_phase === turn_phase.PlayerTurns) {
+    if (this.turn_phase == turn_phase.PlayerTurns) {
       player.endedTurn = true;
       console.log('PlayerTurn: End player turn', clientId);
       this.syncTurnMessage();
@@ -2632,14 +2693,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
         });
       }
 
-      const gameIsOver = this.tryGameOver();
-      if (gameIsOver) {
-        // Prevent infinite loop since there are no players
-        // alive it would continue to loop endlessly and freeze up
-        // the game if it didn't early return here
-        return;
-      }
-      this.updateTurnPhase();
+      this.progressGameState();
     } else {
       console.error("turn_phase must be PlayerTurns to end turn.  Cannot be ", this.turn_phase);
     }
@@ -3153,19 +3207,10 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
             this.turn_phase = turn_phase.Stalled;
             console.log('Turn Management: Skipping initializingPlayerTurns, no players connected. Setting turn_phase to "Stalled"');
           } else {
-            // Start the players' turn
-            for (let u of this.units.filter(u => u.unitType == UnitType.PLAYER_CONTROLLED)) {
-              // Reset stamina for player units so they can move again
-              // Allow overfill with stamina potion so this only sets it UP to
-              // staminaMax, it won't lower it
-              if (u.stamina < u.staminaMax) {
-                u.stamina = u.staminaMax;
-              }
-            }
-            // Lastly, initialize the player turns.
+            // Initialize the player turns.
             // Note, it is possible that calling this will immediately end
             // the player phase (if there are no players to take turns)
-            await this.initializePlayerTurns();
+            await this.executePlayerTurn();
           }
           // Note: The player turn occurs asyncronously because it depends on player input so the call to
           // `broadcastTurnPhase(turn_phase.NPC_ALLY)` happens inside tryEndPlayerTurnPhase(); whereas the other blocks in
@@ -3173,11 +3218,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           // not.
           break;
         case turn_phase[turn_phase.NPC_ALLY]:
-          await this.executeFactionTurn(Faction.ALLY);
+          await this.executeNPCTurn(Faction.ALLY);
           this.broadcastTurnPhase(turn_phase.NPC_ENEMY);
           break;
         case turn_phase[turn_phase.NPC_ENEMY]:
-          await this.executeFactionTurn(Faction.ENEMY);
+          await this.executeNPCTurn(Faction.ENEMY);
           await this.endFullTurnCycle();
           this.broadcastTurnPhase(turn_phase.PlayerTurns);
           break;
@@ -3239,90 +3284,6 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
   }
 
-  async executeNPCTurn(faction: Faction) {
-    console.log('game: executeNPCTurn', Faction[faction]);
-    const cachedTargets: { [id: number]: { targets: Unit.IUnit[], canAttack: boolean } } = {};
-    this.clearPredictedNextTurnDamage();
-    for (let u of this.units.filter(
-      (u) => u.unitType === UnitType.AI && u.alive && u.faction == faction
-    )) {
-      const unitSource = allUnits[u.unitSourceId];
-      if (unitSource) {
-        // Set unit stamina to max so that it can calculate if they can attack target
-        // Note: This must be done BEFORE caching targets and canUnitAttackTarget so that it
-        // will have stamina to make the canUnitAttackTarget evaluation
-        u.stamina = u.staminaMax;
-        const targets = unitSource.getUnitAttackTargets(u, this);
-        const canAttack = this.canUnitAttackTarget(u, targets && targets[0])
-        cachedTargets[u.id] = { targets, canAttack };
-        this.incrementTargetsNextTurnDamage(targets, u.damage, canAttack);
-        if (unitSource.id == PRIEST_ID) {
-          // Signal to other priests that this one is targeted for resurrection
-          // so multiple priests don't try to ressurect the same target
-          this.incrementTargetsNextTurnDamage(targets, -u.healthMax, true);
-        }
-      }
-      // Set all units' stamina to 0 before their turn is initialized so that any melee units that have remaining stamina
-      // wont move during the ranged unit turn
-      u.stamina = 0;
-    }
-
-    for (let subTypes of [[UnitSubType.RANGED_LOS, UnitSubType.RANGED_RADIUS, UnitSubType.SUPPORT_CLASS], [UnitSubType.MELEE], [UnitSubType.SPECIAL_LOS], [UnitSubType.DOODAD]]) {
-      const actionPromises: Promise<void>[] = [];
-      const readyToTakeTurnUnits = this.units.filter(
-        (u) => u.unitType === UnitType.AI && u.alive && u.faction == faction && subTypes.includes(u.unitSubType),
-      );
-
-      const skipTurnUnits = await this.runTurnStartEvents(readyToTakeTurnUnits, false)
-
-      unitloop: for (let u of readyToTakeTurnUnits) {
-        // Units should have their previous path cleared so that their .action can set their path if 
-        // they should move this turn.
-        // Note: This resolves a headless server desync where units go through a complete gameloop before their
-        // .action sets moveTowards, so if they had an existing path, they move on the server but not on the client
-        u.path = undefined;
-
-        // Set unit stamina to max so that they may move now that it is their turn
-        u.stamina = u.staminaMax;
-        if (skipTurnUnits.includes(u)) {
-          continue unitloop;
-        }
-        // If unit is now dead (due to turnStartEvents)
-        // abort their turn
-        if (!u.alive) {
-          continue unitloop;
-        }
-        const unitSource = allUnits[u.unitSourceId];
-        if (unitSource) {
-          const { targets, canAttack } = cachedTargets[u.id] || { targets: [], canAttack: false };
-          // Add unit action to the array of promises to wait for
-          let promise = raceTimeout(5000, `Unit.action; unitSourceId: ${u.unitSourceId}; subType: ${u.unitSubType}`, unitSource.action(u, targets, this, canAttack).then(async (actionResult) => {
-            // Ensure ranged units get out of liquid so they don't take DOT
-            // This doesn't apply to melee units since they will automatically move towards you to attack,
-            // whereas without this ranged units would be content to just sit in liquid and die from the DOT
-            if (u.unitSubType !== UnitSubType.MELEE && u.inLiquid) {
-
-              const seed = seedrandom(`${this.seed}-${this.turn_number}-${u.id}`);
-              const coords = findRandomGroundLocation(this, u, seed);
-              if (coords) {
-                await Unit.moveTowards(u, coords, this);
-              }
-            }
-            return actionResult;
-          }));
-          actionPromises.push(promise);
-        } else {
-          console.error(
-            'Could not find unit source data for',
-            u.unitSourceId,
-          );
-        }
-      }
-      this.triggerGameLoopHeadless();
-      await Promise.all(actionPromises);
-    }
-
-  }
   canUnitAttackTarget(u: Unit.IUnit, attackTarget?: Unit.IUnit): boolean {
     if (!attackTarget) {
       return false;
@@ -3670,119 +3631,78 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
     stopAndDestroyForeverEmitter(castingParticleEmitter);
     if (!prediction) {
-      this.checkIfShouldSpawnPortal();
-      this.tryGameOver();
+      this.progressGameState();
     }
-
     return effectState;
   }
-  // Returns array of unit's whose turns should be skipped
-  async runTurnStartEvents(units: Unit.IUnit[], prediction: boolean): Promise<Unit.IUnit[]> {
-    const turnStartEventPromises = units.map(u => Unit.runTurnStartEvents(u, prediction, this).then(skipTurn => skipTurn ? [u] : []))
-    if (prediction) {
-      await this.fullySimulateForceMovePredictions();
-    }
-    const skipTurnUnits = (await Promise.all(turnStartEventPromises)).flatMap(x => x);
-    return skipTurnUnits;
-
-  }
-  checkIfShouldSpawnPortal() {
+  tryProgressLevelState(): boolean {
     // If all enemy units are dead and at least one player is spawned and connected
-    if (this.units.filter(u => u.faction == Faction.ENEMY && !u.flaggedForRemoval && u.unitSubType !== UnitSubType.DOODAD).every(u => !u.alive) && this.players.some(p => p.isSpawned && p.clientConnected)) {
-      const loopIndex = Math.max(0, (this.levelIndex - config.LAST_LEVEL_INDEX));
-      if (loopIndex > this.wave) {
-        this.wave++;
-        queueCenteredFloatingText(`Wave ${this.wave + 1} of ${loopIndex + 1}`);
-        // Add corpse decay to all dead NPCs
-        this.units.filter(u => u.unitType == UnitType.AI && !u.alive).forEach(u => {
-          Unit.addModifier(u, corpseDecayId, this, false);
-        });
-        const unitIds = getEnemiesForAltitude(this, this.levelIndex);
-        const numberOfMinibossesAllowed = Math.ceil(Math.max(0, (this.levelIndex - 4) / 4));
-        let numberOfMinibossesMade = 0;
-        // Trick for finding valid spawnable tiles
-        const validSpawnCoords = this.lastLevelCreated?.imageOnlyTiles.filter(x => x.image.endsWith('all_ground.png')) || [];
+    const shouldProgressLevelState = this.units.filter(u =>
+      u.faction == Faction.ENEMY &&
+      !u.flaggedForRemoval &&
+      u.unitSubType !== UnitSubType.DOODAD)
+      .every(u =>
+        !u.alive) &&
+      this.players
+        .some(p =>
+          p.isSpawned &&
+          p.clientConnected)
 
-        // Copied from generateRandomLevelData
-        for (let id of unitIds) {
-          if (validSpawnCoords.length == 0) { break; }
-          const validSpawnCoordsIndex = randInt(0, validSpawnCoords.length - 1, this.random);
-          const coord = validSpawnCoords.splice(validSpawnCoordsIndex, 1)[0];
-          const sourceUnit = allUnits[id];
-          const { unitMinLevelIndexSubtractor } = unavailableUntilLevelIndexDifficultyModifier(this);
-          // Disallow miniboss for a unit spawning on the first levelIndex that they are allowed to spawn
-          const minibossAllowed = !sourceUnit?.spawnParams?.excludeMiniboss && ((sourceUnit?.spawnParams?.unavailableUntilLevelIndex || 0) - unitMinLevelIndexSubtractor) < this.levelIndex;
-          if (coord) {
-            const isMiniboss = !minibossAllowed ? false : numberOfMinibossesAllowed > numberOfMinibossesMade;
-            if (isMiniboss) {
-              numberOfMinibossesMade++;
-            }
-            const sourceUnit = allUnits[id];
-            if (sourceUnit) {
-              Unit.create(
-                sourceUnit.id,
-                // Start the unit at the summoners location
-                coord.x,
-                coord.y,
-                // A unit always summons units in their own faction
-                Faction.ENEMY,
-                sourceUnit.info.image,
-                UnitType.AI,
-                sourceUnit.info.subtype,
-                sourceUnit.unitProps,
-                this
-              );
-              skyBeam(coord);
-            } else {
-              console.error('Cannot create unit, missing source unit for', id)
-            }
-          }
-        }
-        // end Copied from generateRandomLevelData
+    if (!shouldProgressLevelState) return false;
 
-
-        return;
-      }
-      // Make all potion pickups disappear so as to not compell players to waste time walking around picking them
-      // all up
-      // Also do not remove portals
-      this.pickups.filter(p => p.name !== Pickup.CARDS_PICKUP_NAME && p.name !== Pickup.PORTAL_PURPLE_NAME).forEach(p => {
-        makeScrollDissapearParticles(p, false);
-        Pickup.removePickup(p, this, false);
+    const loopIndex = Math.max(0, (this.levelIndex - config.LAST_LEVEL_INDEX));
+    if (loopIndex > this.wave) {
+      this.wave++;
+      queueCenteredFloatingText(`Wave ${this.wave + 1} of ${loopIndex + 1}`);
+      // Add corpse decay to all dead NPCs
+      this.units.filter(u => u.unitType == UnitType.AI && !u.alive).forEach(u => {
+        Unit.addModifier(u, corpseDecayId, this, false);
       });
-      // Spawn portal near each player
-      const portalPickup = Pickup.pickups.find(p => p.name == Pickup.PORTAL_PURPLE_NAME);
-      if (portalPickup) {
-        const portalsAlreadySpawned = !!this.pickups.filter(p => !p.flaggedForRemoval && !isNaN(p.x) && !isNaN(p.x)).find(p => p.name === Pickup.PORTAL_PURPLE_NAME)
-        if (!portalsAlreadySpawned) {
-          for (let playerUnit of this.units.filter(u => u.unitType == UnitType.PLAYER_CONTROLLED && u.alive)) {
-            const portalSpawnLocation = this.findValidSpawn(playerUnit, 4) || playerUnit;
-            if (!isOutOfBounds(portalSpawnLocation, this)) {
-              Pickup.create({ pos: portalSpawnLocation, pickupSource: portalPickup, logSource: 'Portal' }, this, false);
-            } else {
-              // If a pickup is attempted to be spawned for an unspawned player this if check prevents it from being spawned out of bounds
-              // and the next invokation of checkIfShouldSpawnPortal will spawn it instead.
-            }
-            // Give all player units infinite stamina when portal spawns for convenience.
-            playerUnit.stamina = Number.POSITIVE_INFINITY;
-            // Give all players max health and mana (it will be reset anyway when they are reset for the next level
-            // but this disswades them from going around to pickup potions)
-            playerUnit.health = playerUnit.healthMax;
-            playerUnit.mana = playerUnit.manaMax;
-            // Since playerUnit's health and mana is reset, we need to immediately sync the prediction unit
-            // so that it doesn't inncorrectly warn "self damage due to spell" by seeing that the prediction unit
-            // has less health than the current player unit.
-            this.syncPlayerPredictionUnitOnly();
+      const unitIds = getEnemiesForAltitude(this, this.levelIndex);
+      const numberOfMinibossesAllowed = Math.ceil(Math.max(0, (this.levelIndex - 4) / 4));
+      let numberOfMinibossesMade = 0;
+      // Trick for finding valid spawnable tiles
+      const validSpawnCoords = this.lastLevelCreated?.imageOnlyTiles.filter(x => x.image.endsWith('all_ground.png')) || [];
 
+      // Copied from generateRandomLevelData
+      for (let id of unitIds) {
+        if (validSpawnCoords.length == 0) { break; }
+        const validSpawnCoordsIndex = randInt(0, validSpawnCoords.length - 1, this.random);
+        const coord = validSpawnCoords.splice(validSpawnCoordsIndex, 1)[0];
+        const sourceUnit = allUnits[id];
+        const { unitMinLevelIndexSubtractor } = unavailableUntilLevelIndexDifficultyModifier(this);
+        // Disallow miniboss for a unit spawning on the first levelIndex that they are allowed to spawn
+        const minibossAllowed = !sourceUnit?.spawnParams?.excludeMiniboss && ((sourceUnit?.spawnParams?.unavailableUntilLevelIndex || 0) - unitMinLevelIndexSubtractor) < this.levelIndex;
+        if (coord) {
+          const isMiniboss = !minibossAllowed ? false : numberOfMinibossesAllowed > numberOfMinibossesMade;
+          if (isMiniboss) {
+            numberOfMinibossesMade++;
           }
-        } else {
-          console.log('Portals have already been spawned, do not spawn additional');
+          const sourceUnit = allUnits[id];
+          if (sourceUnit) {
+            Unit.create(
+              sourceUnit.id,
+              // Start the unit at the summoners location
+              coord.x,
+              coord.y,
+              // A unit always summons units in their own faction
+              Faction.ENEMY,
+              sourceUnit.info.image,
+              UnitType.AI,
+              sourceUnit.info.subtype,
+              sourceUnit.unitProps,
+              this
+            );
+            skyBeam(coord);
+          } else {
+            console.error('Cannot create unit, missing source unit for', id)
+          }
         }
-      } else {
-        console.error('Portal pickup not found')
       }
+      // end Copied from generateRandomLevelData
     }
 
+    return true;
   }
 
   // hasLineOfSight returns true if there are no walls interrupting

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -78,7 +78,7 @@ import { ensureAllClientsHaveAssociatedPlayers, Overworld } from './Overworld';
 import { Emitter } from '@pixi/particle-emitter';
 import { golem_unit_id } from './entity/units/golem';
 import { cleanUpPerkList, createPerkElement, generatePerks, tryTriggerPerk, showPerkList, hidePerkList, createCursePerkElement, StatCalamity, generateRandomStatCalamity } from './Perk';
-import { bossmasonUnitId, summonUnitAtPickup } from './entity/units/deathmason';
+import { ORIGINAL_DEATHMASON_DEATH, bossmasonUnitId, summonUnitAtPickup } from './entity/units/deathmason';
 import { hexToString } from './graphics/ui/colorUtil';
 import { doLiquidEffect } from './inLiquid';
 import { findRandomGroundLocation } from './entity/units/summoner';
@@ -1950,6 +1950,13 @@ export default class Underworld {
     }
     for (let e of enemies) {
       this.spawnEnemy(e.id, e.coord, e.isMiniboss);
+    }
+
+    if (levelData.levelIndex == config.LAST_LEVEL_INDEX) {
+      const deathmason = this.units.find(u => u.unitSourceId == bossmasonUnitId);
+      if (deathmason) {
+        deathmason.onDeathEvents = [ORIGINAL_DEATHMASON_DEATH];
+      }
     }
 
     // Show text in center of screen for the new level

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -112,6 +112,9 @@ export enum turn_phase {
   PlayerTurns,
   NPC_ALLY,
   NPC_ENEMY,
+  // TODO - Consider a "Between Level" phase
+  // that switches to PlayerTurns after a level is generated
+  // To ensure turn start logic for PlayerTurns runs
 }
 const smearJitter = [
   { x: -3, y: -3 },
@@ -1880,6 +1883,8 @@ export default class Underworld {
 
     // Reset kill switch
     this.allyNPCAttemptWinKillSwitch = 0;
+    // Reset wave count
+    this.wave = 0;
   }
   postSetupLevel() {
     document.body?.classList.toggle('loading', false);
@@ -1974,9 +1979,6 @@ export default class Underworld {
     if (globalThis.playNextSong) {
       globalThis.playNextSong();
     }
-
-    // Reset wave count
-    this.wave = 0;
 
     // NOTE: Any data that needs to be synced from host to clients from this function MUST
     // be set BEFORE postSetupLevel is invoked because postSetupLevel will send a sync message

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2003,6 +2003,19 @@ export default class Underworld {
       // Must be called when difficulty (gameMode) changes to update summon spell stats
       Cards.refreshSummonCardDescriptions(this);
     }
+
+    // Use list here in case of hotseat
+    let clientPlayers = this.players.filter(p => p.clientId == globalThis.clientId);
+    for (let player of clientPlayers) {
+      // Record High Score Progress
+      const mageTypeFarthestLevel = storage.getStoredMageTypeFarthestLevelKey(player.mageType || 'Spellmason');
+      const highScore = storageGet(mageTypeFarthestLevel) || '0'
+      if (parseInt(highScore) < this.levelIndex) {
+        console.log('New farthest level record!', mageTypeFarthestLevel, '->', this.levelIndex);
+        storageSet(mageTypeFarthestLevel, this.levelIndex.toString());
+      }
+    }
+
     // When you get to the first plus level after beating the last level,
     // record the winTime for speedrunning
     if (levelData.levelIndex == config.LAST_LEVEL_INDEX + 1) {

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2646,8 +2646,13 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
 
     // No wave to spawn, so spawn portals
-    const livingPlayers = this.players.filter(p => p.unit.unitType == UnitType.PLAYER_CONTROLLED && p.unit.alive);
-    if (livingPlayers.length > 0) {
+
+    // We should check that there are players to spawn portals for
+    // It's possible that all players are dead, frozen, etc.
+    // When the level is completed, and in that case,
+    // we can skip spawning portals and go to next levlel
+    const remainingPlayers = this.players.filter(p => !this.hasCompletedTurn(p));
+    if (remainingPlayers.length > 0) {
       const spawnedPortals = this.pickups.filter(p => !p.flaggedForRemoval && p.name === Pickup.PORTAL_PURPLE_NAME);
       if (spawnedPortals.length <= 0) {
         // TODO - Clear pickups correctly - They are not removed from underworld list
@@ -2662,7 +2667,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
         // Spawn portal near each player
         const portalPickup = Pickup.pickups.find(p => p.name == Pickup.PORTAL_PURPLE_NAME);
         if (portalPickup) {
-          for (let playerUnit of livingPlayers.map(p => p.unit)) {
+          for (let playerUnit of remainingPlayers.map(p => p.unit)) {
             const portalSpawnLocation = this.findValidSpawn(playerUnit, 4) || playerUnit;
             if (!isOutOfBounds(portalSpawnLocation, this)) {
               Pickup.create({ pos: portalSpawnLocation, pickupSource: portalPickup, logSource: 'Portal' }, this, false);

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -254,15 +254,6 @@ export default class Underworld {
 
     this.random = this.syncronizeRNG(RNGState);
   }
-  clientIdToPlayer(clientId: string): Player.IPlayer | undefined {
-    if (globalThis.player && globalThis.clientId == clientId) {
-      console.debug("Returning current player on this client:\n", clientId, "\n", globalThis.player.playerId);
-      return globalThis.player;
-    }
-    const player = this.players.find(p => p.clientId == clientId);
-    console.debug("Finding player on different client:\n", clientId, "\n", player?.playerId);
-    return player;
-  }
   // Returns all potentially targetable entities
   // See cards/index.ts's getCurrentTargets() for the function that returns 
   // the current targets of a spell.
@@ -300,14 +291,6 @@ export default class Underworld {
         this.cardDropsDropped++;
         // Give EVERY player an upgrade when any one player picks up a scroll
         this.players.forEach(p => Pickup.givePlayerUpgrade(p, this));
-        // const pickupSource = Pickup.pickups.find(p => p.name == Pickup.CARDS_PICKUP_NAME)
-        // if (pickupSource) {
-        //   Pickup.create({ pos: enemyKilledPos, pickupSource }, this, false);
-        //   tutorialShowTask('pickupScroll');
-        // } else {
-        //   console.error('pickupSource for', Pickup.CARDS_PICKUP_NAME, ' not found');
-        //   return
-        // }
       } else {
         console.log('No more cards to drop');
       }
@@ -337,7 +320,7 @@ export default class Underworld {
     // if (elSeed) {
     //   elSeed.innerText = `Seed: ${this.seed}`;
     // }
-    console.log("RNG create with seed:", this.seed, ", state: ", RNGState);
+    console.log('RNG create with seed:', this.seed, ', state: ', RNGState);
     // state of "true" initializes the RNG with the ability to save it's state,
     // state of a state object, rehydrates the RNG to a particular state
     this.random = seedrandom(this.seed, { state: RNGState })
@@ -2104,10 +2087,10 @@ export default class Underworld {
     // Are there connected players?
     const connectedPlayers = this.players.filter(p => p.clientConnected);
     if (connectedPlayers.length > 0) {
-      console.log("Game State: Is Game Over?\nConnected Players: ", connectedPlayers);
+      console.log('[GAME] Is Game Over?\nConnected Players: ', connectedPlayers);
     }
     else {
-      console.log("Game State: Game is Over.\nNo connected players in player list: ", this.players);
+      console.log('[GAME] Game is Over\nNo connected players in player list: ', this.players);
       return true;
     }
 
@@ -2116,10 +2099,10 @@ export default class Underworld {
     // Note: This must exclude doodads
     const remainingAllies = this.units.filter(u => u.alive && u.unitSubType != UnitSubType.DOODAD && playerFactions.includes(u.faction));
     if (remainingAllies.length > 0) {
-      console.log("Game State: Is Game Over?\nRemaining allies: ", remainingAllies);
+      console.log('[GAME] Is Game Over?\nRemaining allies: ', remainingAllies);
     }
     else {
-      console.log("Game State: Game is Over.\nNo allies remain");
+      console.log('[GAME] Game is Over\nNo allies remain');
       return true;
     }
 
@@ -2127,12 +2110,14 @@ export default class Underworld {
     // If not, there might be a stalemate, so we need a kill switch.
     const useKillSwitch = this.allyNPCAttemptWinKillSwitch > 50;
     if (!useKillSwitch) {
-      console.log("Game State: Is Game Over?\nKill Switch Counter: ", this.allyNPCAttemptWinKillSwitch);
+      console.log('[GAME] Is Game Over?\nKill Switch Counter: ', this.allyNPCAttemptWinKillSwitch);
     }
     else {
-      console.log("Game State: Game is Over.\nKill Switch threshold reached");
+      console.log('[GAME] Game is Over\nKill Switch threshold reached');
       return true;
     }
+
+    console.log('[GAME] Game is not over');
     return false;
   }
   updateGameOverModal() {
@@ -2171,7 +2156,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
   }
 
   doGameOver() {
-    console.log("- - -\nGame Over\n- - -");
+    console.log('- - -\nGame Over\n- - -');
     // Show game over modal after a delay
     gameOverModalTimeout = setTimeout(() => {
       document.body.classList.toggle('game-over', true);
@@ -2206,7 +2191,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
   // Handles level completion, game over, turn phases, and hotseat
   async progressGameState() {
-    console.log("Game State: Progress...\nCurrent Turn Phase == ", turn_phase[this.turn_phase]);
+    console.log('[GAME] Progress...\nCurrent Turn Phase == ', turn_phase[this.turn_phase]);
 
     // try game over
     // else try next level
@@ -2239,7 +2224,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       // this.endFullTurnCycle();
     }
 
-    console.log("Game State: Progress...\nNew Turn Phase == ", turn_phase[this.turn_phase]);
+    console.log('[GAME] Progress...\nNew Turn Phase == ', turn_phase[this.turn_phase]);
     return;
   }
 
@@ -2259,14 +2244,13 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       const currentPlayer = this.players[i];
       // Found a player that has not completed their turn, switch to them
       if (currentPlayer && !this.hasCompletedTurn(currentPlayer)) {
-        console.log("Game State: \nSwitching to hotseat player: ", currentPlayer);
+        console.log('[GAME] Turn Phase\nSwitching to hotseat player: ', currentPlayer);
         await this.changeToHotseatPlayer(currentPlayer);
         return;
       }
     }
 
-    // TODO - Switch back to player 1 in prep for next turn?
-    console.log("Game State: \nAll remaining hotseat players have completed their turn");
+    console.log('[GAME] Turn Phase\nAll remaining hotseat players have completed their turn');
   }
 
   async changeToFirstHotseatPlayer() {
@@ -2277,12 +2261,12 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       this.changeToHotseatPlayer(firstPlayer)
     }
     else {
-      console.error("Game State: \nFirst hotseat player doesn't exist");
+      console.error('[GAME] Turn Phase\nFirst hotseat player does not exist');
     }
   }
 
   async changeToHotseatPlayer(player: Player.IPlayer) {
-    console.log("Game State: \nChange to hotseat player: " + player.playerId);
+    console.log('[GAME] Turn Phase\nChange to hotseat player: ' + player.playerId);
 
     // If the next player has already completed turn or can't act
     // get the next hotseat player
@@ -2331,7 +2315,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     // Only move on if there are connected players in the game,
     // so that the server doesn't run cycles pointlessly
     if (!(connectedPlayers.length > 0)) {
-      console.error("PlayerTurn: tryEndPlayerTurnPhase = false; No active players found");
+      console.error('[GAME] Turn Phase\n tryEndPlayerTurnPhase = false; No active players found');
       return false;
     }
 
@@ -2346,7 +2330,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
   }
 
   async endPlayerTurnCleanup() {
-    console.log('Game State: \nEnd player turn phase');
+    console.log('[GAME] Turn Phase\nEnd player turn phase');
 
     for (let p of this.players) {
       // Decrement card usage counts,
@@ -2449,7 +2433,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
     const units = this.units.filter(u => u.unitType == UnitType.AI && u.faction == faction);
 
-    console.log('Game State: \nExecuteNPCTurn', Faction[faction]);
+    console.log('[GAME] Turn Phase\nExecuteNPCTurn', Faction[faction]);
     const cachedTargets: { [id: number]: { targets: Unit.IUnit[], canAttack: boolean } } = {};
     this.clearPredictedNextTurnDamage();
     await Unit.startTurnForUnits(units, this, false);
@@ -2515,7 +2499,6 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           );
         }
       }
-      console.log(actionPromises);
       this.triggerGameLoopHeadless();
       await Promise.all(actionPromises);
     }
@@ -2557,7 +2540,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
                 console.error('Player was reset because they ended up out of bounds');
                 Player.resetPlayerForNextLevel(player, this);
               } else {
-                console.error("Unexpected: Tried to reset out of bounds player but player unit matched no player object.");
+                console.error('Unexpected: Tried to reset out of bounds player but player unit matched no player object.');
               }
             } else {
               console.error('Unit was force killed because they ended up out of bounds', u.unitSubType)
@@ -2677,7 +2660,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     if (this.turn_phase != turn_phase.PlayerTurns) {
       // (A player "ending their turn" when it is not their turn
       // can occur when a client disconnects when it is not their turn)
-      console.info('Cannot end the turn of a player when it isn\'t currently their turn')
+      console.info('Cannot end the turn of a player when it is not currently their turn')
       return
     }
     // Don't play turn sfx when recording or for auto-ended dead players
@@ -2693,11 +2676,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     // Ensure players can only end the turn when it IS their turn
     if (this.turn_phase == turn_phase.PlayerTurns) {
       player.endedTurn = true;
-      console.log('Game State: \nEnd player turn', clientId);
+      console.log('[GAME] Turn Phase\nEnd player turn', clientId);
       this.syncTurnMessage();
       this.progressGameState();
     } else {
-      console.error("Game State: \nturn_phase must be PlayerTurns to end turn. Cannot be ", this.turn_phase);
+      console.error('[GAME] Turn Phase\nturn_phase must be PlayerTurns to end turn. Cannot be ', this.turn_phase);
     }
 
     // Should progress game state go here as a failsafe?
@@ -3052,7 +3035,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
   tryRestartTurnPhaseLoop() {
     // See GameLoops.md for more details 
     if (this.turn_phase == turn_phase.Stalled && this.players.some(player => Player.ableToAct(player))) {
-      console.log('Game State: Turn Management\nRestarting turn loop with PlayerTurns')
+      console.log('[GAME] Turn Phase\nRestarting turn loop with PlayerTurns')
       this.broadcastTurnPhase(turn_phase.PlayerTurns);
       // Special Case: in the event that a client is stuck with a stalled turn phase
       // it can set itself back to PlayerTurns. (The server won't send another 
@@ -3068,7 +3051,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
   async broadcastTurnPhase(p: turn_phase) {
     // If host, send sync; if non-host, ignore 
     if (globalThis.isHost(this.pie)) {
-      console.log('Game State: \nBroadcast SET_PHASE: ', turn_phase[p]);
+      console.log('[GAME] Turn Phase\nBroadcast SET_PHASE: ', turn_phase[p]);
 
       this.pie.sendData({
         type: MESSAGE_TYPES.SET_PHASE,
@@ -3092,7 +3075,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
   // initializeTurnPhase (on each client and itself);
   // otherwise the clients and host could get out of sync
   setTurnPhase(p: turn_phase) {
-    console.log('Game State: \nsetTurnPhase(', turn_phase[p], ')');
+    console.log('[GAME] Turn Phase\nsetTurnPhase: ', turn_phase[p]);
     this.turn_phase = p;
     this.syncTurnMessage();
 
@@ -3119,7 +3102,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
   // when you want to set the turn_phase
   // See GameLoops.md for more details
   async initializeTurnPhase(p: turn_phase) {
-    console.log('Game State: \ninitializeTurnPhase(', turn_phase[p], ')');
+    console.log('[GAME] Turn Phase\ninitializeTurnPhase: ', turn_phase[p]);
 
     // Clear cast this turn
     globalThis.castThisTurn = false;
@@ -3152,7 +3135,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
     const phase = turn_phase[this.turn_phase];
     if (!phase) {
-      console.error('Invalid turn phase', this.turn_phase);
+      console.error('[GAME] Turn Phase\nInvalid turn phase: ', turn_phase[p]);
       return;
     }
 
@@ -3167,7 +3150,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           // Setting it immediately ensures that any following messages in the queue won't reengage
           // the turn_phase loop, causing an infinite loop
           this.turn_phase = turn_phase.Stalled;
-          console.log('Game State: Turn Management\nSkipping initializingPlayerTurns, no players connected. Setting turn_phase to "Stalled"');
+          console.log('[GAME] Turn Phase\nSkipping initializingPlayerTurns, no players connected. Setting turn_phase to "Stalled"');
         } else {
           // Initialize the player turns.
           // Note, it is possible that calling this will immediately end
@@ -3617,7 +3600,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
           p.clientConnected)
 
     if (!canProgress) {
-      console.log("Game State: Can't Progress Level\nThere are living enemy units, or no players are spawned and connected.");
+      console.log('[GAME] Cannot Progress Level\nThere are living enemy units, or no players are spawned and connected.');
       return false;
     }
 
@@ -3655,11 +3638,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       }
       // end Copied from generateRandomLevelData
 
-      console.log("Game State: Level Progressed\nSpawned new wave of enemies");
+      console.log('[GAME] Level Progressed\nSpawned new wave of enemies');
       return true;
     }
     else {
-      console.log("Game State: Handling Level Progress...\nNo more waves to spawn");
+      console.log('[GAME] Handling Level Progress...\nNo more waves to spawn');
     }
 
     // No wave to spawn, so spawn portals
@@ -3694,11 +3677,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
         console.error('Portal pickup not found')
       }
 
-      console.log("Game State: Level Progressed\nSpawned portals");
+      console.log('[GAME] Level Progressed\nSpawned portals');
       return true;
     }
     else {
-      console.log("Game State: Handling Level Progress...\nPortals have already been spawned");
+      console.log('[GAME] Handling Level Progress...\nPortals have already been spawned');
     }
 
     // Go To Next Level
@@ -3721,11 +3704,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
         }
       }, 0);
 
-      console.log("Game State: Level Progressed\nMoving to next level");
+      console.log('[GAME] Level Progressed\nMoving to next level');
       return true;
     }
     else {
-      console.log("Game State: Handling Level Progress...\nDon't go to next level");
+      console.log('[GAME] Handling Level Progress...\nDo not go to next level');
     }
 
     return false;

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2170,8 +2170,12 @@ export default class Underworld {
 
     const connectedPlayers = this.players.filter(p => p.clientConnected);
 
-    // TODO - Below is a temp failsafe. It should be removed:
-    // Progress game state should not be getting called before enemies are spawned
+    // TODO - Below is a temp failsafe. It should be removed eventually:
+    // This failsafe is here to account for an edge case where progressGameState()
+    // is called during underworld generation / in headless when all players are still in lobby
+    // I think. Haven't had time to investigate.
+    // Point: Progress game state should not be getting called before the game "starts"
+    // I.E. level is generated, enemies are spawned, players are ready to play and spawn, etc.
     const spawnedPlayers = this.players.filter(p => p.isSpawned)
     if (spawnedPlayers.length == 0) {
       console.log('[GAME] Can\'t Progress Level \nNo players have spawned: ', this.players);

--- a/src/Upgrade.ts
+++ b/src/Upgrade.ts
@@ -93,7 +93,7 @@ export function generateUpgrades(player: IPlayer, numberOfUpgrades: number, mini
   // the number of cards that they have  This will prevent save scamming the chances and also make sure each time you are presented with
   // cards it is unique.
   // Note: Only count non-empty card spaces
-  const playerUniqueIdentifier = globalThis.numberOfHotseatPlayers > 1 ? player.name : player.clientId;
+  const playerUniqueIdentifier = player.clientId;
   const rSeed = `${underworld.seed}-${playerUniqueIdentifier}-${player.reroll}-${player.inventory.filter(x => !!x).length}`;
   const random = seedrandom(rSeed);
   for (

--- a/src/Upgrade.ts
+++ b/src/Upgrade.ts
@@ -93,8 +93,7 @@ export function generateUpgrades(player: IPlayer, numberOfUpgrades: number, mini
   // the number of cards that they have  This will prevent save scamming the chances and also make sure each time you are presented with
   // cards it is unique.
   // Note: Only count non-empty card spaces
-  const playerUniqueIdentifier = player.clientId;
-  const rSeed = `${underworld.seed}-${playerUniqueIdentifier}-${player.reroll}-${player.inventory.filter(x => !!x).length}`;
+  const rSeed = `${underworld.seed}-${player.playerId}-${player.reroll}-${player.inventory.filter(x => !!x).length}`;
   const random = seedrandom(rSeed);
   for (
     let i = 0;

--- a/src/cards/capture_soul.ts
+++ b/src/cards/capture_soul.ts
@@ -35,7 +35,7 @@ const spell: Spell = {
               const upgrade = upgradeCardsSource.find(u => u.title == newCardId)
               if (upgrade) {
                 floatingText({ coords: target, text: 'Soul Captured!' });
-                underworld.getFreeUpgrade(player, upgrade);
+                underworld.forceUpgrade(player, upgrade, true);
                 makeManaTrail(target, state.casterUnit, underworld, '#321d73', '#9526cc').then(() => {
                   playDefaultSpellSFX(card, prediction);
                 });

--- a/src/cards/clone.ts
+++ b/src/cards/clone.ts
@@ -27,11 +27,6 @@ const spell: Spell = {
       let targets: Vec2[] = getCurrentTargets(state);
       targets = targets.length ? targets : [state.castLocation];
       for (let target of targets) {
-        // Disallow cloning scrolls because it ruins the spell aquisition part of the game
-        if (Pickup.isPickup(target) && target.name == Pickup.CARDS_PICKUP_NAME && !prediction) {
-          floatingText({ coords: target, text: 'The knowledge in these scrolls cannot be cloned', style: { fill: 'red' } });
-          continue;
-        }
         clonePairs.push([target, { x: target.x, y: target.y }]);
       }
       let animationPromise = Promise.resolve();

--- a/src/cards/conserve.ts
+++ b/src/cards/conserve.ts
@@ -62,8 +62,6 @@ const spell: Spell = {
           Unit.removeModifier(unit, conserveSpellId, underworld);
         }, 0);
       }
-      // Do not skip turn
-      return false;
     },
   },
 

--- a/src/cards/fortify.ts
+++ b/src/cards/fortify.ts
@@ -66,8 +66,6 @@ const spell: Spell = {
       // Since this blessing only applies for one turn, remove it
       // on turn start
       Unit.removeModifier(unit, id, underworld);
-      // do not skip turn
-      return false;
     },
     onDamage: (unit, amount, underworld, prediction, damageDealer) => {
       const modifier = unit.modifiers[id];

--- a/src/cards/freeze.ts
+++ b/src/cards/freeze.ts
@@ -68,11 +68,6 @@ const spell: Spell = {
   },
   events: {
     onTurnStart: async (unit: Unit.IUnit) => {
-      const modifier = unit.modifiers[freezeCardId];
-      if (modifier && modifier.quantity <= 0) {
-        // do not skip turn
-        return false;
-      }
       // Ensure that the unit cannot move when frozen
       // (even when players' turns are ended they can still act so long
       // as it is underworld.turn_phase === turn_phase.PlayerTurns, this is because all players act simultaneously
@@ -80,8 +75,6 @@ const spell: Spell = {
       // prevents players from moving when they are frozen)
       // and then returning true also ends their turn.
       unit.stamina = 0;
-      // Skip turn
-      return true;
     },
     onTurnEnd: async (unit: Unit.IUnit, prediction: boolean, underworld: Underworld) => {
       // Decrement how many turns left the unit is frozen

--- a/src/cards/freeze.ts
+++ b/src/cards/freeze.ts
@@ -9,11 +9,11 @@ import { playDefaultSpellAnimation, playDefaultSpellSFX } from './cardUtils';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { getOrInitModifier } from './util';
 
-export const id = 'freeze';
+export const freezeCardId = 'freeze';
 const imageName = 'spell-effects/spellFreeze_still.png';
 const spell: Spell = {
   card: {
-    id,
+    id: freezeCardId,
     category: CardCategory.Curses,
     sfx: 'freeze',
     supportQuantity: true,
@@ -35,7 +35,7 @@ const spell: Spell = {
         })
         await Promise.all([spellAnimationPromise, playDefaultSpellSFX(card, prediction)]);
         for (let unit of targets) {
-          Unit.addModifier(unit, id, underworld, prediction, quantity);
+          Unit.addModifier(unit, freezeCardId, underworld, prediction, quantity);
         }
         for (let pickup of state.targetedPickups) {
           if (pickup.turnsLeftToGrab !== undefined) {
@@ -68,7 +68,7 @@ const spell: Spell = {
   },
   events: {
     onTurnStart: async (unit: Unit.IUnit) => {
-      const modifier = unit.modifiers[id];
+      const modifier = unit.modifiers[freezeCardId];
       if (modifier && modifier.quantity <= 0) {
         // do not skip turn
         return false;
@@ -85,7 +85,7 @@ const spell: Spell = {
     },
     onTurnEnd: async (unit: Unit.IUnit, prediction: boolean, underworld: Underworld) => {
       // Decrement how many turns left the unit is frozen
-      const modifier = unit.modifiers[id];
+      const modifier = unit.modifiers[freezeCardId];
       if (modifier) {
         modifier.quantity--;
         if (modifier.quantity <= 0) {
@@ -97,10 +97,10 @@ const spell: Spell = {
           // removing the ice image
           if (unit.unitType == UnitType.PLAYER_CONTROLLED) {
             setTimeout(() => {
-              Unit.removeModifier(unit, id, underworld);
+              Unit.removeModifier(unit, freezeCardId, underworld);
             }, 1000)
           } else {
-            Unit.removeModifier(unit, id, underworld);
+            Unit.removeModifier(unit, freezeCardId, underworld);
           }
         }
       }
@@ -109,16 +109,16 @@ const spell: Spell = {
 };
 
 function add(unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, quantity: number = 1) {
-  getOrInitModifier(unit, id, { isCurse: true, quantity }, () => {
+  getOrInitModifier(unit, freezeCardId, { isCurse: true, quantity }, () => {
     unit.radius = config.COLLISION_MESH_RADIUS;
     // Immediately set stamina to 0 so they can't move
     unit.stamina = 0;
     // Add event
-    if (!unit.onTurnStartEvents.includes(id)) {
-      unit.onTurnStartEvents.push(id);
+    if (!unit.onTurnStartEvents.includes(freezeCardId)) {
+      unit.onTurnStartEvents.push(freezeCardId);
     }
-    if (!unit.onTurnEndEvents.includes(id)) {
-      unit.onTurnEndEvents.push(id);
+    if (!unit.onTurnEndEvents.includes(freezeCardId)) {
+      unit.onTurnEndEvents.push(freezeCardId);
     }
 
     // Add subsprite image
@@ -129,15 +129,6 @@ function add(unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, qua
     // act as a blockade
     unit.immovable = true;
   });
-  // If the frozen unit is a player, end their turn when they become frozen
-  if (unit.unitType === UnitType.PLAYER_CONTROLLED) {
-    const player = underworld.players.find(
-      (p) => p.unit === unit,
-    );
-    if (player) {
-      underworld.endPlayerTurn(player.clientId);
-    }
-  }
 }
 function remove(unit: Unit.IUnit) {
   unit.radius = config.UNIT_BASE_RADIUS

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -107,6 +107,7 @@ import { registerUrnpoisonExplode } from '../entity/units/urn_poison';
 import { registerUrnexplosiveExplode } from '../entity/units/urn_explosive';
 import { calculateGameDifficulty } from '../Difficulty';
 import registerCorpseDecay from '../modifierCorpseDecay';
+import { registerDeathmasonEvents } from '../entity/units/deathmason';
 
 export interface Modifiers {
   subsprite?: Subsprite;
@@ -297,6 +298,7 @@ export function registerCards(overworld: Overworld) {
   registerUrnpoisonExplode();
   registerUrnexplosiveExplode();
   registerImmune();
+  registerDeathmasonEvents();
 }
 
 // This is necessary because unit stats change with difficulty.

--- a/src/cards/target_cone.ts
+++ b/src/cards/target_cone.ts
@@ -12,12 +12,12 @@ import { easeOutCubic } from '../jmath/Easing';
 import * as config from '../config';
 import { HasSpace } from '../entity/Type';
 
-export const id = 'Target Cone';
+export const targetConeId = 'Target Cone';
 const range = 200;
 const coneAngle = Math.PI / 4
 const spell: Spell = {
   card: {
-    id,
+    id: targetConeId,
     category: CardCategory.Targeting,
     supportQuantity: true,
     manaCost: 20,

--- a/src/effects/force_move.ts
+++ b/src/effects/force_move.ts
@@ -6,6 +6,7 @@ import { ForceMoveType, ForceMoveUnitOrPickup } from "../jmath/moveWithCollision
 
 // TODO - Force moves need to be handled differently
 // such that they are consistent at different framerates and velocity falloffs
+// https://github.com/jdoleary/Spellmasons/issues/381
 
 export const defaultPushDistance = 140; // In game units
 const velocity_falloff = 0.992;

--- a/src/entity/Pickup.ts
+++ b/src/entity/Pickup.ts
@@ -192,63 +192,6 @@ export function create({ pos, pickupSource, idOverride, logSource }:
   }
 
   underworld.addPickupToArray(self, prediction);
-  // Ensure players get outstanding scroll pickups at the end of the level
-  if (self) {
-    // If pickup is a portal
-    // make existing scroll pickups fly to player
-    if (self.name == PORTAL_PURPLE_NAME) {
-      let timeBetweenPickupFly = 100;
-      const scrolls = underworld.pickups.filter(p => p.name == CARDS_PICKUP_NAME && !p.flaggedForRemoval);
-      for (let scroll of scrolls) {
-        removePickup(scroll, underworld, false);
-      }
-      scrolls.map(pickup => {
-        return raceTimeout(5000, 'spawnPortalFlyScrolls', new Promise<void>((resolve) => {
-          timeBetweenPickupFly += 100;
-          // Make the pickup fly to the player. this gives them some time so it doesn't trigger immediately.
-          setTimeout(() => {
-            if (pickup.image) {
-              pickup.image.sprite.visible = false;
-            }
-            const flyingPickupPromises = [];
-            for (let p of underworld.players) {
-              flyingPickupPromises.push(createVisualLobbingProjectile(pickup, p.unit, pickup.imagePath))
-            }
-            Promise.all(flyingPickupPromises)
-              .then(() => {
-                underworld.players.forEach(p => givePlayerUpgrade(p, underworld));
-                resolve();
-              });
-          }, timeBetweenPickupFly);
-        }))
-      });
-    }
-
-    // If there are existing portals and a pickup is spawned make pickups fly to player
-    if (self.name == CARDS_PICKUP_NAME && underworld.pickups.some(p => p.name == PORTAL_PURPLE_NAME)) {
-      removePickup(self, underworld, false);
-      raceTimeout(5000, 'spawnScrollFlyScroll', new Promise<void>((resolve) => {
-        // Make the pickup fly to the player. this gives them some time so it doesn't trigger immediately.
-        setTimeout(() => {
-          if (self) {
-            if (self.image) {
-              self.image.sprite.visible = false;
-            }
-            const flyingPickupPromises = [];
-            for (let p of underworld.players) {
-              flyingPickupPromises.push(createVisualLobbingProjectile(self, p.unit, self.imagePath))
-            }
-            Promise.all(flyingPickupPromises)
-              .then(() => {
-                underworld.players.forEach(p => givePlayerUpgrade(p, underworld));
-                resolve();
-              });
-          }
-        }, 100);
-      }));
-    }
-  }
-
   return self;
 }
 function assignEmitter(pickup: IPickup, emitterId: string, prediction: boolean, underworld: Underworld) {
@@ -496,7 +439,6 @@ export function tryTriggerPickup(pickup: IPickup, unit: IUnit, underworld: Under
 const manaPotionRestoreAmount = 40;
 const healthPotionRestoreAmount = 50;
 export const spike_damage = 30;
-export const CARDS_PICKUP_NAME = 'Spells';
 export const PICKUP_SPIKES_NAME = 'Trap';
 export const PORTAL_PURPLE_NAME = 'Portal';
 const cursedManaPotionRemovalProportion = 0.1;

--- a/src/entity/Pickup.ts
+++ b/src/entity/Pickup.ts
@@ -586,7 +586,6 @@ export const pickups: IPickupSource[] = [
           type: MESSAGE_TYPES.ENTER_PORTAL
         });
         CardUI.clearSelectedCards(underworld);
-        tutorialCompleteTask('portal');
       }
       // Move the player unit so they don't continue to trigger the pickup more than once
       if (player && player.unit) {

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -555,7 +555,7 @@ export function enterPortal(player: IPlayer, underworld: Underworld) {
     underworld.endPlayerTurn(player.clientId);
   }
 }
-// Note: this is also used for AI targeting to ensure that AI don't target disabled plaeyrs
+
 export function ableToAct(player: IPlayer) {
   // So long as a player is clientConnected, they can act if:
   // - They haven't spawned yet

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -353,13 +353,11 @@ export function resetPlayerForNextLevel(player: IPlayer, underworld: Underworld)
 }
 // Keep a global reference to the current client's player
 export function updateGlobalRefToCurrentClientPlayer(player: IPlayer, underworld: Underworld) {
-  if (globalThis.clientId === player.clientId) {
-    if (numberOfHotseatPlayers > 1) {
-      globalThis.player = underworld.players[underworld.hotseatCurrentPlayerIndex];
-      if (!globalThis.player) {
-        console.error('Unexpected: Hotseat player is undefined');
-      }
-    } else {
+  if (numberOfHotseatPlayers > 1) {
+    globalThis.player = player;
+    globalThis.clientId = player.clientId;
+  } else {
+    if (globalThis.clientId === player.clientId) {
       globalThis.player = player;
     }
   }
@@ -468,6 +466,10 @@ export function load(player: IPlayerSerialized, index: number, underworld: Under
 
 // Sets boolean and substring denoting if the player has a @websocketpie/client client associated with it
 export function setClientConnected(player: IPlayer, connected: boolean, underworld: Underworld) {
+  // Override: If in hotseat multiplayer than all clients are considered connected
+  if (globalThis.numberOfHotseatPlayers > 1) {
+    connected = true;
+  }
   player.clientConnected = connected;
   if (connected) {
     Image.removeSubSprite(player.unit.image, 'disconnected.png');

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -302,20 +302,11 @@ export function setPlayerRobeColor(player: IPlayer, color: number | string, colo
   }
 }
 export function resetPlayerForNextLevel(player: IPlayer, underworld: Underworld) {
-  console.trace("TEMP - Reset player!");
-  console.warn("TEMP - Reset player: ", player);
-  console.warn("TEMP - Global Player: ", globalThis.player);
-  console.warn("TEMP - Same player?: ", player == globalThis.player);
-
   // Set the player so they can choose their next spawn
   player.isSpawned = false;
-  if (player === globalThis.player) {
+  if (player == globalThis.player) {
     globalThis.awaitingSpawn = false;
   }
-  player.endedTurn = false;
-
-  console.warn("TEMP - isSpawned: ", player.isSpawned);
-  console.warn("TEMP - Global awaiting spawn: ", globalThis.awaitingSpawn);
 
   // Update player position to be NOT NaN or null (which indicates that the player is in portal),
   // instead, the player is now spawning so their position should be a number.
@@ -533,7 +524,6 @@ export function enterPortal(player: IPlayer, underworld: Underworld) {
   player.unit.resolveDoneMoving();
   // Move "portaled" unit out of the way to prevent collisions and chaining while portaled
   Unit.setLocation(player.unit, { x: NaN, y: NaN });
-  updateGlobalRefToPlayerIfCurrentClient(player);
   // Clear the selection so that it doesn't persist after portalling (which would show
   // your user's move circle in the upper left hand of the map but without the user there)
   clearTooltipSelection();

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -492,33 +492,6 @@ export function syncLobby(underworld: Underworld) {
 }
 export function enterPortal(player: IPlayer, underworld: Underworld) {
   console.log(`Player ${player.clientId}/${player.name} entered portal.`);
-  // In the event that it was "game over" because the player died, but ally npcs clear the
-  // level, the player will enter the portal, in which case allowForceInitGameState
-  // should be disabled so that it ignored INIT_GAME_STATE messages again
-  // (During a regular gameover this is set to true so that when the game restarts
-  // the client can recieve the new underworld state)
-  underworld.allowForceInitGameState = false;
-
-  // TODO - Handle this outside of the enter portal function?
-  // Record Progress
-  const mageTypeFarthestLevel = storage.getStoredMageTypeFarthestLevelKey(player.mageType || 'Spellmason');
-  const highScore = storageGet(mageTypeFarthestLevel) || '0'
-  if (parseInt(highScore) < underworld.levelIndex) {
-    console.log('New farthest level record!', mageTypeFarthestLevel, '->', underworld.levelIndex);
-    storageSet(mageTypeFarthestLevel, underworld.levelIndex.toString());
-  }
-
-  if (player == globalThis.player) {
-    // At the end of each level ensure the server has an up-to-date state
-    // of the current client's player object.
-    // The client is the source of truth for it's own player object
-    underworld.pie.sendData({
-      type: MESSAGE_TYPES.CLIENT_SEND_PLAYER_TO_SERVER,
-      player: serialize(player)
-    });
-  }
-
-
   Image.hide(player.unit.image);
   // Make sure to resolve the moving promise once they enter the portal or else 
   // the client queue will get stuck

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -16,7 +16,7 @@ import Underworld, { turn_phase } from '../Underworld';
 import * as target_cone from '../cards/target_cone';
 import * as lastWill from '../cards/lastwill';
 import * as captureSoul from '../cards/capture_soul';
-import { explain, EXPLAIN_BLESSINGS, isFirstTutorialStepComplete, isTutorialComplete } from '../graphics/Explain';
+import { explain, EXPLAIN_BLESSINGS, isTutorialComplete } from '../graphics/Explain';
 import { lightenColor } from '../graphics/ui/colorUtil';
 import { AttributePerk } from '../Perk';
 import { setPlayerNameUI } from '../PlayerUtils';
@@ -129,7 +129,7 @@ export function changeMageType(type: MageType, player?: IPlayer, underworld?: Un
         {
           const upgrade = Upgrade.getUpgradeByTitle(arrowCardId);
           if (upgrade) {
-            underworld.getFreeUpgrade(player, upgrade);
+            underworld.forceUpgrade(player, upgrade, true);
           } else {
             console.error('Could not find arrow upgrade for', type);
           }
@@ -139,7 +139,7 @@ export function changeMageType(type: MageType, player?: IPlayer, underworld?: Un
         {
           const upgrade = Upgrade.getUpgradeByTitle(captureSoul.id);
           if (upgrade) {
-            underworld.getFreeUpgrade(player, upgrade);
+            underworld.forceUpgrade(player, upgrade, true);
           } else {
             console.error('Could not find upgrade for', type);
           }
@@ -149,7 +149,7 @@ export function changeMageType(type: MageType, player?: IPlayer, underworld?: Un
         {
           const upgrade = Upgrade.getUpgradeByTitle(heal_id);
           if (upgrade) {
-            underworld.getFreeUpgrade(player, upgrade);
+            underworld.forceUpgrade(player, upgrade, true);
           } else {
             console.error('Could not find upgrade for', type);
           }
@@ -159,7 +159,7 @@ export function changeMageType(type: MageType, player?: IPlayer, underworld?: Un
         {
           const upgrade = Upgrade.getUpgradeByTitle(contaminate_id);
           if (upgrade) {
-            underworld.getFreeUpgrade(player, upgrade);
+            underworld.forceUpgrade(player, upgrade, true);
           } else {
             console.error('Could not find upgrade for', type);
           }

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -353,11 +353,13 @@ export function resetPlayerForNextLevel(player: IPlayer, underworld: Underworld)
 }
 // Keep a global reference to the current client's player
 export function updateGlobalRefToCurrentClientPlayer(player: IPlayer, underworld: Underworld) {
-  if (numberOfHotseatPlayers > 1) {
-    globalThis.player = player;
-    globalThis.clientId = player.clientId;
-  } else {
-    if (globalThis.clientId === player.clientId) {
+  if (globalThis.clientId == player.clientId) {
+    if (numberOfHotseatPlayers > 1) {
+      globalThis.player = underworld.players[underworld.hotseatCurrentPlayerIndex];
+      if (!globalThis.player) {
+        console.error('Unexpected: Hotseat player is undefined');
+      }
+    } else {
       globalThis.player = player;
     }
   }
@@ -406,25 +408,16 @@ export function load(player: IPlayerSerialized, index: number, underworld: Under
     // might be wrongfully overwritten by a server SYNC_PLAYERS such as getting
     // a summon spell or rerolling.
 
-    if (globalThis.numberOfHotseatPlayers > 1) {
-      // In hotseat, players share the same client Id and if the below else statement were to run
-      // it would make the hotseat players share references to the same arrays and objects
-      // giving them a shared inventory and toolbar which is not desireable.
-      // Besides, there won't be any sync errors on hotseat anyway since hotseat isn't
-      // networked
-      console.debug('Ignore isClientPlayerSourceOfTruth on hotseat multiplayer');
-    } else {
-      if (globalThis.player && playerLoaded.clientId == globalThis.player.clientId) {
-        playerLoaded.cardsInToolbar = globalThis.player.cardsInToolbar;
-        playerLoaded.inventory = globalThis.player.inventory;
-        playerLoaded.freeSpells = globalThis.player.freeSpells;
-        playerLoaded.upgrades = globalThis.player.upgrades;
-        playerLoaded.upgradesLeftToChoose = globalThis.player.upgradesLeftToChoose;
-        playerLoaded.perksLeftToChoose = globalThis.player.perksLeftToChoose;
-        playerLoaded.reroll = globalThis.player.reroll;
-        playerLoaded.attributePerks = globalThis.player.attributePerks;
-        playerLoaded.statPointsUnspent = globalThis.player.statPointsUnspent;
-      }
+    if (globalThis.player && playerLoaded.clientId == globalThis.player.clientId) {
+      playerLoaded.cardsInToolbar = globalThis.player.cardsInToolbar;
+      playerLoaded.inventory = globalThis.player.inventory;
+      playerLoaded.freeSpells = globalThis.player.freeSpells;
+      playerLoaded.upgrades = globalThis.player.upgrades;
+      playerLoaded.upgradesLeftToChoose = globalThis.player.upgradesLeftToChoose;
+      playerLoaded.perksLeftToChoose = globalThis.player.perksLeftToChoose;
+      playerLoaded.reroll = globalThis.player.reroll;
+      playerLoaded.attributePerks = globalThis.player.attributePerks;
+      playerLoaded.statPointsUnspent = globalThis.player.statPointsUnspent;
     }
   }
   // Backwards compatibility after property name change

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -302,6 +302,7 @@ export function setPlayerRobeColor(player: IPlayer, color: number | string, colo
   }
 }
 export function resetPlayerForNextLevel(player: IPlayer, underworld: Underworld) {
+  player.endedTurn = false;
   // Set the player so they can choose their next spawn
   player.isSpawned = false;
   if (player == globalThis.player) {

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -266,8 +266,6 @@ export function setPlayerRobeColor(player: IPlayer, color: number | string, colo
   // Add player-specific shaders
   // regardless of if the image sprite changes to a new animation or not.
   if (player.unit.image && player.unit.image.sprite.filters) {
-
-
     const colorSecondary = lightenColor(color, 0.3);
     if (color && colorSecondary && color !== playerNoColor) {
       const robeColorFilter = new MultiColorReplaceFilter(
@@ -451,17 +449,11 @@ export function load(player: IPlayerSerialized, index: number, underworld: Under
 // Sets boolean and substring denoting if the player has a @websocketpie/client client associated with it
 export function setClientConnected(player: IPlayer, connected: boolean, underworld: Underworld) {
   // Override: If in hotseat multiplayer than all clients are considered connected
-  if (globalThis.numberOfHotseatPlayers > 1) {
-    connected = true;
-  }
-  player.clientConnected = connected;
+  player.clientConnected = globalThis.numberOfHotseatPlayers > 1 ? true : connected;
   if (connected) {
     Image.removeSubSprite(player.unit.image, 'disconnected.png');
-    underworld.queueGameLoop();
   } else {
     Image.addSubSprite(player.unit.image, 'disconnected.png');
-    // If they disconnect, end their turn
-    underworld.endPlayerTurn(player);
   }
   syncLobby(underworld);
 }

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -302,12 +302,21 @@ export function setPlayerRobeColor(player: IPlayer, color: number | string, colo
   }
 }
 export function resetPlayerForNextLevel(player: IPlayer, underworld: Underworld) {
+  console.trace("TEMP - Reset player!");
+  console.warn("TEMP - Reset player: ", player);
+  console.warn("TEMP - Global Player: ", globalThis.player);
+  console.warn("TEMP - Same player?: ", player == globalThis.player);
+
   // Set the player so they can choose their next spawn
   player.isSpawned = false;
   if (player === globalThis.player) {
     globalThis.awaitingSpawn = false;
   }
   player.endedTurn = false;
+
+  console.warn("TEMP - isSpawned: ", player.isSpawned);
+  console.warn("TEMP - Global awaiting spawn: ", globalThis.awaitingSpawn);
+
   // Update player position to be NOT NaN or null (which indicates that the player is in portal),
   // instead, the player is now spawning so their position should be a number.
   // This is important because it allows the player to see enemy attentionMarkers when
@@ -498,6 +507,7 @@ export function enterPortal(player: IPlayer, underworld: Underworld) {
   // the client can recieve the new underworld state)
   underworld.allowForceInitGameState = false;
 
+  // TODO - Handle this outside of the enter portal function?
   // Record Progress
   const mageTypeFarthestLevel = storage.getStoredMageTypeFarthestLevelKey(player.mageType || 'Spellmason');
   const highScore = storageGet(mageTypeFarthestLevel) || '0'

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1332,10 +1332,9 @@ export async function runTurnStartEvents(unit: IUnit, underworld: Underworld, pr
     async (eventName) => {
       const fn = Events.onTurnStartSource[eventName];
       if (fn) {
-        return await fn(unit, prediction, underworld);
+        await fn(unit, prediction, underworld);
       } else {
         console.error('No function associated with turn start event', eventName);
-        return false;
       }
     },
   ));
@@ -1346,10 +1345,9 @@ export async function runTurnEndEvents(unit: IUnit, underworld: Underworld, pred
     async (eventName) => {
       const fn = Events.onTurnEndSource[eventName];
       if (fn) {
-        return await fn(unit, prediction, underworld);
+        await fn(unit, prediction, underworld);
       } else {
         console.error('No function associated with turn end event', eventName);
-        return false;
       }
     },
   ));

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1118,6 +1118,9 @@ export function canMove(unit: IUnit): boolean {
     // console.log("canMove: false - unit has already used all their stamina this turn")
     return false;
   }
+  if (unit.moveSpeed <= 0) {
+    return false;
+  }
   return true;
 }
 export function livingUnitsInDifferentFaction(unit: IUnit, underworld: Underworld) {

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1285,9 +1285,12 @@ export function inRange(unit: IUnit, target: Vec2): boolean {
 
 export async function startTurnForUnits(units: IUnit[], underworld: Underworld, prediction: boolean) {
   // Trigger start turn events
+  const turnStartPromises = [];
   for (let unit of units) {
-    await runTurnStartEvents(unit, underworld, prediction);
+    turnStartPromises.push(runTurnStartEvents(unit, underworld, prediction))
   }
+  await raceTimeout(5000, 'Turn Start Events did not resolve', Promise.all(turnStartPromises));
+
   // Regenerate stamina to max
   for (let unit of units.filter(u => u.alive)) {
     if (unit.stamina < unit.staminaMax) {
@@ -1305,9 +1308,12 @@ export async function startTurnForUnits(units: IUnit[], underworld: Underworld, 
 
 export async function endTurnForUnits(units: IUnit[], underworld: Underworld, prediction: boolean) {
   // Trigger end turn events
+  const turnEndPromises = [];
   for (let unit of units) {
-    await runTurnEndEvents(unit, underworld, prediction);
+    turnEndPromises.push(runTurnEndEvents(unit, underworld, prediction))
   }
+  await raceTimeout(5000, 'Turn End Events did not resolve', Promise.all(turnEndPromises));
+
   // At the end of their turn, deal damage if still in liquid
   for (let unit of units.filter(u => u.inLiquid && u.alive)) {
     doLiquidEffect(underworld, unit, false);

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1,6 +1,5 @@
 import type * as PIXI from 'pixi.js';
 import { OutlineFilter } from '@pixi/filter-outline';
-import * as storage from "../storage";
 import * as config from '../config';
 import * as Image from '../graphics/Image';
 import * as math from '../jmath/math';
@@ -865,62 +864,6 @@ export function die(unit: IUnit, underworld: Underworld, prediction: boolean) {
   }
   // Once a unit dies it is no longer on it's originalLife
   unit.originalLife = false;
-  // For the bossmason level, if there is only 1 bossmason, when it dies, spawn 3 more:
-  if (underworld.levelIndex === config.LAST_LEVEL_INDEX && underworld.units.filter(u => u.unitSourceId == bossmasonUnitId).length == 1) {
-    if (unit.unitSourceId == bossmasonUnitId) {
-      const mageTypeWinsKey = storage.getStoredMageTypeWinsKey(player?.mageType || 'Spellmason');
-      const currentMageTypeWins = parseInt(storageGet(mageTypeWinsKey) || '0');
-      storageSet(mageTypeWinsKey, (currentMageTypeWins + 1).toString());
-      (prediction
-        ? underworld.unitsPrediction
-        : underworld.units).filter(u => u.unitType == UnitType.AI && u.unitSubType !== UnitSubType.DOODAD).forEach(u => die(u, underworld, prediction));
-      if (!prediction) {
-        let retryAttempts = 0;
-        for (let i = 0; (i < 3 && retryAttempts < 10); i++) {
-          const seed = seedrandom(`${underworld.seed}-${underworld.turn_number}-${unit.id}`);
-          const coords = findRandomGroundLocation(underworld, unit, seed);
-          if (!coords) {
-            retryAttempts++;
-            i--;
-            continue;
-          } else {
-            retryAttempts = 0;
-          }
-          // Animate effect of unit spawning from the sky
-          const newBossmason = create(
-            bossmasonUnitId,
-            coords.x,
-            coords.y,
-            Faction.ENEMY,
-            deathmason.info.image,
-            UnitType.AI,
-            deathmason.info.subtype,
-            deathmason.unitProps,
-            underworld,
-            prediction
-          );
-          const givenName = ['Darius', 'Magnus', 'Lucius'][i] || '';
-          const dialogue = [
-            'deathmason dialogue 1',
-            'deathmason dialogue 2',
-            'deathmason dialogue 3',
-          ][i];
-          newBossmason.name = `${givenName}`;
-          // If deathmasons are spawned during the NPC_ALLY turn
-          // meaning an ally killed the first deathmason, give them
-          // summoning sickness so they can't attack right after spawning
-          if (underworld.turn_phase == turn_phase.NPC_ALLY) {
-            addModifier(newBossmason, summoningSicknessId, underworld, false);
-          }
-          skyBeam(newBossmason);
-          if (dialogue) {
-            floatingText({ coords: newBossmason, text: dialogue, valpha: 0.005, aalpha: 0 })
-          }
-        }
-      }
-
-    }
-  }
 }
 export function composeOnDamageEvents(unit: IUnit, damage: number, underworld: Underworld, prediction: boolean): number {
   // Compose onDamageEvents

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1522,6 +1522,7 @@ export function drawSelectedGraphics(unit: IUnit, prediction: boolean = false, u
 
   // TODO - Ideally the logic below would be defined in each Unit's ts file individually
   // Instead of using if/else and unit subtypes
+  // Cleanup for AI Refactor https://github.com/jdoleary/Spellmasons/issues/388
 
   // If unit is an archer, draw LOS attack line
   // instead of attack range for them
@@ -1546,26 +1547,35 @@ export function drawSelectedGraphics(unit: IUnit, prediction: boolean = false, u
       // If getBestRangedLOSTarget returns undefined, the archer doesn't have a valid attack target
       canAttack = false;
     }
+    const rangeCircleColor = false
+      ? colors.outOfRangeGrey
+      : unit.faction == Faction.ALLY
+        ? colors.attackRangeAlly
+        : colors.attackRangeEnemy;
 
-    if (archerTargets.length) {
-      for (let target of archerTargets) {
-        const attackLine = { p1: unit, p2: target };
-        globalThis.selectedUnitGraphics.moveTo(attackLine.p1.x, attackLine.p1.y);
+    // Draw outer attack range circle
+    drawUICircle(globalThis.selectedUnitGraphics, unit, unit.attackRange, rangeCircleColor, i18n('Attack Range'));
 
-        // If the los unit can attack you, use red, if not, use grey
-        const color = canAttack ? colors.healthRed : colors.outOfRangeGrey;
+    // TODO - Consider re-implementing attack lines with AI refactor
+    // https://github.com/jdoleary/Spellmasons/issues/408
+    // if (archerTargets.length) {
+    //   for (let target of archerTargets) {
+    //     const attackLine = { p1: unit, p2: target };
+    //     globalThis.selectedUnitGraphics.moveTo(attackLine.p1.x, attackLine.p1.y);
 
-        // Draw los line
-        globalThis.selectedUnitGraphics.lineStyle(3, color, 0.7);
-        globalThis.selectedUnitGraphics.lineTo(attackLine.p2.x, attackLine.p2.y);
-        globalThis.selectedUnitGraphics.drawCircle(attackLine.p2.x, attackLine.p2.y, 3);
+    //     // If the los unit can attack you, use red, if not, use grey
+    //     const color = canAttack ? colors.healthRed : colors.outOfRangeGrey;
 
-        // Draw outer attack range circle
-        drawUICircle(globalThis.selectedUnitGraphics, unit, unit.attackRange, color, i18n('Attack Range'));
-      }
-    }
+    //     // Draw los line
+    //     globalThis.selectedUnitGraphics.lineStyle(3, color, 0.7);
+    //     globalThis.selectedUnitGraphics.lineTo(attackLine.p2.x, attackLine.p2.y);
+    //     globalThis.selectedUnitGraphics.drawCircle(attackLine.p2.x, attackLine.p2.y, 3);
+    //   }
+    // }
   } else {
     if (unit.attackRange > 0) {
+      // TODO - Unused outOfRangeGrey below, consider for AI refactor
+      // https://github.com/jdoleary/Spellmasons/issues/388
       const rangeCircleColor = false
         ? colors.outOfRangeGrey
         : unit.faction == Faction.ALLY

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -835,19 +835,6 @@ export function die(unit: IUnit, underworld: Underworld, prediction: boolean) {
     explain(EXPLAIN_DEATH);
     playSFXKey('game_over');
   }
-  if (unit.unitType == UnitType.PLAYER_CONTROLLED && !prediction) {
-    const player = underworld.players.find(p => p.unit == unit);
-    if (!player) {
-      console.error('Player unit died but could not find them in players array to end their turn');
-    } else if (player == globalThis.player) {
-      // Send an end turn message rather than just invoking endPlayerTurn
-      // so that it waits to execute until the spell is done casting.
-      // This change was made in response to self kill + resurrect 
-      // triggering the end of your turn before the spell finished
-      // (before the resurrect occurred)
-      underworld.pie.sendData({ type: MESSAGE_TYPES.END_TURN });
-    }
-  }
   // In the event that this unit that just died is the selected unit,
   // this will remove the tooltip:
   checkIfNeedToClearTooltip();

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -44,6 +44,8 @@ import seedrandom from 'seedrandom';
 import { summoningSicknessId } from '../modifierSummoningSickness';
 import * as log from '../log';
 import { suffocateCardId, updateSuffocate } from '../cards/suffocate';
+import { doLiquidEffect } from '../inLiquid';
+import { freezeCardId } from '../cards/freeze';
 
 const elCautionBox = document.querySelector('#caution-box') as HTMLElement;
 const elCautionBoxText = document.querySelector('#caution-box-text') as HTMLElement;
@@ -755,10 +757,6 @@ export function resurrect(unit: IUnit, underworld: Underworld) {
   // Return dead units back to full health
   unit.health = unit.healthMax;
   unit.alive = true;
-  if (unit.unitType == UnitType.PLAYER_CONTROLLED) {
-    const player = underworld.players.find(p => p.unit == unit);
-    if (player) player.endedTurn = false;
-  }
   returnToDefaultSprite(unit);
 }
 export function die(unit: IUnit, underworld: Underworld, prediction: boolean) {
@@ -1107,6 +1105,20 @@ export function syncPlayerHealthManaUI(underworld: Underworld) {
 
   }
 }
+
+export function canAct(unit: IUnit): boolean {
+  if (!unit.alive) {
+    return false;
+  }
+
+  // TODO - Find cleaner method. Event args?
+  if (unit.modifiers[freezeCardId]) {
+    return false;
+  }
+
+  return true;
+}
+
 export function canMove(unit: IUnit): boolean {
   // Do not move if dead
   if (!unit.alive) {
@@ -1315,6 +1327,34 @@ export async function runTurnStartEvents(unit: IUnit, prediction: boolean = fals
   }
   return abortTurn
 
+}
+export async function endTurnForUnits(units: IUnit[], underworld: Underworld) {
+  // Trigger end turn events
+  for (let unit of units) {
+    await Promise.all(unit.onTurnEndEvents.map(
+      async (eventName) => {
+        const fn = Events.onTurnEndSource[eventName];
+        return fn ? await fn(unit, false, underworld) : false;
+      },
+    ));
+  }
+
+  // At the end of their turn, deal damage if still in liquid
+  for (let unit of units) {
+    if (unit.inLiquid && unit.alive) {
+      doLiquidEffect(underworld, unit, false);
+      floatingText({ coords: unit, text: 'Liquid damage', style: { fill: 'red' } });
+    }
+  }
+
+  // Add mana to AI units
+  for (let unit of units.filter(u => u.unitType == UnitType.AI)) {
+    if (unit.alive) {
+      unit.mana += unit.manaPerTurn;
+      // Cap manaPerTurn at manaMax
+      unit.mana = Math.min(unit.mana, unit.manaMax);
+    }
+  }
 }
 export function makeMiniboss(unit: IUnit) {
   if (unit.unitSourceId == bossmasonUnitId) {

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1098,7 +1098,7 @@ export function canAct(unit: IUnit): boolean {
   }
 
   // TODO - Find cleaner method. Event args?
-  if (unit.modifiers[freezeCardId]) {
+  if (unit.modifiers[freezeCardId] || unit.modifiers[summoningSicknessId]) {
     return false;
   }
 

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1637,7 +1637,6 @@ export function resetUnitStats(unit: IUnit, underworld: Underworld) {
   unit.stamina = unit.staminaMax;
 
   returnToDefaultSprite(unit);
-
 }
 
 export function unitSourceIdToName(unitSourceId: string, asMiniboss: boolean): string {

--- a/src/entity/units/deathmason.ts
+++ b/src/entity/units/deathmason.ts
@@ -193,9 +193,13 @@ export function registerDeathmasonEvents() {
       // For the bossmason level, if the original deathmason dies spawn 3 more:
       if (underworld.levelIndex === config.LAST_LEVEL_INDEX) {
         if (unit.unitSourceId == bossmasonUnitId && unit.originalLife && unit.name == undefined) {
-          const mageTypeWinsKey = storage.getStoredMageTypeWinsKey(player?.mageType || 'Spellmason');
-          const currentMageTypeWins = parseInt(storageGet(mageTypeWinsKey) || '0');
-          storageSet(mageTypeWinsKey, (currentMageTypeWins + 1).toString());
+          // Use list here in case of hotseat
+          let clientPlayers = underworld.players.filter(p => p.clientId == globalThis.clientId);
+          for (let player of clientPlayers) {
+            const mageTypeWinsKey = storage.getStoredMageTypeWinsKey(player.mageType || 'Spellmason');
+            const currentMageTypeWins = parseInt(storageGet(mageTypeWinsKey) || '0');
+            storageSet(mageTypeWinsKey, (currentMageTypeWins + 1).toString());
+          }
           (prediction
             ? underworld.unitsPrediction
             : underworld.units).filter(u => u.unitType == UnitType.AI && u.unitSubType !== UnitSubType.DOODAD).forEach(u => Unit.die(u, underworld, prediction));

--- a/src/entity/units/urn_ice.ts
+++ b/src/entity/units/urn_ice.ts
@@ -57,7 +57,7 @@ export function registerUrnIceExplode() {
       const units = explode(unit, unit.attackRange, 0, 0, underworld, prediction, "#002c6e", "#59deff");
       units.filter(u => u.alive)
         .forEach(u => {
-          Unit.addModifier(u, freeze.id, underworld, prediction, 1);
+          Unit.addModifier(u, freeze.freezeCardId, underworld, prediction, 1);
         });
 
       // Remove corpse

--- a/src/entity/units/urn_poison.ts
+++ b/src/entity/units/urn_poison.ts
@@ -59,7 +59,7 @@ export function registerUrnpoisonExplode() {
       units.filter(u => u.alive)
         .forEach(u => {
           if (!prediction) {
-            animateSpell(u, 'spell-effects/spellPoison'); // TODO - Put in poison modifier?
+            animateSpell(u, 'spell-effects/spellPoison'); // TODO - Put in poison modifier "add" function?
           }
           Unit.addModifier(u, poison.poisonCardId, underworld, prediction, 1);
         });

--- a/src/graphics/Explain.ts
+++ b/src/graphics/Explain.ts
@@ -5,49 +5,49 @@ import Jprompt, { PromptArgs } from './Jprompt';
 import { keyToHumanReadable } from './ui/keyMapping';
 const ALREADY_EXPLAINED = 'explained'
 export function explain(key: string, forceShow?: boolean) {
-    if (globalThis.headless) {
-        return;
-    }
-    const explainData = explainMap[key];
-    if (forceShow || !isAlreadyExplained(key)) {
-        if (explainData) {
-            // If condition is met
-            if (forceShow || !explainData.condition || explainData.condition()) {
-                let portal = document.getElementById('explain-portal');
-                if (portal) {
-                    // Clear previous explain if this is a forceShow (meaning it's coming from the help screen)
-                    // and rendering into a portal
-                    portal.innerHTML = "";
-                }
-                // Slightly delay showing explain prompt so the button doesn't flicker on for a moment before CSS has a chance
-                // to mark cinematic camera as active
-                setTimeout(() => {
-                    Jprompt({ ...explainData.prompt(), portal: forceShow ? (portal || undefined) : undefined, forceShow });
-                }, 500);
-                storage.set(key, ALREADY_EXPLAINED);
-            }
-        } else {
-            console.error('explainData not found for key', key);
+  if (globalThis.headless) {
+    return;
+  }
+  const explainData = explainMap[key];
+  if (forceShow || !isAlreadyExplained(key)) {
+    if (explainData) {
+      // If condition is met
+      if (forceShow || !explainData.condition || explainData.condition()) {
+        let portal = document.getElementById('explain-portal');
+        if (portal) {
+          // Clear previous explain if this is a forceShow (meaning it's coming from the help screen)
+          // and rendering into a portal
+          portal.innerHTML = "";
         }
+        // Slightly delay showing explain prompt so the button doesn't flicker on for a moment before CSS has a chance
+        // to mark cinematic camera as active
+        setTimeout(() => {
+          Jprompt({ ...explainData.prompt(), portal: forceShow ? (portal || undefined) : undefined, forceShow });
+        }, 500);
+        storage.set(key, ALREADY_EXPLAINED);
+      }
+    } else {
+      console.error('explainData not found for key', key);
     }
+  }
 
 }
 globalThis.menuExplain = (key: string) => {
-    explain(key, true);
+  explain(key, true);
 }
 function isAlreadyExplained(key: string): boolean {
-    const explainData = explainMap[key];
-    if (globalThis.privacyPolicyAndEULAConsent) {
-        if (explainData) {
-            // If not already explained
-            return storage.get(key) == ALREADY_EXPLAINED;
-        } else {
-            console.error('explainData not found for key', key);
-            return false;
-        }
+  const explainData = explainMap[key];
+  if (globalThis.privacyPolicyAndEULAConsent) {
+    if (explainData) {
+      // If not already explained
+      return storage.get(key) == ALREADY_EXPLAINED;
     } else {
-        return false;
+      console.error('explainData not found for key', key);
+      return false;
     }
+  } else {
+    return false;
+  }
 }
 
 export const EXPLAIN_WALK = 'How to Move';
@@ -69,305 +69,308 @@ export const EXPLAIN_DEATH = 'Surviving Death';
 export const EXPLAIN_MINI_BOSSES = 'Mini Bosses';
 export const EXPLAIN_PING = 'Pinging';
 interface ExplainData {
-    condition?: () => boolean;
-    // Returns args to pass into Jprompt
-    prompt: () => PromptArgs;
+  condition?: () => boolean;
+  // Returns args to pass into Jprompt
+  prompt: () => PromptArgs;
 };
 
 const explainMap: { [key: string]: ExplainData } = {
-    [EXPLAIN_WALK]: {
-        prompt: () => ({ imageSrc: 'images/explain/walk.gif', text: 'explain move', yesText: 'Okay' })
-    },
-    [EXPLAIN_CAST]: {
-        prompt: () => ({ imageSrc: 'images/explain/cast.gif', text: ['explain cast', keyToHumanReadable(['Escape'])], yesText: 'Nice!' })
-    },
-    [EXPLAIN_STACK]: {
-        prompt: () => ({ imageSrc: 'images/explain/stack-spells.gif', text: 'explain stack', yesText: 'Intriguing...' })
+  [EXPLAIN_WALK]: {
+    prompt: () => ({ imageSrc: 'images/explain/walk.gif', text: 'explain move', yesText: 'Okay' })
+  },
+  [EXPLAIN_CAST]: {
+    prompt: () => ({ imageSrc: 'images/explain/cast.gif', text: ['explain cast', keyToHumanReadable(['Escape'])], yesText: 'Nice!' })
+  },
+  [EXPLAIN_STACK]: {
+    prompt: () => ({ imageSrc: 'images/explain/stack-spells.gif', text: 'explain stack', yesText: 'Intriguing...' })
 
-    },
-    [EXPLAIN_WALK_ROPE]: {
-        prompt: () => ({ imageSrc: 'images/explain/walk-rope.gif', text: ['explain walk rope', keyToHumanReadable(globalThis.controlMap.showWalkRope)], yesText: 'Okay' })
+  },
+  [EXPLAIN_WALK_ROPE]: {
+    prompt: () => ({ imageSrc: 'images/explain/walk-rope.gif', text: ['explain walk rope', keyToHumanReadable(globalThis.controlMap.showWalkRope)], yesText: 'Okay' })
 
-    },
-    [EXPLAIN_END_TURN]: {
-        prompt: () => ({
-            imageSrc: 'images/explain/end-turn.gif', text: ['explain end turn', keyToHumanReadable(globalThis.controlMap.endTurn)], yesText: 'Okay'
-        })
-    },
-    [EXPLAIN_OVERFILL]: {
-        condition: () => !!globalThis.player && globalThis.player.unit.mana > globalThis.player.unit.manaMax,
-        prompt: () => ({ imageSrc: 'images/explain/mana-overfill.gif', text: 'explain overfill', yesText: 'Cool!' })
+  },
+  [EXPLAIN_END_TURN]: {
+    prompt: () => ({
+      imageSrc: 'images/explain/end-turn.gif', text: ['explain end turn', keyToHumanReadable(globalThis.controlMap.endTurn)], yesText: 'Okay'
+    })
+  },
+  [EXPLAIN_OVERFILL]: {
+    condition: () => !!globalThis.player && globalThis.player.unit.mana > globalThis.player.unit.manaMax,
+    prompt: () => ({ imageSrc: 'images/explain/mana-overfill.gif', text: 'explain overfill', yesText: 'Cool!' })
 
-    },
-    [EXPLAIN_MANA_COST]: {
-        prompt: () => ({ imageSrc: 'images/explain/mana-cost.gif', text: 'explain mana cost', yesText: 'Okay' })
+  },
+  [EXPLAIN_MANA_COST]: {
+    prompt: () => ({ imageSrc: 'images/explain/mana-cost.gif', text: 'explain mana cost', yesText: 'Okay' })
 
-    },
-    [EXPLAIN_ATTENTION_MARKER_MELEE]: {
-        prompt: () => ({ imageSrc: 'images/explain/attentionMarkerMelee.gif', text: 'explain attention markers melee', yesText: 'Okay' })
+  },
+  [EXPLAIN_ATTENTION_MARKER_MELEE]: {
+    prompt: () => ({ imageSrc: 'images/explain/attentionMarkerMelee.gif', text: 'explain attention markers melee', yesText: 'Okay' })
 
-    },
-    [EXPLAIN_ATTENTION_MARKER_RANGED]: {
-        prompt: () => ({ imageSrc: 'images/explain/attentionMarkerRanged.gif', text: 'explain attention markers', yesText: 'Okay' })
+  },
+  [EXPLAIN_ATTENTION_MARKER_RANGED]: {
+    prompt: () => ({ imageSrc: 'images/explain/attentionMarkerRanged.gif', text: 'explain attention markers', yesText: 'Okay' })
 
-    },
-    [EXPLAIN_CAMERA]: {
-        prompt: () => ({
-            imageSrc: 'images/explain/camera-movement.gif', text: ['explain camera movement', keyToHumanReadable(globalThis.controlMap.cameraUp), keyToHumanReadable(globalThis.controlMap.cameraLeft), keyToHumanReadable(globalThis.controlMap.cameraDown), keyToHumanReadable(globalThis.controlMap.cameraRight), keyToHumanReadable(globalThis.controlMap.recenterCamera)], yesText: 'Okay'
-        })
+  },
+  [EXPLAIN_CAMERA]: {
+    prompt: () => ({
+      imageSrc: 'images/explain/camera-movement.gif', text: ['explain camera movement', keyToHumanReadable(globalThis.controlMap.cameraUp), keyToHumanReadable(globalThis.controlMap.cameraLeft), keyToHumanReadable(globalThis.controlMap.cameraDown), keyToHumanReadable(globalThis.controlMap.cameraRight), keyToHumanReadable(globalThis.controlMap.recenterCamera)], yesText: 'Okay'
+    })
 
-    },
-    [EXPLAIN_INVENTORY]: {
-        prompt: () => ({
-            imageSrc: 'images/explain/inventory.gif', text: ['explain inventory', keyToHumanReadable(globalThis.controlMap.openInventory)], yesText: "I'm so organized!"
-        })
+  },
+  [EXPLAIN_INVENTORY]: {
+    prompt: () => ({
+      imageSrc: 'images/explain/inventory.gif', text: ['explain inventory', keyToHumanReadable(globalThis.controlMap.openInventory)], yesText: "I'm so organized!"
+    })
 
-    },
-    [EXPLAIN_LIQUID_DAMAGE]: {
-        prompt: () => ({
-            imageSrc: 'images/explain/liquid-damage.gif', text: 'explain liquid damage', yesText: 'Yikes!'
-        })
-    },
-    [EXPLAIN_BLESSINGS]: {
-        prompt: () => ({
-            imageSrc: 'images/explain/bless-ally.gif', text: `explain blessings`, yesText: 'Got it!'
-        })
-    },
-    [EXPLAIN_REMOVE_SPELLS]: {
-        prompt: () => ({
-            imageSrc: 'images/explain/delete-queued-spells.gif', text: ['explain remove spells', keyToHumanReadable(globalThis.controlMap.dequeueSpell)], yesText: 'Okay'
-        })
-    },
-    [EXPLAIN_FORGE_ORDER]: {
-        prompt: () => ({
-            imageSrc: 'images/explain/forge-order.gif', text: 'explain forge order', yesText: 'Okay'
-        })
-    },
-    [EXPLAIN_DEATH]: {
-        prompt: () => ({
-            imageSrc: 'images/explain/death.gif', text: 'explain death', yesText: 'Okay'
-        })
-    },
-    [EXPLAIN_MINI_BOSSES]: {
-        prompt: () => ({
-            imageSrc: 'images/explain/minibosses.gif', text: 'explain minibosses', yesText: 'Got it!'
-        })
-    },
-    [EXPLAIN_PING]: {
-        prompt: () => ({
-            imageSrc: 'images/explain/ping.gif', text: ['explain ping', keyToHumanReadable(globalThis.controlMap.ping)], yesText: 'Cool!'
-        })
-    },
+  },
+  [EXPLAIN_LIQUID_DAMAGE]: {
+    prompt: () => ({
+      imageSrc: 'images/explain/liquid-damage.gif', text: 'explain liquid damage', yesText: 'Yikes!'
+    })
+  },
+  [EXPLAIN_BLESSINGS]: {
+    prompt: () => ({
+      imageSrc: 'images/explain/bless-ally.gif', text: `explain blessings`, yesText: 'Got it!'
+    })
+  },
+  [EXPLAIN_REMOVE_SPELLS]: {
+    prompt: () => ({
+      imageSrc: 'images/explain/delete-queued-spells.gif', text: ['explain remove spells', keyToHumanReadable(globalThis.controlMap.dequeueSpell)], yesText: 'Okay'
+    })
+  },
+  [EXPLAIN_FORGE_ORDER]: {
+    prompt: () => ({
+      imageSrc: 'images/explain/forge-order.gif', text: 'explain forge order', yesText: 'Okay'
+    })
+  },
+  [EXPLAIN_DEATH]: {
+    prompt: () => ({
+      imageSrc: 'images/explain/death.gif', text: 'explain death', yesText: 'Okay'
+    })
+  },
+  [EXPLAIN_MINI_BOSSES]: {
+    prompt: () => ({
+      imageSrc: 'images/explain/minibosses.gif', text: 'explain minibosses', yesText: 'Got it!'
+    })
+  },
+  [EXPLAIN_PING]: {
+    prompt: () => ({
+      imageSrc: 'images/explain/ping.gif', text: ['explain ping', keyToHumanReadable(globalThis.controlMap.ping)], yesText: 'Cool!'
+    })
+  },
 }
 globalThis.explainKeys = Object.keys(explainMap);
 export const autoExplains = [
-    EXPLAIN_ATTENTION_MARKER_MELEE,
-    EXPLAIN_MANA_COST,
-    EXPLAIN_WALK_ROPE,
-    EXPLAIN_STACK,
-    EXPLAIN_ATTENTION_MARKER_RANGED,
-    EXPLAIN_CAMERA,
-    EXPLAIN_REMOVE_SPELLS,
-    EXPLAIN_FORGE_ORDER
+  EXPLAIN_ATTENTION_MARKER_MELEE,
+  EXPLAIN_MANA_COST,
+  EXPLAIN_WALK_ROPE,
+  EXPLAIN_STACK,
+  EXPLAIN_ATTENTION_MARKER_RANGED,
+  EXPLAIN_CAMERA,
+  EXPLAIN_REMOVE_SPELLS,
+  EXPLAIN_FORGE_ORDER
 ]
 export function autoExplain() {
-    // @ts-ignore: This global isn't on the server
-    if (globalThis.devUnderworld && globalThis.devUnderworld.levelIndex > 2) {
-        for (let e of autoExplains) {
-            if (!isAlreadyExplained(e)) {
-                explain(e);
-                // Stop after finding one that needs explaining
-                return;
-            }
-        }
+  // @ts-ignore: This global isn't on the server
+  if (globalThis.devUnderworld && globalThis.devUnderworld.levelIndex > 2) {
+    for (let e of autoExplains) {
+      if (!isAlreadyExplained(e)) {
+        explain(e);
+        // Stop after finding one that needs explaining
+        return;
+      }
     }
+  }
 
 }
 export function setTutorialVisiblity(visible: boolean) {
-    document.body.classList.toggle('showTutorial', visible);
-    globalThis.doUpdateTutorialChecklist = visible;
-    updateTutorialChecklist();
+  document.body.classList.toggle('showTutorial', visible);
+  globalThis.doUpdateTutorialChecklist = visible;
+  updateTutorialChecklist();
 }
 interface TutorialChecklistItem {
-    visible: boolean;
-    complete: boolean;
-    text: string;
-    nextVisibleTasks: (keyof TutorialChecklist)[];
-    showExplainPopup: string[];
+  visible: boolean;
+  complete: boolean;
+  text: string;
+  nextVisibleTasks: (keyof TutorialChecklist)[];
+  showExplainPopup: string[];
 }
 export interface TutorialChecklist {
-    spawn: TutorialChecklistItem;
-    moved: TutorialChecklistItem;
-    portal: TutorialChecklistItem;
-    cast: TutorialChecklistItem;
-    castMultipleInOneTurn: TutorialChecklistItem;
-    camera: TutorialChecklistItem;
-    recenterCamera: TutorialChecklistItem;
+  spawn: TutorialChecklistItem;
+  moved: TutorialChecklistItem;
+  portal: TutorialChecklistItem;
+  cast: TutorialChecklistItem;
+  castMultipleInOneTurn: TutorialChecklistItem;
+  camera: TutorialChecklistItem;
+  recenterCamera: TutorialChecklistItem;
 }
 const tutorialChecklist: TutorialChecklist = {
-    spawn: {
-        visible: true,
-        complete: false,
-        text: "Click somewhere on the grass to choose a spawn point",
-        nextVisibleTasks: ['moved', 'portal'],
-        showExplainPopup: [],
-    },
-    moved: {
-        visible: false,
-        complete: false,
-        text: "Hold right mouse button to walk towards your cursor",
-        nextVisibleTasks: [],
-        showExplainPopup: [EXPLAIN_WALK],
-    },
-    portal: {
-        visible: false,
-        complete: false,
-        text: "Move into the portal to go to the next level",
-        nextVisibleTasks: ['camera', 'cast'],
-        showExplainPopup: [],
-    },
-    cast: {
-        visible: false,
-        complete: false,
-        text: "Click on a spell from your toolbar to queue it up and then click on a target to cast it",
-        nextVisibleTasks: ['castMultipleInOneTurn'],
-        showExplainPopup: [EXPLAIN_CAST],
-    },
-    castMultipleInOneTurn: {
-        visible: false,
-        complete: false,
-        text: "Cast more than once in a single turn",
-        nextVisibleTasks: [],
-        showExplainPopup: [],
-    },
-    camera: {
-        visible: false,
-        complete: false,
-        text: "Move the camera with W,A,S, and D keys or by holding and dragging Middle Mouse Button",
-        nextVisibleTasks: ['recenterCamera'],
-        showExplainPopup: [],
-    },
-    recenterCamera: {
-        visible: false,
-        complete: false,
-        text: "Recenter the camera with the Z key",
-        nextVisibleTasks: [],
-        showExplainPopup: [],
-    },
+  spawn: {
+    visible: true,
+    complete: false,
+    text: "Click somewhere on the grass to choose a spawn point",
+    nextVisibleTasks: ['moved', 'portal'],
+    showExplainPopup: [],
+  },
+  moved: {
+    visible: false,
+    complete: false,
+    text: "Hold right mouse button to walk towards your cursor",
+    nextVisibleTasks: [],
+    showExplainPopup: [EXPLAIN_WALK],
+  },
+  portal: {
+    visible: false,
+    complete: false,
+    text: "Move into the portal to go to the next level",
+    nextVisibleTasks: ['camera', 'cast'],
+    showExplainPopup: [],
+  },
+  cast: {
+    visible: false,
+    complete: false,
+    text: "Click on a spell from your toolbar to queue it up and then click on a target to cast it",
+    nextVisibleTasks: ['castMultipleInOneTurn'],
+    showExplainPopup: [EXPLAIN_CAST],
+  },
+  castMultipleInOneTurn: {
+    visible: false,
+    complete: false,
+    text: "Cast more than once in a single turn",
+    nextVisibleTasks: [],
+    showExplainPopup: [],
+  },
+  camera: {
+    visible: false,
+    complete: false,
+    text: "Move the camera with W,A,S, and D keys or by holding and dragging Middle Mouse Button",
+    nextVisibleTasks: ['recenterCamera'],
+    showExplainPopup: [],
+  },
+  recenterCamera: {
+    visible: false,
+    complete: false,
+    text: "Recenter the camera with the Z key",
+    nextVisibleTasks: [],
+    showExplainPopup: [],
+  },
 }
 
 export function updateTutorialChecklist() {
-    if (globalThis.usingTestRunner) {
-        return;
+  if (globalThis.usingTestRunner) {
+    return;
+  }
+  let html = `<h3>${i18n('Tutorial')}</h3>`;
+  const tutorialItems = Object.values(tutorialChecklist);
+  const completeTutorialItems = tutorialItems.filter(x => x.complete);
+  if (completeTutorialItems.length) {
+    let completedItemsHtml = '';
+    for (let item of completeTutorialItems) {
+      if (item.visible) {
+        completedItemsHtml += `<div class="complete">&#x2611; <span class="text complete">${i18n(item.text)}</span></div>`
+      }
     }
-    let html = `<h3>${i18n('Tutorial')}</h3>`;
-    const tutorialItems = Object.values(tutorialChecklist);
-    const completeTutorialItems = tutorialItems.filter(x => x.complete);
-    if (completeTutorialItems.length) {
-        let completedItemsHtml = '';
-        for (let item of completeTutorialItems) {
-            if (item.visible) {
-                completedItemsHtml += `<div class="complete">&#x2611; <span class="text complete">${i18n(item.text)}</span></div>`
-            }
-        }
-        html += `<details>
+    html += `<details>
             <summary>${i18n('Completed Tasks')} ${completeTutorialItems.length}/${tutorialItems.length}</summary>
             ${completedItemsHtml}
             </details>`
+  }
+  for (let item of tutorialItems.filter(x => !x.complete)) {
+    if (item.visible) {
+      html += `<div>&#x2610; <span class="text">${i18n(item.text)}</span></div>`
     }
-    for (let item of tutorialItems.filter(x => !x.complete)) {
-        if (item.visible) {
-            html += `<div>&#x2610; <span class="text">${i18n(item.text)}</span></div>`
-        }
-    }
-    elTutorialChecklistInner.innerHTML = html;
+  }
+  elTutorialChecklistInner.innerHTML = html;
 }
 const COMPLETE = 'complete';
 export function tutorialCompleteTask(key: keyof TutorialChecklist, condition?: () => boolean) {
-    if (globalThis.doUpdateTutorialChecklist && (condition ? condition() : true)) {
-        const task = tutorialChecklist[key];
-        if (task) {
-            console.log('Tutorial: Complete task', task.text);
-            task.complete = true;
-            storage.set(getTutorialStorageKey(key), COMPLETE);
-            for (let nextTask of task.nextVisibleTasks) {
-                tutorialShowTask(nextTask);
-            }
-            updateTutorialChecklist();
-            isTutorialComplete();
-        } else {
-            console.error('No such tutorial task with key', key);
-        }
+  if (globalThis.doUpdateTutorialChecklist && (condition ? condition() : true)) {
+    const task = tutorialChecklist[key];
+    if (task) {
+      console.log('Tutorial: Complete task', task.text);
+      task.complete = true;
+      storage.set(getTutorialStorageKey(key), COMPLETE);
+      for (let nextTask of task.nextVisibleTasks) {
+        tutorialShowTask(nextTask);
+      }
+      updateTutorialChecklist();
+      isTutorialComplete();
+    } else {
+      console.error('No such tutorial task with key', key);
     }
+  }
 }
 globalThis.skipTutorial = async () => {
-    const yesSkip = await Jprompt({ text: 'skip tutorial detail', yesText: 'Yes', noBtnText: 'Cancel', noBtnKey: 'Escape', forceShow: true })
-    if (yesSkip) {
-        // Set all enemies as encountered:
-        globalThis.enemyEncountered = Object.keys(allUnits);
-        storage.set(storage.ENEMY_ENCOUNTERED_STORAGE_KEY, JSON.stringify(globalThis.enemyEncountered));
+  const yesSkip = await Jprompt({ text: 'skip tutorial detail', yesText: 'Yes', noBtnText: 'Cancel', noBtnKey: 'Escape', forceShow: true })
+  if (yesSkip) {
+    // Set all enemies as encountered:
+    globalThis.enemyEncountered = Object.keys(allUnits);
+    storage.set(storage.ENEMY_ENCOUNTERED_STORAGE_KEY, JSON.stringify(globalThis.enemyEncountered));
 
-        // Complete all tutorial tasks
-        for (let task of Object.keys(tutorialChecklist)) {
-            tutorialCompleteTask(task as keyof TutorialChecklist);
-        }
-        for (let key of Object.keys(explainMap)) {
-            storage.set(key, ALREADY_EXPLAINED);
-        }
+    // Complete all tutorial tasks
+    for (let task of Object.keys(tutorialChecklist)) {
+      tutorialCompleteTask(task as keyof TutorialChecklist);
     }
+    for (let key of Object.keys(explainMap)) {
+      storage.set(key, ALREADY_EXPLAINED);
+    }
+  }
 }
 export function tutorialShowTask(key: keyof TutorialChecklist) {
-    if (globalThis.doUpdateTutorialChecklist) {
-        const task = tutorialChecklist[key];
-        if (task) {
-            task.visible = true;
-            if (storage.get(getTutorialStorageKey(key)) === COMPLETE) {
-                tutorialCompleteTask(key);
-            }
-            setTutorialVisiblity(true);
-        } else {
-            console.error('No such tutorial task with key', key);
-        }
+  if (globalThis.doUpdateTutorialChecklist) {
+    const task = tutorialChecklist[key];
+    if (task) {
+      task.visible = true;
+      for (let popup of task.showExplainPopup) {
+        explain(popup);
+      }
+      if (storage.get(getTutorialStorageKey(key)) === COMPLETE) {
+        tutorialCompleteTask(key);
+      }
+      setTutorialVisiblity(true);
+    } else {
+      console.error('No such tutorial task with key', key);
     }
+  }
 }
 function getTutorialStorageKey(key: string): string {
-    return `tutorial_${key}`;
+  return `tutorial_${key}`;
 
 }
 globalThis.resetTutorial = function resetTutorial() {
-    for (let key of Object.keys(tutorialChecklist)) {
-        storage.remove(getTutorialStorageKey(key));
-    }
-    setTutorialVisiblity(true);
-    // Reset all explain prompts when tutorial is reset
-    for (let explainKey of explainKeys) {
-        storage.remove(explainKey);
-    }
-    globalThis.enemyEncountered = [];
-    storage.remove(storage.ENEMY_ENCOUNTERED_STORAGE_KEY);
-    Jprompt({ text: 'Tutorial will reset after the game is restarted.', yesText: 'Okay', forceShow: true });
+  for (let key of Object.keys(tutorialChecklist)) {
+    storage.remove(getTutorialStorageKey(key));
+  }
+  setTutorialVisiblity(true);
+  // Reset all explain prompts when tutorial is reset
+  for (let explainKey of explainKeys) {
+    storage.remove(explainKey);
+  }
+  globalThis.enemyEncountered = [];
+  storage.remove(storage.ENEMY_ENCOUNTERED_STORAGE_KEY);
+  Jprompt({ text: 'Tutorial will reset after the game is restarted.', yesText: 'Okay', forceShow: true });
 }
 // Returns a value that remains the same as the first time this function was invoked for the duration of the play session
 export function isTutorialComplete() {
-    if (globalThis.headless) {
-        // Never run the tutorial on a headless server because it is hosting games for clients
-        return true;
+  if (globalThis.headless) {
+    // Never run the tutorial on a headless server because it is hosting games for clients
+    return true;
+  }
+  // Update tutorialChecklist from storage:
+  const tutorialKeys: (keyof TutorialChecklist)[] = Object.keys(tutorialChecklist) as (keyof TutorialChecklist)[]
+  for (let key of tutorialKeys) {
+    const item = tutorialChecklist[key];
+    if (storage.get(getTutorialStorageKey(key)) === COMPLETE) {
+      item.complete = true;
     }
-    // Update tutorialChecklist from storage:
-    const tutorialKeys: (keyof TutorialChecklist)[] = Object.keys(tutorialChecklist) as (keyof TutorialChecklist)[]
-    for (let key of tutorialKeys) {
-        const item = tutorialChecklist[key];
-        if (storage.get(getTutorialStorageKey(key)) === COMPLETE) {
-            item.complete = true;
-        }
-    }
-    if (tutorialKeys.every(key => tutorialChecklist[key].complete)) {
-        setTutorialVisiblity(false);
-        return true;
-    } else {
-        setTutorialVisiblity(true);
-        return false;
-    }
+  }
+  if (tutorialKeys.every(key => tutorialChecklist[key].complete)) {
+    setTutorialVisiblity(false);
+    return true;
+  } else {
+    setTutorialVisiblity(true);
+    return false;
+  }
 }
 globalThis.isTutorialComplete = isTutorialComplete;
 
@@ -375,14 +378,14 @@ globalThis.isTutorialComplete = isTutorialComplete;
 // Will only return true for the first two steps of the tutorial, once they know how to
 // spawn and portal just let them play regular
 export function isFirstTutorialStepComplete() {
-    if (globalThis.headless) {
-        // Never run the tutorial on a headless server because it is hosting games for clients
-        return true;
-    }
-    const firstStepKeys: (keyof TutorialChecklist)[] = ['spawn', 'portal'];
-    if (firstStepKeys.every(key => tutorialChecklist[key].complete)) {
-        return true;
-    } else {
-        return false;
-    }
+  if (globalThis.headless) {
+    // Never run the tutorial on a headless server because it is hosting games for clients
+    return true;
+  }
+  const firstStepKeys: (keyof TutorialChecklist)[] = ['spawn', 'portal'];
+  if (firstStepKeys.every(key => tutorialChecklist[key].complete)) {
+    return true;
+  } else {
+    return false;
+  }
 }

--- a/src/graphics/Explain.ts
+++ b/src/graphics/Explain.ts
@@ -266,9 +266,7 @@ export function updateTutorialChecklist() {
   if (completeTutorialItems.length) {
     let completedItemsHtml = '';
     for (let item of completeTutorialItems) {
-      if (item.visible) {
-        completedItemsHtml += `<div class="complete">&#x2611; <span class="text complete">${i18n(item.text)}</span></div>`
-      }
+      completedItemsHtml += `<div class="complete">&#x2611; <span class="text complete">${i18n(item.text)}</span></div>`
     }
     html += `<details>
             <summary>${i18n('Completed Tasks')} ${completeTutorialItems.length}/${tutorialItems.length}</summary>
@@ -376,13 +374,12 @@ globalThis.isTutorialComplete = isTutorialComplete;
 
 // Used to determine whether or not the player has gone through
 // the first few steps of the tutorial, and has a basic understanding of the game
-export function isTutorialFirstStepsComplete() {
+export function isTutorialFirstStepsComplete(steps: (keyof TutorialChecklist)[] = ['moved', 'portal', 'camera', 'cast']) {
   if (globalThis.headless) {
     // Never run the tutorial on a headless server because it is hosting games for clients
     return true;
   }
-  const firstStepKeys: (keyof TutorialChecklist)[] = ['moved', 'portal', 'camera', 'cast'];
-  if (firstStepKeys.every(key => tutorialChecklist[key].complete)) {
+  if (steps.every(key => tutorialChecklist[key].complete)) {
     return true;
   } else {
     return false;

--- a/src/graphics/Explain.ts
+++ b/src/graphics/Explain.ts
@@ -315,6 +315,8 @@ globalThis.skipTutorial = async () => {
   }
 }
 export function tutorialShowTask(key: keyof TutorialChecklist) {
+  // This is called to reveal the next step of the tutorial
+  // If there are any popups attached to that new step, show them
   if (globalThis.doUpdateTutorialChecklist) {
     const task = tutorialChecklist[key];
     if (task) {

--- a/src/graphics/Explain.ts
+++ b/src/graphics/Explain.ts
@@ -374,15 +374,14 @@ export function isTutorialComplete() {
 }
 globalThis.isTutorialComplete = isTutorialComplete;
 
-// Used to spawn the player into early tutorial levels if they've never played before
-// Will only return true for the first two steps of the tutorial, once they know how to
-// spawn and portal just let them play regular
-export function isFirstTutorialStepComplete() {
+// Used to determine whether or not the player has gone through
+// the first few steps of the tutorial, and has a basic understanding of the game
+export function isTutorialFirstStepsComplete() {
   if (globalThis.headless) {
     // Never run the tutorial on a headless server because it is hosting games for clients
     return true;
   }
-  const firstStepKeys: (keyof TutorialChecklist)[] = ['spawn', 'portal'];
+  const firstStepKeys: (keyof TutorialChecklist)[] = ['moved', 'portal', 'camera', 'cast'];
   if (firstStepKeys.every(key => tutorialChecklist[key].complete)) {
     return true;
   } else {

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -612,10 +612,11 @@ export async function runPredictions(underworld: Underworld) {
       globalThis.attentionMarkers = [];
       // Clear predicted next turn damage so that attack targets can be intelligently calculated
       underworld.clearPredictedNextTurnDamage();
-      const skipTurnUnits = await underworld.runTurnStartEvents(underworld.unitsPrediction, true);
+
+      // TODO - Find a way to run turn start events for units that will run it?
 
       for (let u of underworld.unitsPrediction) {
-        if (skipTurnUnits.includes(u)) {
+        if (!Unit.canAct(u)) {
           continue;
         }
         // Only check for threats if the threat is alive and AI controlled
@@ -650,7 +651,6 @@ export async function runPredictions(underworld: Underworld) {
               }
             } else {
               console.error('Cannot find unit source for unitSourceId', u.unitSourceId);
-
             }
           }
         }

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -610,6 +610,7 @@ export async function runPredictions(underworld: Underworld) {
       // Careful when making enemy predictions:
       // Ally turn happens before Enemy turn, and some effects
       // like bloat may not be easy to factor into predictions
+      // Issue: https://github.com/jdoleary/Spellmasons/issues/388
 
       // TODO - Run turn start events for units that will run it?
       //Unit.startTurnForUnits(aiUnits, underworld, true);

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -676,7 +676,8 @@ export function mouseUpHandler(overworld: Overworld, e: Pick<MouseEvent, "button
         // On release, send a final move player to ensure that the player moves to the full destination on the server
         overworld.underworld.pie.sendData({
           type: MESSAGE_TYPES.SET_PLAYER_POSITION,
-          ...Vec.clone(globalThis.player.unit),
+          position: Vec.clone(globalThis.player.unit),
+          stamina: globalThis.player.unit.stamina,
         });
       }
     } else {

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -1342,14 +1342,16 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
     {
       label: 'Regenerate Level',
       action: () => {
-        if (!overworld.underworld) {
+        const underworld = overworld.underworld;
+        if (!underworld) {
           console.error('Cannot "Regenerate Level", underworld does not exist');
           return;
         }
-        // Clear lastLevelCreated in order to allow it to regenerate the level without
-        // changing the levelIndex
-        overworld.underworld.lastLevelCreated = undefined;
-        overworld.underworld.generateLevelData(overworld.underworld.levelIndex);
+        if (!globalThis.isHost(underworld.pie)) {
+          console.error('Cannot "Regenerate Level", player is not the host');
+          return;
+        }
+        underworld.generateLevelData(underworld.levelIndex);
       },
       supportInMultiplayer: false,
       domQueryContainer: '#menu-global'

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -833,7 +833,7 @@ export function clickHandler(overworld: Overworld, e: MouseEvent) {
         }
 
 
-        if (selfPlayer.unit.modifiers[Freeze.id]) {
+        if (selfPlayer.unit.modifiers[Freeze.freezeCardId]) {
           floatingText({ coords: selfPlayer.unit, text: 'Cannot Cast. Frozen.' })
           playSFXKey('deny');
           // Cancel Casting

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -1308,7 +1308,7 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
             console.error('Cannot "Skip to Deathmason level", underworld does not exist');
             return;
           }
-          overworld.underworld.levelIndex = config.LAST_LEVEL_INDEX;
+          overworld.underworld.levelIndex = config.LAST_LEVEL_INDEX - 1;
           Player.enterPortal(globalThis.player, overworld.underworld);
         }
       },

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -534,8 +534,7 @@ export function useMousePosition(underworld: Underworld, e?: MouseEvent) {
 
             // Send current player movements to server
             sendMovePlayer(underworld);
-            tutorialCompleteTask('moved', () => !!globalThis.player && globalThis.player.unit.stamina <= globalThis.player.unit.staminaMax * 0.7);
-
+            tutorialCompleteTask('moved');
           } else {
             if (!globalThis.notifiedOutOfStamina) {
               if (globalThis.player.unit.stamina <= 0) {

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -983,7 +983,7 @@ export function triggerAdminCommand(label: string, clientId: string, payload: an
   }
 }
 interface AdminActionProps {
-  clientId?: string;
+  playerId?: string;
   pos?: Vec2;
   selectedUnitid?: number;
   selectedPickupLocation?: Vec2;
@@ -1000,9 +1000,9 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
   const options: AdminContextMenuOption[] = [
     {
       label: '🦸‍♂️ Super Me',
-      action: ({ clientId }: { clientId?: string }) => {
+      action: ({ playerId }: { playerId?: string }) => {
         if (superMe && overworld.underworld) {
-          superMe(overworld.underworld, overworld.underworld.players.find(p => p.clientId == clientId) || globalThis.player);
+          superMe(overworld.underworld, overworld.underworld.players.find(p => p.playerId == playerId) || globalThis.player);
         }
       },
       supportInMultiplayer: true,
@@ -1010,7 +1010,7 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
     },
     {
       label: '️Level Up',
-      action: ({ clientId }: { clientId?: string }) => {
+      action: () => {
         if (superMe && overworld.underworld) {
           const numberOfEnemiesKilledNeededForNextDrop = overworld.underworld.getNumberOfEnemyKillsNeededForNextLevelUp() - overworld.underworld.enemiesKilled;
           for (let i = 0; i < numberOfEnemiesKilledNeededForNextDrop; i++) {
@@ -1035,12 +1035,12 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
     {
       label: '☄️ Teleport Here',
       action: (props) => {
-        const { clientId, pos } = props;
+        const { playerId, pos } = props;
         if (!overworld.underworld) {
           console.error('Cannot teleport, underworld does not exist');
           return;
         }
-        const player = overworld.underworld.players.find(p => p.clientId == clientId);
+        const player = overworld.underworld.players.find(p => p.playerId == playerId);
         if (player && pos) {
           player.unit.x = pos.x;
           player.unit.y = pos.y;
@@ -1776,7 +1776,7 @@ export function triggerAdminOption(option: AdminContextMenuOption, overworld: Ov
         floatingText({ coords: globalThis.player.unit, style: { fill: 'red' }, text: errMsg })
       }
     }
-    action({ clientId: globalThis.clientId || '', pos });
+    action({ playerId: globalThis.player?.playerId || '', pos });
   }
 
 }

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -1229,11 +1229,16 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
       label: 'Skip to Next Level',
       action: () => {
         if (globalThis.player) {
-          if (!overworld.underworld) {
+          const underworld = overworld.underworld;
+          if (!underworld) {
             console.error('Cannot "Skip to Next level", underworld does not exist');
             return;
           }
-          Player.enterPortal(globalThis.player, overworld.underworld);
+          if (!globalThis.isHost(underworld.pie)) {
+            console.error('Cannot "Skip to Next level", player is not the host');
+            return;
+          }
+          underworld.generateLevelData(underworld.levelIndex + 1);
         }
       },
       supportInMultiplayer: false,
@@ -1243,12 +1248,16 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
       label: 'Skip to Water Biome',
       action: () => {
         if (globalThis.player) {
-          if (!overworld.underworld) {
-            console.error('Cannot "Skip to Water Biome", underworld does not exist');
+          const underworld = overworld.underworld;
+          if (!underworld) {
+            console.error('Cannot "Skip to Lava Biome", underworld does not exist');
             return;
           }
-          overworld.underworld.levelIndex = 0;
-          Player.enterPortal(globalThis.player, overworld.underworld);
+          if (!globalThis.isHost(underworld.pie)) {
+            console.error('Cannot "Skip to Lava Biome", player is not the host');
+            return;
+          }
+          underworld.generateLevelData(0);
         }
       },
       supportInMultiplayer: false,
@@ -1258,12 +1267,16 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
       label: 'Skip to Lava Biome',
       action: () => {
         if (globalThis.player) {
-          if (!overworld.underworld) {
+          const underworld = overworld.underworld;
+          if (!underworld) {
             console.error('Cannot "Skip to Lava Biome", underworld does not exist');
             return;
           }
-          overworld.underworld.levelIndex = 3;
-          Player.enterPortal(globalThis.player, overworld.underworld);
+          if (!globalThis.isHost(underworld.pie)) {
+            console.error('Cannot "Skip to Lava Biome", player is not the host');
+            return;
+          }
+          underworld.generateLevelData(3);
         }
       },
       supportInMultiplayer: false,
@@ -1273,12 +1286,16 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
       label: 'Skip to Blood Biome',
       action: () => {
         if (globalThis.player) {
-          if (!overworld.underworld) {
+          const underworld = overworld.underworld;
+          if (!underworld) {
             console.error('Cannot "Skip to Blood Biome", underworld does not exist');
             return;
           }
-          overworld.underworld.levelIndex = 6;
-          Player.enterPortal(globalThis.player, overworld.underworld);
+          if (!globalThis.isHost(underworld.pie)) {
+            console.error('Cannot "Skip to Blood Biome", player is not the host');
+            return;
+          }
+          underworld.generateLevelData(6);
         }
       },
       supportInMultiplayer: false,
@@ -1288,12 +1305,16 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
       label: 'Skip to Ghost Biome',
       action: () => {
         if (globalThis.player) {
-          if (!overworld.underworld) {
+          const underworld = overworld.underworld;
+          if (!underworld) {
             console.error('Cannot "Skip to Ghost Biome", underworld does not exist');
             return;
           }
-          overworld.underworld.levelIndex = 9;
-          Player.enterPortal(globalThis.player, overworld.underworld);
+          if (!globalThis.isHost(underworld.pie)) {
+            console.error('Cannot "Skip to Ghost Biome", player is not the host');
+            return;
+          }
+          underworld.generateLevelData(9);
         }
       },
       supportInMultiplayer: false,
@@ -1303,12 +1324,16 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
       label: 'Skip to Deathmason',
       action: () => {
         if (globalThis.player) {
-          if (!overworld.underworld) {
+          const underworld = overworld.underworld;
+          if (!underworld) {
             console.error('Cannot "Skip to Deathmason level", underworld does not exist');
             return;
           }
-          overworld.underworld.levelIndex = config.LAST_LEVEL_INDEX - 1;
-          Player.enterPortal(globalThis.player, overworld.underworld);
+          if (!globalThis.isHost(underworld.pie)) {
+            console.error('Cannot "Skip to Deathmason level", player is not the host');
+            return;
+          }
+          underworld.generateLevelData(config.LAST_LEVEL_INDEX);
         }
       },
       supportInMultiplayer: false,

--- a/src/jmath/rand.ts
+++ b/src/jmath/rand.ts
@@ -94,6 +94,6 @@ export function chooseObjectWithProbability<T extends objectWithProbability>(
 export function getUniqueSeedString(underworld: Underworld, player?: IPlayer): string {
   // Seeded random based on the turn so it's consistent across all clients
   // based on player client ids so it's unique to each player
-  const playerUniqueIdentifier = !player ? '0' : player.clientId;
+  const playerUniqueIdentifier = !player ? '0' : player.playerId;
   return `${underworld.seed}-${underworld.levelIndex}-${underworld.turn_number}-${playerUniqueIdentifier}`;
 }

--- a/src/jmath/rand.ts
+++ b/src/jmath/rand.ts
@@ -94,6 +94,6 @@ export function chooseObjectWithProbability<T extends objectWithProbability>(
 export function getUniqueSeedString(underworld: Underworld, player?: IPlayer): string {
   // Seeded random based on the turn so it's consistent across all clients
   // based on player client ids so it's unique to each player
-  const playerUniqueIdentifier = !player ? '0' : (globalThis.numberOfHotseatPlayers > 1 ? player.name : player.clientId);
+  const playerUniqueIdentifier = !player ? '0' : player.clientId;
   return `${underworld.seed}-${underworld.levelIndex}-${underworld.turn_number}-${playerUniqueIdentifier}`;
 }

--- a/src/modifierSummoningSickness.ts
+++ b/src/modifierSummoningSickness.ts
@@ -6,44 +6,41 @@ import Underworld from './Underworld';
 
 export const summoningSicknessId = 'summoningSickness';
 export default function registerSummoningSickness() {
-    registerModifiers(summoningSicknessId, {
-        add: (unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, quantity: number = 1) => {
-            // Only add summoning sickness to AI
-            // Summoning sickness is only meant to prevent units from attacking 
-            // the player without a pre warning attack badge - but if it gets added
-            // to a player it will skip their turn which we do not want.
-            if (unit.unitType == UnitType.PLAYER_CONTROLLED) {
-                console.log('Prevented adding summoning sickness to player unit')
-                return
-            }
-            getOrInitModifier(unit, summoningSicknessId, { isCurse: true, quantity }, () => {
-                // Immediately set stamina to 0 so they can't move
-                unit.stamina = 0;
-                // Add event
-                if (!unit.onTurnStartEvents.includes(summoningSicknessId)) {
-                    unit.onTurnStartEvents.push(summoningSicknessId);
-                }
-                if (!unit.onTurnEndEvents.includes(summoningSicknessId)) {
-                    unit.onTurnEndEvents.push(summoningSicknessId);
-                }
-            });
+  registerModifiers(summoningSicknessId, {
+    add: (unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, quantity: number = 1) => {
+      // Only add summoning sickness to AI
+      // Summoning sickness is only meant to prevent units from attacking 
+      // the player without a pre warning attack badge - but if it gets added
+      // to a player it will skip their turn which we do not want.
+      if (unit.unitType == UnitType.PLAYER_CONTROLLED) {
+        console.log('Prevented adding summoning sickness to player unit')
+        return
+      }
+      getOrInitModifier(unit, summoningSicknessId, { isCurse: true, quantity }, () => {
+        // Immediately set stamina to 0 so they can't move
+        unit.stamina = 0;
+        // Add event
+        if (!unit.onTurnStartEvents.includes(summoningSicknessId)) {
+          unit.onTurnStartEvents.push(summoningSicknessId);
         }
-    });
-    registerEvents(summoningSicknessId, {
-        onTurnStart: async (unit: Unit.IUnit, _prediction: boolean, underworld: Underworld) => {
-            // Ensure that the unit cannot move with summoning sickness
-            // (even when players' turns are ended they can still act so long
-            // as it is underworld.turn_phase === turn_phase.PlayerTurns, this is because all players act simultaneously
-            // during that phase, so setting stamina to 0
-            // prevents players from moving when they have summoning sickness)
-            // and then returning true also ends their turn.
-            unit.stamina = 0;
-            // Unit.removeModifier(unit, summoningSicknessId, underworld);
-            // Skip turn
-            return true;
-        },
-        onTurnEnd: async (unit: Unit.IUnit, prediction: boolean, underworld: Underworld) => {
-            Unit.removeModifier(unit, summoningSicknessId, underworld);
+        if (!unit.onTurnEndEvents.includes(summoningSicknessId)) {
+          unit.onTurnEndEvents.push(summoningSicknessId);
         }
-    });
+      });
+    }
+  });
+  registerEvents(summoningSicknessId, {
+    onTurnStart: async (unit: Unit.IUnit, _prediction: boolean, underworld: Underworld) => {
+      // Ensure that the unit cannot move with summoning sickness
+      // (even when players' turns are ended they can still act so long
+      // as it is underworld.turn_phase === turn_phase.PlayerTurns, this is because all players act simultaneously
+      // during that phase, so setting stamina to 0
+      // prevents players from moving when they have summoning sickness)
+      // and then returning true also ends their turn.
+      unit.stamina = 0;
+    },
+    onTurnEnd: async (unit: Unit.IUnit, prediction: boolean, underworld: Underworld) => {
+      Unit.removeModifier(unit, summoningSicknessId, underworld);
+    }
+  });
 }

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -130,9 +130,7 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
         // Must be called when difficulty (gameMode) changes to update summon spell stats
         Cards.refreshSummonCardDescriptions(underworld);
         recalculateGameDifficulty(underworld);
-        // Clear lastLevelCreated in order to allow it to regenerate the level without
-        // changing the levelIndex
-        underworld.lastLevelCreated = undefined;
+        // Regenerate level data with new game mode information
         underworld.generateLevelData(underworld.levelIndex);
 
         // Since svelte can't keep track of state outside of itself,

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -759,6 +759,7 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       }
       Player.syncLobby(underworld);
       underworld.tryRestartTurnPhaseLoop();
+      underworld.progressGameState();
       underworld.assertDemoExit();
       break;
     }

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -53,12 +53,12 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
         try {
           const startTime = payload.type == MESSAGE_TYPES.INIT_GAME_STATE ? Date.now() : undefined;
           sendEventToServerHub({
-            seed: overworld.underworld.seed, gameName: 'default', startTime, serverRegion: process.env.serverRegion || undefined,
+            startTime,
             events: [{
               time: Date.now(),
               message: JSON.stringify({ _type: MESSAGE_TYPES[payload.type], ...payload })
             }]
-          });
+          }, overworld.underworld);
         } catch (e) {
           console.error('Could not send event to server', e);
         }

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -765,8 +765,8 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       // This message is only for the host, it ensures that the player position
       // of the host matches exactly the player position on the player's client
       if (isHost(overworld.pie)) {
-        if (fromPlayer && fromPlayer.unit && payload.x !== undefined && payload.y !== undefined) {
-          Unit.setLocation(fromPlayer.unit, payload);
+        if (fromPlayer && fromPlayer.unit && payload.position.x !== undefined && payload.position.y !== undefined) {
+          Unit.setLocation(fromPlayer.unit, payload.position);
           fromPlayer.unit.stamina = payload.stamina;
         }
       }

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -774,7 +774,6 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
           // their image may be hidden if they are the non-current user
           // player in multiplayer
           Image.show(fromPlayer.unit.image);
-          fromPlayer.endedTurn = false;
           underworld.syncTurnMessage();
           // Used for the tutorial but harmless if invoked under other circumstances.
           // Spawns the portal after the player choses a spawn point if there are no

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -894,10 +894,10 @@ function getFromPlayerViaClientId(clientId: string, underworld: Underworld): Pla
   }
   return player;
 }
-function joinGameAsPlayer(fromClient: string, asPlayerId: string, overworld: Overworld) {
+function joinGameAsPlayer(fromClient: string, asClientId: string, overworld: Overworld) {
   const underworld = overworld.underworld;
   if (underworld) {
-    const asPlayer = underworld.players.find(p => p.playerId == asPlayerId);
+    const asPlayer = underworld.players.find(p => p.clientId == asClientId);
     const oldFromPlayer = getFromPlayerViaClientId(fromClient, underworld);
     if (fromClient && asPlayer) {
       if (asPlayer.clientConnected) {
@@ -905,13 +905,14 @@ function joinGameAsPlayer(fromClient: string, asPlayerId: string, overworld: Ove
         return;
       }
       console.log('JOIN_GAME_AS_PLAYER: Reassigning player', asPlayer.clientId, 'to', fromClient);
-      const oldAsPlayerClientId = asPlayer.clientId;
+      const clientIdToGiveOldPlayer = asPlayer.clientId;
       asPlayer.clientId = fromClient;
+      asPlayer.playerId = asPlayer.clientId + "_" + 0;
       // Ensure their turn doesn't get skipped
       asPlayer.endedTurn = false;
       // Change the clientId of fromClient's old player now that they have inhabited the asPlayer
       if (oldFromPlayer) {
-        oldFromPlayer.clientId = oldAsPlayerClientId;
+        oldFromPlayer.clientId = clientIdToGiveOldPlayer;
         // force update clientConnected due to client switching players
         const isConnected = overworld.clients.includes(oldFromPlayer.clientId);
         oldFromPlayer.clientConnected = isConnected;
@@ -919,7 +920,7 @@ function joinGameAsPlayer(fromClient: string, asPlayerId: string, overworld: Ove
         if (!oldFromPlayer.clientConnected && oldFromPlayer.inventory.length == 0) {
           underworld.players = underworld.players.filter(p => p !== oldFromPlayer);
         } else {
-          console.error('Unexpected, joinGameAsPlayer could not delete oldPlayer')
+          console.warn('JoinGameAsPlayer could not delete oldPlayer, this is expected if oldPlayer is part of the loaded game.')
         }
       } else {
         console.error('Unexpected, joinGameAsPlayer: oldFromPlayer does not exist')

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -63,7 +63,6 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
           console.error('Could not send event to server', e);
         }
       }
-
     } catch (e) {
       console.warn('Prevent error due to Stringify:', e);
     }
@@ -74,15 +73,19 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
     console.error('Cannot process onData, underworld does not exist');
     return;
   }
-  // Note: If the message is from the server there will not be a fromPlayer
-  const fromPlayer = underworld.players.find(p => p.clientId == fromClient);
+
+  const fromPlayer = underworld.clientIdToPlayer(fromClient);
+  if (!fromPlayer) {
+    console.error("No fromPlayer found for clientId: " + fromClient);
+  }
 
   switch (type) {
-    case MESSAGE_TYPES.CHAT_SENT:
+    case MESSAGE_TYPES.CHAT_SENT: {
       const { message } = payload;
       Chat.ReceiveMessage(fromPlayer, message);
       break;
-    case MESSAGE_TYPES.PLAYER_THINKING:
+    }
+    case MESSAGE_TYPES.PLAYER_THINKING: {
       const thinkingPlayer = fromPlayer;
       if (thinkingPlayer && thinkingPlayer != globalThis.player) {
         const thought = underworld.playerThoughts[thinkingPlayer.clientId];
@@ -93,16 +96,14 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
         underworld.playerThoughts[thinkingPlayer.clientId] = { ...payload, currentDrawLocation, lerp: 0 };
       }
       break;
-    case MESSAGE_TYPES.CLIENT_SEND_PLAYER_TO_SERVER:
-
-      // TODO - Outdated?
-
+    }
+    case MESSAGE_TYPES.CLIENT_SEND_PLAYER_TO_SERVER: {
       // This message is only ever handled by the host.  It is for the client
       // to send it's Player state to the host because the client is the source of truth for the player object
       // Do NOT process this message for hotseat or else it will may overwrite a player https://github.com/jdoleary/Spellmasons/issues/198
       if (isHost(overworld.pie) && overworld.underworld && globalThis.numberOfHotseatPlayers == 1) {
         const { player } = payload;
-        const foundPlayerIndex = overworld.underworld.players.findIndex(p => p.clientId == player.clientId);
+        const foundPlayerIndex = overworld.underworld.players.findIndex(p => p.playerId == player.playerId);
         if (foundPlayerIndex !== undefined) {
           // Report Differences to evaluate where client server player desyncs are ocurring
           const currentPlayer = overworld.underworld.players[foundPlayerIndex];
@@ -120,13 +121,13 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
           }
           // End Report Differences to evaluate where client server player desyncs are ocurring
 
-
           // Host loads player data from client to syncronize the state
           Player.load(player, foundPlayerIndex, overworld.underworld, false);
         }
       }
       break;
-    case MESSAGE_TYPES.SET_GAME_MODE:
+    }
+    case MESSAGE_TYPES.SET_GAME_MODE: {
       const { gameMode } = payload;
       if (underworld.levelIndex <= 1) {
         underworld.gameMode = gameMode;
@@ -148,37 +149,39 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
         Jprompt({ text: 'Cannot change difficulty for an ongoing game', yesText: 'Okay', forceShow: true });
       }
       break;
-    case MESSAGE_TYPES.SET_MODS:
+    }
+    case MESSAGE_TYPES.SET_MODS: {
       const { activeMods } = payload;
       if (activeMods) {
         underworld.activeMods = activeMods;
       }
       break;
-    case MESSAGE_TYPES.JOIN_GAME_AS_PLAYER:
+    }
+    case MESSAGE_TYPES.JOIN_GAME_AS_PLAYER: {
       const { asPlayerClientId } = payload;
-      joinGameAsPlayer(asPlayerClientId, overworld, fromClient);
+      joinGameAsPlayer(fromClient, asPlayerClientId, overworld);
       break;
-    case MESSAGE_TYPES.FORCE_TRIGGER_PICKUP:
-      {
-        const { pickupId, pickupName, unitId, playerClientId } = payload;
-        let pickup = underworld.pickups.find(p => p.id == pickupId);
-        const unit = underworld.units.find(u => u.id == unitId);
-        // Important: This is NOT fromPlayer, this is the optional player that collided
-        // with the pickup
-        const player = underworld.players.find(p => p.clientId == playerClientId);
-        if (pickup) {
-          if (pickup.name !== pickupName) {
-            console.error("FORCE_TRIGGER_PICKUP: pickup name is desynced", pickup.name, pickupName);
-          }
-          if (unit) {
-            Pickup.triggerPickup(pickup, unit, player, underworld, false);
-          } else {
-            console.error('Force trigger pickup failed, unit is undefined');
-          }
-        } else {
-          console.error('Force trigger pickup failed, pickup is undefined');
+    }
+    case MESSAGE_TYPES.FORCE_TRIGGER_PICKUP: {
+      const { pickupId, pickupName, unitId, collidedPlayerId } = payload;
+      let pickup = underworld.pickups.find(p => p.id == pickupId);
+      const unit = underworld.units.find(u => u.id == unitId);
+      // Important: This is NOT fromPlayer
+      // this is the optional player that collided with the pickup
+      const player = underworld.players.find(p => p.playerId == collidedPlayerId);
+      if (pickup) {
+        if (pickup.name !== pickupName) {
+          console.error("FORCE_TRIGGER_PICKUP: pickup name is desynced", pickup.name, pickupName);
         }
+        if (unit) {
+          Pickup.triggerPickup(pickup, unit, player, underworld, false);
+        } else {
+          console.error('Force trigger pickup failed, unit is undefined');
+        }
+      } else {
+        console.error('Force trigger pickup failed, pickup is undefined');
       }
+    }
       break;
     case MESSAGE_TYPES.QUEUE_PICKUP_TRIGGER:
       // QUEUE_PICKUP_TRIGGER is only for clients, the headless server triggers pickups
@@ -187,7 +190,7 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
       if (globalThis.isHost(underworld.pie)) {
         return;
       }
-      const { pickupId, pickupName, unitId, playerClientId } = payload;
+      const { pickupId, pickupName, unitId } = payload;
       let pickup = underworld.pickups.find(p => p.id == pickupId);
       const unit = underworld.units.find(u => u.id == unitId);
       if (!pickup) {
@@ -365,11 +368,11 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
       break;
   }
 }
-function joinGameAsPlayer(asPlayerClientId: string, overworld: Overworld, fromClient: string) {
+function joinGameAsPlayer(fromClient: string, asPlayerId: string, overworld: Overworld) {
   const underworld = overworld.underworld;
   if (underworld) {
-    const asPlayer = underworld.players.find(p => p.clientId == asPlayerClientId);
-    const oldFromPlayer = underworld.players.find(p => p.clientId == fromClient);
+    const asPlayer = underworld.players.find(p => p.playerId == asPlayerId);
+    const oldFromPlayer = underworld.clientIdToPlayer(fromClient);
     if (fromClient && asPlayer) {
       if (asPlayer.clientConnected) {
         console.error('Cannot join as player that is controlled by another client')
@@ -396,13 +399,11 @@ function joinGameAsPlayer(asPlayerClientId: string, overworld: Overworld, fromCl
         console.error('Unexpected, joinGameAsPlayer: oldFromPlayer does not exist')
       }
 
-
       const players = underworld.players.map(Player.serialize)
       // isClientPlayerSourceOfTruth: false; Overwrite client's own player object because the client is switching players
       underworld.syncPlayers(players, false);
     }
   }
-
 }
 let onDataQueueContainer = messageQueue.makeContainer<OnDataArgs>();
 // Waits until a message is done before it will continue to process more messages that come through
@@ -480,16 +481,22 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
   currentlyProcessingOnDataMessage = d;
   const { payload, fromClient } = d;
   const type: MESSAGE_TYPES = payload.type;
+
   const { underworld } = overworld;
   if (!underworld) {
     console.error('Cannot handleOnDataMessage, underworld does not exist');
     return;
   }
   logHandleOnDataMessage(type, payload, fromClient, underworld);
-  // Get player of the client that sent the message 
-  const fromPlayer = underworld.players.find(p => p.clientId == fromClient);
+
+
+  const fromPlayer = underworld.clientIdToPlayer(fromClient);
+  if (!fromPlayer) {
+    console.error("No fromPlayer found for clientId: " + fromClient);
+  }
+
   switch (type) {
-    case MESSAGE_TYPES.CHANGE_CHARACTER:
+    case MESSAGE_TYPES.CHANGE_CHARACTER: {
       if (fromPlayer) {
         const userSource = allUnits[payload.unitId];
         if (!userSource) {
@@ -501,88 +508,89 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
         fromPlayer.unit.defaultImagePath = userSource.info.image;
         Unit.returnToDefaultSprite(fromPlayer.unit);
       } else {
-        console.error('Cannot change character, player not found with id', fromClient);
+        console.error('Cannot change character, no fromPlayer found');
         // TODO: This should request a unit and player sync
       }
       break;
-    case MESSAGE_TYPES.REQUEST_SYNC_GAME_STATE:
+    }
+    case MESSAGE_TYPES.REQUEST_SYNC_GAME_STATE: {
       // If host, send sync; if non-host, ignore 
       if (globalThis.isHost(overworld.pie)) {
         console.log('Host: Sending game state for REQUEST_SYNC_GAME_STATE')
         hostGiveClientGameState(fromClient, underworld, underworld.lastLevelCreated, MESSAGE_TYPES.LOAD_GAME_STATE);
       }
       break;
-    case MESSAGE_TYPES.SYNC_PLAYERS:
-      {
-        console.log('sync: SYNC_PLAYERS; syncs units and players')
-        const { units, players, lastUnitId } = payload as {
-          // Note: When syncing players, must also sync units
-          // because IPlayerSerialized doesn't container a full
-          // unit serialized
-          units: Unit.IUnitSerialized[],
-          // Sync data for players
-          players: Player.IPlayerSerialized[],
-          lastUnitId: number
-        }
-        // Units must be synced before players so that the player's
-        // associated unit is available for referencing
-        underworld.syncUnits(units, true);
-        // isClientPlayerSourceOfTruth: true; for regular syncs the client's own player object
-        // is the source of truth so that the server's async player sync call doesn't overwrite
-        // something that happened syncronously on the client
-        underworld.syncPlayers(players, true);
-        // Protect against old versions that didn't send lastUnitId with
-        // this message
-        if (lastUnitId !== undefined) {
-          underworld.lastUnitId = lastUnitId
-        }
+    }
+    case MESSAGE_TYPES.SYNC_PLAYERS: {
+      console.log('sync: SYNC_PLAYERS; syncs units and players')
+      const { units, players, lastUnitId } = payload as {
+        // Note: When syncing players, must also sync units
+        // because IPlayerSerialized doesn't container a full
+        // unit serialized
+        units: Unit.IUnitSerialized[],
+        // Sync data for players
+        players: Player.IPlayerSerialized[],
+        lastUnitId: number
+      }
+      // Units must be synced before players so that the player's
+      // associated unit is available for referencing
+      underworld.syncUnits(units, true);
+      // isClientPlayerSourceOfTruth: true; for regular syncs the client's own player object
+      // is the source of truth so that the server's async player sync call doesn't overwrite
+      // something that happened syncronously on the client
+      underworld.syncPlayers(players, true);
+      // Protect against old versions that didn't send lastUnitId with
+      // this message
+      if (lastUnitId !== undefined) {
+        underworld.lastUnitId = lastUnitId
       }
       break;
-    case MESSAGE_TYPES.SYNC_SOME_STATE:
-      {
-        if (globalThis.headless) {
-          // SYNC_SOME_STATE is only ever sent from headless and doesn't need to be run on headless
-          break;
-        }
-        console.log('sync: SYNC_SOME_STATE; syncs non-player units')
-        const { timeOfLastSpellMessage, units, pickups, lastUnitId, lastPickupId, RNGState } = payload as {
-          // timeOfLastSpellMessage ensures that SYNC_SOME_STATE won't overwrite valid state with old state
-          // if someone a second SPELL message is recieved between this message and it's corresponding SPELL message
-          // Messages don't currently have a unique id so I'm storing d.time which should be good enough
-          timeOfLastSpellMessage: number,
-          // Sync data for units
-          units?: Unit.IUnitSerialized[],
-          // Sync data for pickups
-          pickups?: Pickup.IPickupSerialized[],
-          lastUnitId: number,
-          lastPickupId: number,
-          RNGState: SeedrandomState,
-        }
-        if (timeOfLastSpellMessage !== lastSpellMessageTime) {
-          // Do not sync, state has changed since this sync message was sent
-          console.warn('Discarding SYNC_SOME_STATE message, it is no longer valid');
-          break;
-        }
-        if (RNGState) {
-          underworld.syncronizeRNG(RNGState);
-        }
-
-        if (units) {
-          underworld.syncUnits(units, true);
-        }
-
-        if (pickups) {
-          underworld.syncPickups(pickups);
-        }
-
-        // Syncronize the lastXId so that when a new unit or pickup is created
-        // it will get the same id on both server and client
-        underworld.lastUnitId = lastUnitId;
-        underworld.lastPickupId = lastPickupId;
-
+    }
+    case MESSAGE_TYPES.SYNC_SOME_STATE: {
+      if (globalThis.headless) {
+        // SYNC_SOME_STATE is only ever sent from headless and doesn't need to be run on headless
         break;
       }
-    case MESSAGE_TYPES.SET_PHASE:
+      console.log('sync: SYNC_SOME_STATE; syncs non-player units')
+      const { timeOfLastSpellMessage, units, pickups, lastUnitId, lastPickupId, RNGState } = payload as {
+        // timeOfLastSpellMessage ensures that SYNC_SOME_STATE won't overwrite valid state with old state
+        // if someone a second SPELL message is recieved between this message and it's corresponding SPELL message
+        // Messages don't currently have a unique id so I'm storing d.time which should be good enough
+        timeOfLastSpellMessage: number,
+        // Sync data for units
+        units?: Unit.IUnitSerialized[],
+        // Sync data for pickups
+        pickups?: Pickup.IPickupSerialized[],
+        lastUnitId: number,
+        lastPickupId: number,
+        RNGState: SeedrandomState,
+      }
+      if (timeOfLastSpellMessage !== lastSpellMessageTime) {
+        // Do not sync, state has changed since this sync message was sent
+        console.warn('Discarding SYNC_SOME_STATE message, it is no longer valid');
+        break;
+      }
+      if (RNGState) {
+        underworld.syncronizeRNG(RNGState);
+      }
+
+      if (units) {
+        // Sync all non-player units.  If it syncs player units it will overwrite player movements
+        // that occurred during the cast
+        underworld.syncUnits(units, true);
+      }
+
+      if (pickups) {
+        underworld.syncPickups(pickups);
+      }
+
+      // Syncronize the lastXId so that when a new unit or pickup is created
+      // it will get the same id on both server and client
+      underworld.lastUnitId = lastUnitId;
+      underworld.lastPickupId = lastPickupId;
+      break;
+    }
+    case MESSAGE_TYPES.SET_PHASE: {
       console.log('sync: SET_PHASE; syncs units and players')
       const { phase, units, players, pickups, lastUnitId, lastPickupId, RNGState } = payload as {
         phase: turn_phase,
@@ -607,7 +615,7 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       }
 
       if (units) {
-        underworld.syncUnits(units, false);
+        underworld.syncUnits(units);
       }
       // Note: Players should sync after units so
       // that the player.unit reference is synced
@@ -632,7 +640,8 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       // via the public setTurnPhase
       await underworld.initializeTurnPhase(phase);
       break;
-    case MESSAGE_TYPES.CREATE_LEVEL:
+    }
+    case MESSAGE_TYPES.CREATE_LEVEL: {
       const { level, gameMode } = payload as {
         level: LevelData,
         gameMode?: GameMode
@@ -643,12 +652,13 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       } else {
         console.error('Cannot sync level, no underworld exists')
       }
-
       break;
-    case MESSAGE_TYPES.INIT_GAME_STATE:
+    }
+    case MESSAGE_TYPES.INIT_GAME_STATE: {
       await handleLoadGameState(payload, overworld);
       break;
-    case MESSAGE_TYPES.LOAD_GAME_STATE:
+    }
+    case MESSAGE_TYPES.LOAD_GAME_STATE: {
       // Make everyone go back to the lobby
       for (let p of overworld.underworld?.players || []) {
         p.lobbyReady = false;
@@ -660,21 +670,24 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
         globalThis.setMenu?.('MULTIPLAYER_SERVER_CHOOSER');
       }
       break;
-    case MESSAGE_TYPES.ENTER_PORTAL:
+    }
+    case MESSAGE_TYPES.ENTER_PORTAL: {
       if (fromPlayer) {
         Player.enterPortal(fromPlayer, underworld);
       } else {
         console.error('Recieved ENTER_PORTAL message but "caster" is undefined')
       }
       break;
-    case MESSAGE_TYPES.PLAYER_CARDS:
+    }
+    case MESSAGE_TYPES.PLAYER_CARDS: {
       if (fromPlayer) {
         fromPlayer.cardsInToolbar = payload.cards;
       } else {
         console.error('No fromPlayer to set card order on')
       }
       break;
-    case MESSAGE_TYPES.PLAYER_CONFIG:
+    }
+    case MESSAGE_TYPES.PLAYER_CONFIG: {
       if (globalThis.numberOfHotseatPlayers > 1) {
         // Hotseat multiplayer has it's own player config management
         // because it needs to hold configs for multiple players on a single
@@ -689,9 +702,6 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
           const connectedPlayers = underworld.players.filter(p => p.clientConnected);
           if (connectedPlayers.length > 0 && connectedPlayers.every(p => p.lobbyReady)) {
             console.log('Lobby: All players are ready, start game.');
-            // If loading into a game, tryGameOver so that if the game over modal is up, it will
-            // be removed if there are acting players.
-            underworld.tryGameOver();
             setView(View.Game);
             if (globalThis.player && fromPlayer.clientId == globalThis.player.clientId && !globalThis.player.isSpawned) {
               // Retrigger the cinematic camera since the first time
@@ -719,15 +729,16 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
         // a player with their same name automatically even if their cliendID has changed
         const takeControlOfPlayer = underworld.players.find(p => !p.clientConnected && p.name == name);
         if (takeControlOfPlayer) {
-          joinGameAsPlayer(takeControlOfPlayer.clientId, overworld, fromClient);
+          joinGameAsPlayer(fromClient, takeControlOfPlayer.playerId, overworld);
         }
         underworld.tryRestartTurnPhaseLoop();
       } else {
-        console.log('Players: ', underworld.players.map(p => p.clientId))
+        console.log('Players: ', underworld.players.map(p => p.playerId))
         console.error('Cannot PLAYER_CONFIG, fromPlayer is undefined.');
       }
       break;
-    case MESSAGE_TYPES.SPAWN_PLAYER:
+    }
+    case MESSAGE_TYPES.SPAWN_PLAYER: {
       if (fromPlayer) {
         // Ensure a newly spawned player unit has fresh stats
         Unit.resetUnitStats(fromPlayer.unit, underworld);
@@ -796,22 +807,18 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       underworld.tryRestartTurnPhaseLoop();
       underworld.assertDemoExit();
       break;
-    case MESSAGE_TYPES.SET_PLAYER_POSITION:
+    }
+    case MESSAGE_TYPES.SET_PLAYER_POSITION: {
       // This message is only for the host, it ensures that the player position
       // of the host matches exactly the player position on the player's client
       if (isHost(overworld.pie)) {
         if (fromPlayer && fromPlayer.unit && payload.x !== undefined && payload.y !== undefined) {
-          // Ensure server unit stamina matches the client's unit stamina
-          const moveDist = distance(fromPlayer.unit, payload);
-          fromPlayer.unit.stamina -= moveDist;
-          // Force set the location so that the server's unit position matches the client
-          // doing the moving
           Unit.setLocation(fromPlayer.unit, payload);
-
         }
       }
       break;
-    case MESSAGE_TYPES.MOVE_PLAYER:
+    }
+    case MESSAGE_TYPES.MOVE_PLAYER: {
       if (fromPlayer == globalThis.player) {
         // Do not do anything, own player movement is handled locally
         // so that it is smooth
@@ -825,15 +832,13 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       if (fromPlayer) {
         // Only allow spawned players to move
         if (fromPlayer.isSpawned) {
-          if (!globalThis.headless) {
-            // Network Sync: Make sure other players move a little slower so that the MOVE_PLAYER messages have time to set the
-            // next move point on the client's screen.  This prevents jagged movement due to network latency
-            fromPlayer.unit.moveSpeed = config.UNIT_MOVE_SPEED * 0.9;
-            // Network Sync: Make sure the other player always has stamina to get where they're going, this is to ensure that
-            // the local copies of other player's stay in sync with the server and aren't prematurely stopped due
-            // to a stamina limitation
-            fromPlayer.unit.stamina = 100;
-          }
+          // Network Sync: Make sure other players move a little slower so that the MOVE_PLAYER messages have time to set the
+          // next move point on the client's screen.  This prevents jagged movement due to network latency
+          fromPlayer.unit.moveSpeed = config.UNIT_MOVE_SPEED * 0.9;
+          // Network Sync: Make sure the other player always has stamina to get where they're going, this is to ensure that
+          // the local copies of other player's stay in sync with the server and aren't prematurely stopped due
+          // to a stamina limitation
+          fromPlayer.unit.stamina = 100;
           const moveTowardsPromise = Unit.moveTowards(fromPlayer.unit, payload, underworld).then(() => {
             if (fromPlayer.unit.path?.points.length && fromPlayer.unit.stamina == 0) {
               // If they do not reach their destination, notify that they are out of stamina
@@ -860,7 +865,8 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
         console.error('Cannot move player, caster does not exist');
       }
       break;
-    case MESSAGE_TYPES.SPELL:
+    }
+    case MESSAGE_TYPES.SPELL: {
       lastSpellMessageTime = d.time;
       if (fromPlayer) {
         if (underworld.turn_phase == turn_phase.Stalled) {
@@ -890,18 +896,21 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
         console.error('Cannot cast, caster does not exist');
       }
       break;
-    case MESSAGE_TYPES.END_TURN:
+    }
+    case MESSAGE_TYPES.END_TURN: {
       if (fromPlayer) {
-        underworld.endPlayerTurn(fromPlayer.clientId);
+        underworld.endPlayerTurn(fromPlayer);
       } else {
         console.error('Unable to end turn because caster is undefined');
       }
       break;
-    case MESSAGE_TYPES.ADMIN_COMMAND:
+    }
+    case MESSAGE_TYPES.ADMIN_COMMAND: {
       const { label } = payload;
       triggerAdminCommand(label, fromClient, payload)
       break;
-    case MESSAGE_TYPES.ADMIN_CHANGE_STAT:
+    }
+    case MESSAGE_TYPES.ADMIN_CHANGE_STAT: {
       const { unitId, stats } = payload;
       const unit = underworld.units.find(u => u.id == unitId);
       if (unit) {
@@ -910,7 +919,7 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
         console.error('ADMIN_CHANGE_STAT failed', payload)
       }
       break;
-
+    }
   }
 }
 async function handleLoadGameState(payload: {

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -1322,6 +1322,20 @@ export function setupNetworkHandlerGlobalFunctions(overworld: Overworld) {
       const { underworld: savedUnderworld, phase, units, players, pickups, version, numberOfHotseatPlayers } = fileSaveObj as SaveFile;
       if (numberOfHotseatPlayers !== undefined) {
         globalThis.numberOfHotseatPlayers = numberOfHotseatPlayers;
+        if (!overworld.pie.soloMode) {
+          console.log('Loading a hotseat multiplayer game into an online multiplayer server: so reset numberOfHotseatPlayers to 1 so that other players can assume control of hotseat players.');
+          globalThis.numberOfHotseatPlayers = 1;
+          for (let i = 1; i < players.length; i++) {
+            const player = players[i];
+            // Ensure players have different client ids when loading a hotseat game
+            // in a multiplayer lobby
+            if (player && player.clientId == players[0]?.clientId) {
+              player.clientId += `_${i}`;
+            }
+
+          }
+
+        }
       }
       if (version !== globalThis.SPELLMASONS_PACKAGE_VERSION) {
         Jprompt({

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -48,7 +48,7 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
   if (!NO_LOG_LIST.includes(d.payload.type)) {
     // Don't clog up server logs with payloads, leave that for the client which can handle them better
     try {
-      console.log("Recieved onData:", MESSAGE_TYPES[d.payload.type], globalThis.headless ? '' : JSON.stringify(d))
+      //console.log("Recieved onData:", MESSAGE_TYPES[d.payload.type], globalThis.headless ? '' : JSON.stringify(d))
       if (overworld.underworld && globalThis.headless) {
         try {
           const startTime = payload.type == MESSAGE_TYPES.INIT_GAME_STATE ? Date.now() : undefined;
@@ -75,7 +75,7 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
     return;
   }
   // Note: If the message is from the server there will not be a fromPlayer
-  const fromPlayer = globalThis.numberOfHotseatPlayers > 1 ? underworld.players[underworld.hotseatCurrentPlayerIndex] : underworld.players.find(p => p.clientId == fromClient);
+  const fromPlayer = underworld.players.find(p => p.clientId == fromClient);
 
   switch (type) {
     case MESSAGE_TYPES.CHAT_SENT:
@@ -94,6 +94,9 @@ export function onData(d: OnDataArgs, overworld: Overworld) {
       }
       break;
     case MESSAGE_TYPES.CLIENT_SEND_PLAYER_TO_SERVER:
+
+      // TODO - Outdated?
+
       // This message is only ever handled by the host.  It is for the client
       // to send it's Player state to the host because the client is the source of truth for the player object
       // Do NOT process this message for hotseat or else it will may overwrite a player https://github.com/jdoleary/Spellmasons/issues/198
@@ -484,7 +487,7 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
   }
   logHandleOnDataMessage(type, payload, fromClient, underworld);
   // Get player of the client that sent the message 
-  const fromPlayer = globalThis.numberOfHotseatPlayers > 1 ? underworld.players[underworld.hotseatCurrentPlayerIndex] : underworld.players.find(p => p.clientId == fromClient);
+  const fromPlayer = underworld.players.find(p => p.clientId == fromClient);
   switch (type) {
     case MESSAGE_TYPES.CHANGE_CHARACTER:
       if (fromPlayer) {
@@ -775,10 +778,6 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
           // player in multiplayer
           Image.show(fromPlayer.unit.image);
           underworld.syncTurnMessage();
-          // Used for the tutorial but harmless if invoked under other circumstances.
-          // Spawns the portal after the player choses a spawn point if there are no
-          // enemies left
-          underworld.checkIfShouldSpawnPortal();
         } else {
           console.error('Cannot spawn player at NaN')
         }

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -767,6 +767,7 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       if (isHost(overworld.pie)) {
         if (fromPlayer && fromPlayer.unit && payload.x !== undefined && payload.y !== undefined) {
           Unit.setLocation(fromPlayer.unit, payload);
+          fromPlayer.unit.stamina = payload.stamina;
         }
       }
       break;

--- a/src/network/networkUtil.ts
+++ b/src/network/networkUtil.ts
@@ -54,6 +54,7 @@ export interface IHostApp {
     // Copied from PieClient.d.ts
     sendData(payload: any, extras?: any): void;
     isHostApp: boolean;
+    soloMode: boolean;
 }
 export function typeGuardHostApp(x: PieClient | IHostApp): x is IHostApp {
     // @ts-ignore: PieClient does not have isHostApp property but this typeguard will

--- a/src/network/networkUtil.ts
+++ b/src/network/networkUtil.ts
@@ -11,85 +11,83 @@ import type { Room } from '@websocketpie/client';
 
 // Copied from PieClient.d.ts so as to not have to import PieClient
 export interface ClientPresenceChangedArgs {
-    type: string;
-    clients: string[];
-    time: number;
+  type: string;
+  clients: string[];
+  time: number;
 }
 export function onClientPresenceChanged(o: ClientPresenceChangedArgs, overworld: Overworld) {
-    console.log('clientPresenceChanged', o);
-    // clientPresenceChanged message is only ever received if the current client is in a room
-    // The client will also receive one when they first join a room.
-    globalThis.setMenuIsInRoom?.(true);
-    // Ensure each client corresponds with a Player instance
-    ensureAllClientsHaveAssociatedPlayers(overworld, o.clients);
-    if (overworld.underworld) {
-        overworld.underworld.tryGameOver();
-    }
-    if (o.clients.length == 0 && overworld.underworld) {
-        // Send an end time for the game when all clients disconnect
-        sendEventToServerHub({
-            endTime: Date.now(),
-        }, overworld.underworld);
-    }
+  console.log('clientPresenceChanged', o);
+  // clientPresenceChanged message is only ever received if the current client is in a room
+  // The client will also receive one when they first join a room.
+  globalThis.setMenuIsInRoom?.(true);
+  // Ensure each client corresponds with a Player instance
+  ensureAllClientsHaveAssociatedPlayers(overworld, o.clients);
+  if (overworld.underworld) {
+    overworld.underworld.progressGameState();
+  }
+  if (o.clients.length == 0 && overworld.underworld) {
+    // Send an end time for the game when all clients disconnect
+    sendEventToServerHub({
+      endTime: Date.now(),
+    }, overworld.underworld);
+  }
 }
 export function hostGiveClientGameState(clientId: string, underworld: Underworld, level: LevelData | undefined, message_type: MESSAGE_TYPES.INIT_GAME_STATE | MESSAGE_TYPES.LOAD_GAME_STATE) {
-    // Only the host should be sending INIT_GAME_STATE messages
-    // because the host has the canonical game state
-    if (globalThis.isHost(underworld.pie)) {
-        // Do not send this message to self
-        if (globalThis.clientId !== clientId) {
-            if (level) {
-                console.log(`Host: Send ${clientId} game state for initial load`);
-                underworld.pie.sendData({
-                    type: message_type,
-                    level,
-                    underworld: underworld.serializeForSyncronize(),
-                    phase: underworld.turn_phase,
-                    pickups: underworld.pickups.filter(p => !p.flaggedForRemoval).map(Pickup.serialize),
-                    units: underworld.units.filter(u => !u.flaggedForRemoval).map(Unit.serialize),
-                    players: underworld.players.map(Player.serialize)
-                }, {
-                    subType: "Whisper",
-                    whisperClientIds: [clientId],
-                });
-            } else {
-                console.error('hostGiveClientGameState: Could not send INIT_GAME_STATE, levelData is undefined');
-            }
-        }
+  // Only the host should be sending INIT_GAME_STATE messages
+  // because the host has the canonical game state
+  if (globalThis.isHost(underworld.pie)) {
+    // Do not send this message to self
+    if (globalThis.clientId !== clientId) {
+      if (level) {
+        console.log(`Host: Send ${clientId} game state for initial load`);
+        underworld.pie.sendData({
+          type: message_type,
+          level,
+          underworld: underworld.serializeForSyncronize(),
+          phase: underworld.turn_phase,
+          pickups: underworld.pickups.filter(p => !p.flaggedForRemoval).map(Pickup.serialize),
+          units: underworld.units.filter(u => !u.flaggedForRemoval).map(Unit.serialize),
+          players: underworld.players.map(Player.serialize)
+        }, {
+          subType: "Whisper",
+          whisperClientIds: [clientId],
+        });
+      } else {
+        console.error('hostGiveClientGameState: Could not send INIT_GAME_STATE, levelData is undefined');
+      }
     }
+  }
 }
 export interface IHostApp {
-    // Copied from PieClient.d.ts
-    sendData(payload: any, extras?: any): void;
-    isHostApp: boolean;
-    soloMode: boolean;
-    currentRoomInfo?: Room;
+  // Copied from PieClient.d.ts
+  sendData(payload: any, extras?: any): void;
+  isHostApp: boolean;
 }
 export function typeGuardHostApp(x: PieClient | IHostApp): x is IHostApp {
-    // @ts-ignore: PieClient does not have isHostApp property but this typeguard will
-    // still work
-    return x.isHostApp;
+  // @ts-ignore: PieClient does not have isHostApp property but this typeguard will
+  // still work
+  return x.isHostApp;
 }
 
 export function getVersionInequality(clientVersion?: string, serverVersion?: string): 'equal' | 'client behind' | 'server behind' | 'malformed' {
-    if (clientVersion && serverVersion) {
-        const [clientMajor, clientMinor, _clientPatch] = clientVersion.split('.');
-        const [serverMajor, serverMinor, _serverPath] = serverVersion.split('.');
-        if ((clientMajor !== undefined && clientMinor !== undefined && serverMajor !== undefined && serverMinor !== undefined)) {
-            if ((clientMajor !== serverMajor || clientMinor !== serverMinor)) {
-                if (parseInt(serverMajor) > parseInt(clientMajor)) {
-                    return 'client behind'
+  if (clientVersion && serverVersion) {
+    const [clientMajor, clientMinor, _clientPatch] = clientVersion.split('.');
+    const [serverMajor, serverMinor, _serverPath] = serverVersion.split('.');
+    if ((clientMajor !== undefined && clientMinor !== undefined && serverMajor !== undefined && serverMinor !== undefined)) {
+      if ((clientMajor !== serverMajor || clientMinor !== serverMinor)) {
+        if (parseInt(serverMajor) > parseInt(clientMajor)) {
+          return 'client behind'
 
-                } else if (parseInt(serverMajor) < parseInt(clientMajor)) {
-                    return 'server behind'
-                } else {
-                    return parseInt(serverMinor) > parseInt(clientMinor) ? 'client behind' : 'server behind';
-                }
-            } else {
-                return 'equal'
-            }
+        } else if (parseInt(serverMajor) < parseInt(clientMajor)) {
+          return 'server behind'
+        } else {
+          return parseInt(serverMinor) > parseInt(clientMinor) ? 'client behind' : 'server behind';
         }
+      } else {
+        return 'equal'
+      }
     }
-    return 'malformed'
+  }
+  return 'malformed'
 
 }

--- a/src/network/wsPieSetup.ts
+++ b/src/network/wsPieSetup.ts
@@ -13,7 +13,7 @@ import { onData } from './networkHandler';
 import { getVersionInequality, onClientPresenceChanged, typeGuardHostApp } from './networkUtil';
 import { setView, View } from '../views';
 import * as storage from '../storage';
-import { updateGlobalRefToPlayer } from '../entity/Player';
+import { updateGlobalRefToPlayerIfCurrentClient } from '../entity/Player';
 import Underworld from '../Underworld';
 import { version } from '../../package.json';
 import makeOverworld, { Overworld } from '../Overworld';

--- a/src/network/wsPieSetup.ts
+++ b/src/network/wsPieSetup.ts
@@ -13,7 +13,7 @@ import { onData } from './networkHandler';
 import { getVersionInequality, onClientPresenceChanged, typeGuardHostApp } from './networkUtil';
 import { setView, View } from '../views';
 import * as storage from '../storage';
-import { updateGlobalRefToCurrentClientPlayer } from '../entity/Player';
+import { updateGlobalRefToPlayer } from '../entity/Player';
 import Underworld from '../Underworld';
 import { version } from '../../package.json';
 import makeOverworld, { Overworld } from '../Overworld';
@@ -205,12 +205,6 @@ ${explainUpdateText}
 
     }
     globalThis.clientId = o.clientId;
-    if (overworld.underworld) {
-      const selfPlayer = overworld.underworld.players.find(p => p.clientId == globalThis.clientId);
-      if (selfPlayer) {
-        updateGlobalRefToCurrentClientPlayer(selfPlayer, overworld.underworld);
-      }
-    }
   };
   pie.onData = d => onData(d, overworld);
   pie.onError = ({ message }: { message: any }) => {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -74,11 +74,14 @@ export function getSavedData() {
             const storedAccessibilityOutline = get(ACCESSIBILITY_OUTLINE_STORAGE_KEY);
             console.log('Setup: Initializing outline settings', storedAccessibilityOutline);
             if (storedAccessibilityOutline !== null) {
+                globalThis.remoteLog?.('Accessibility Outlines: Active')
                 try {
                     globalThis.accessibilityOutline = JSON.parse(storedAccessibilityOutline);
                 } catch (e) {
                     console.error('Failled to parse stored accessibility outline options', storedAccessibilityOutline)
                 }
+            } else {
+                globalThis.remoteLog?.('Accessibility Outlines: Inactive')
             }
             globalThis.playMusicIfNotAlreadyPlaying?.();
             // Default stored color if player doesn't already have one stored

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -18,183 +18,183 @@ globalThis.enemyEncountered = [];
 globalThis.spellsDiscovered = [];
 
 export function getSavedData() {
-    if (globalThis.headless) {
-        // Headless server does not use storage
-        return;
-    }
-    // Initialize settings once the settings object is loaded
-    // If this is running as an electron app, get settings from storage
-    // If this is not running as an electron app, just resolve immediately
-    // because settings can be gotten syncronously from local storage
-    (globalThis.isElectron && globalThis.diskStorage ?
-        globalThis.diskStorage.getDiskStorage().then(settings => {
-            console.log('Setup: Got settings from disk:', settings);
-            // Cache settings from disk in localStorage so they can
-            // be access syncronously
-            for (let [key, value] of Object.entries(settings || {})) {
-                localStorage.setItem(key, value);
-            }
-        })
-        : Promise.resolve())
-        .then(() => {
-            // Default language to english if no language is stored:
-            const storedLanguageCode = get(STORAGE_LANGUAGE_CODE_KEY);
-            setLanguage(storedLanguageCode ? storedLanguageCode : 'en', false);
-            // Retrieve settings from storage
-            const storedOptions = get(STORAGE_OPTIONS);
-            console.log('Setup: Initializing saved settings', storedOptions);
-            if (storedOptions !== null) {
-                const options = JSON.parse(storedOptions);
-                if (options.fontOverride && globalThis.setFontOverride) {
-                    globalThis.setFontOverride(options.fontOverride);
-                }
-                if (options.cinematicCameraEnabled !== undefined) {
-                    globalThis.cinematicCameraEnabled = options.cinematicCameraEnabled;
-                }
-                if (options.volume !== undefined) {
-                    globalThis.changeVolume?.(options.volume, false)
-                }
-                if (options.volumeMusic !== undefined) {
-                    globalThis.changeVolumeMusic?.(options.volumeMusic, false)
-                }
-                if (options.volumeGame !== undefined) {
-                    globalThis.changeVolumeGame?.(options.volumeGame, false)
-                }
-                if (options.UIEasyOnTheEyes !== undefined) {
-                    globalThis.UIEasyOnTheEyes = options.UIEasyOnTheEyes;
-                }
-                if (options.limitParticleEmitters !== undefined) {
-                    globalThis.limitParticleEmitters = options.limitParticleEmitters;
-                }
-                globalThis.activeMods = [];
-                if (!!options.activeMods) {
-                    globalThis.activeMods = options.activeMods;
-                }
-            }
-            const storedAccessibilityOutline = get(ACCESSIBILITY_OUTLINE_STORAGE_KEY);
-            console.log('Setup: Initializing outline settings', storedAccessibilityOutline);
-            if (storedAccessibilityOutline !== null) {
-                globalThis.remoteLog?.('Accessibility Outlines: Active')
-                try {
-                    globalThis.accessibilityOutline = JSON.parse(storedAccessibilityOutline);
-                } catch (e) {
-                    console.error('Failled to parse stored accessibility outline options', storedAccessibilityOutline)
-                }
-            } else {
-                globalThis.remoteLog?.('Accessibility Outlines: Inactive')
-            }
-            globalThis.playMusicIfNotAlreadyPlaying?.();
-            // Default stored color if player doesn't already have one stored
-            const color = get(STORAGE_ID_PLAYER_COLOR);
-            if (!color) {
-                const newColor = robeColors[Math.floor(Math.random() * robeColors.length)] || 0xef476f;
-                set(STORAGE_ID_PLAYER_COLOR, newColor);
-            }
-            // Set uiZoom:
-            if (globalThis.isElectron) {
-                if (globalThis.electronSettings) {
-                    const uiZoom = get(STORAGE_ID_UI_ZOOM);
-                    if (uiZoom) {
-                        globalThis.electronSettings.setUIZoom(parseFloat(uiZoom));
-                    }
-                } else {
-                    console.error('globalThis.electronSettings is undefined, cannot set uiZoom');
-                }
-            }
-            // Update controls:
-            // Get saved controls from storage:
-            const savedControls = JSON.parse(get(STORAGE_CONTROLS_KEY) || '{}');
-            console.log('Retrieved saved controls:', savedControls);
-            fullyUpdateControls(savedControls);
-            // Update enemy encountered:
-            globalThis.enemyEncountered = JSON.parse(get(ENEMY_ENCOUNTERED_STORAGE_KEY) || '[]');
-            console.log('Setup: initializing enemyEncountered as', globalThis.enemyEncountered);
-            // Update spells discovered:
-            globalThis.spellsDiscovered = JSON.parse(get(SPELLS_DISCOVERED_STORAGE_KEY) || '[]');
-            console.log('Setup: initializing spellsDiscovered as', globalThis.spellsDiscovered);
-        });
+  if (globalThis.headless) {
+    // Headless server does not use storage
+    return;
+  }
+  // Initialize settings once the settings object is loaded
+  // If this is running as an electron app, get settings from storage
+  // If this is not running as an electron app, just resolve immediately
+  // because settings can be gotten syncronously from local storage
+  (globalThis.isElectron && globalThis.diskStorage ?
+    globalThis.diskStorage.getDiskStorage().then(settings => {
+      console.log('Setup: Got settings from disk:', settings);
+      // Cache settings from disk in localStorage so they can
+      // be access syncronously
+      for (let [key, value] of Object.entries(settings || {})) {
+        localStorage.setItem(key, value);
+      }
+    })
+    : Promise.resolve())
+    .then(() => {
+      // Default language to english if no language is stored:
+      const storedLanguageCode = get(STORAGE_LANGUAGE_CODE_KEY);
+      setLanguage(storedLanguageCode ? storedLanguageCode : 'en', false);
+      // Retrieve settings from storage
+      const storedOptions = get(STORAGE_OPTIONS);
+      console.log('Setup: Initializing saved settings', storedOptions);
+      if (storedOptions !== null) {
+        const options = JSON.parse(storedOptions);
+        if (options.fontOverride && globalThis.setFontOverride) {
+          globalThis.setFontOverride(options.fontOverride);
+        }
+        if (options.cinematicCameraEnabled !== undefined) {
+          globalThis.cinematicCameraEnabled = options.cinematicCameraEnabled;
+        }
+        if (options.volume !== undefined) {
+          globalThis.changeVolume?.(options.volume, false)
+        }
+        if (options.volumeMusic !== undefined) {
+          globalThis.changeVolumeMusic?.(options.volumeMusic, false)
+        }
+        if (options.volumeGame !== undefined) {
+          globalThis.changeVolumeGame?.(options.volumeGame, false)
+        }
+        if (options.UIEasyOnTheEyes !== undefined) {
+          globalThis.UIEasyOnTheEyes = options.UIEasyOnTheEyes;
+        }
+        if (options.limitParticleEmitters !== undefined) {
+          globalThis.limitParticleEmitters = options.limitParticleEmitters;
+        }
+        globalThis.activeMods = [];
+        if (!!options.activeMods) {
+          globalThis.activeMods = options.activeMods;
+        }
+      }
+      const storedAccessibilityOutline = get(ACCESSIBILITY_OUTLINE_STORAGE_KEY);
+      console.log('Setup: Initializing outline settings', storedAccessibilityOutline);
+      if (storedAccessibilityOutline !== null) {
+        globalThis.remoteLog?.('Accessibility Outlines: Active')
+        try {
+          globalThis.accessibilityOutline = JSON.parse(storedAccessibilityOutline);
+        } catch (e) {
+          console.error('Failled to parse stored accessibility outline options', storedAccessibilityOutline)
+        }
+      } else {
+        globalThis.remoteLog?.('Accessibility Outlines: Inactive')
+      }
+      globalThis.playMusicIfNotAlreadyPlaying?.();
+      // Default stored color if player doesn't already have one stored
+      const color = get(STORAGE_ID_PLAYER_COLOR);
+      if (!color) {
+        const newColor = robeColors[Math.floor(Math.random() * robeColors.length)] || 0xef476f;
+        set(STORAGE_ID_PLAYER_COLOR, newColor);
+      }
+      // Set uiZoom:
+      if (globalThis.isElectron) {
+        if (globalThis.electronSettings) {
+          const uiZoom = get(STORAGE_ID_UI_ZOOM);
+          if (uiZoom) {
+            globalThis.electronSettings.setUIZoom(parseFloat(uiZoom));
+          }
+        } else {
+          console.error('globalThis.electronSettings is undefined, cannot set uiZoom');
+        }
+      }
+      // Update controls:
+      // Get saved controls from storage:
+      const savedControls = JSON.parse(get(STORAGE_CONTROLS_KEY) || '{}');
+      console.log('Retrieved saved controls:', savedControls);
+      fullyUpdateControls(savedControls);
+      // Update enemy encountered:
+      globalThis.enemyEncountered = JSON.parse(get(ENEMY_ENCOUNTERED_STORAGE_KEY) || '[]');
+      console.log('Setup: initializing enemyEncountered as', globalThis.enemyEncountered);
+      // Update spells discovered:
+      globalThis.spellsDiscovered = JSON.parse(get(SPELLS_DISCOVERED_STORAGE_KEY) || '[]');
+      console.log('Setup: initializing spellsDiscovered as', globalThis.spellsDiscovered);
+    });
 }
 
 export function remove(key: string) {
-    if (globalThis.headless) {
-        // Headless server does not use storage
-        return;
+  if (globalThis.headless) {
+    // Headless server does not use storage
+    return;
+  }
+  localStorage.removeItem(key);
+  if (globalThis.isElectron) {
+    if (globalThis.diskStorage) {
+      globalThis.diskStorage.remove(key);
     }
-    localStorage.removeItem(key);
-    if (globalThis.isElectron) {
-        if (globalThis.diskStorage) {
-            globalThis.diskStorage.remove(key);
-        }
-    }
+  }
 }
 export function set(key: string, value: any) {
-    console.log('Setting ', key, 'to', value, 'in local storage');
-    if (globalThis.headless) {
-        // Headless server does not use storage
-        return;
-    }
-    if (globalThis.isElectron || globalThis.privacyPolicyAndEULAConsent) {
-        if (globalThis.diskStorage) {
-            // Store both on disk and in local storage
-            // because local storage is used for accessing the
-            // settings in game while the diskStorage is only used
-            // once when the app boots
-            localStorage.setItem(key, value);
-            globalThis.diskStorage.set(key, value);
-        } else {
-            localStorage.setItem(key, value);
-        }
+  console.debug('Setting ', key, 'to', value, 'in local storage');
+  if (globalThis.headless) {
+    // Headless server does not use storage
+    return;
+  }
+  if (globalThis.isElectron || globalThis.privacyPolicyAndEULAConsent) {
+    if (globalThis.diskStorage) {
+      // Store both on disk and in local storage
+      // because local storage is used for accessing the
+      // settings in game while the diskStorage is only used
+      // once when the app boots
+      localStorage.setItem(key, value);
+      globalThis.diskStorage.set(key, value);
     } else {
-        console.log(`Could not save "${key}" to storage, without cookie consent`);
+      localStorage.setItem(key, value);
     }
+  } else {
+    console.log(`Could not save "${key}" to storage, without cookie consent`);
+  }
 }
 export function assign(key: string, value: object) {
-    if (globalThis.privacyPolicyAndEULAConsent) {
-        const obj = localStorage.getItem(key);
-        let json = {};
-        if (obj) {
-            json = JSON.parse(obj);
-        }
-        console.log('Changing ', value, 'in', key, 'in local storage');
-        const options = JSON.stringify(Object.assign(json, value))
-        set(key, options);
-    } else {
-        console.log(`Could not add "${key}" to storage, without cookie consent`);
+  if (globalThis.privacyPolicyAndEULAConsent) {
+    const obj = localStorage.getItem(key);
+    let json = {};
+    if (obj) {
+      json = JSON.parse(obj);
     }
+    console.log('Changing ', value, 'in', key, 'in local storage');
+    const options = JSON.stringify(Object.assign(json, value))
+    set(key, options);
+  } else {
+    console.log(`Could not add "${key}" to storage, without cookie consent`);
+  }
 }
 export function get(key: string): string | null {
-    if (globalThis.headless) {
-        // Headless server does not use storage
-        return null;
-    }
-    if (globalThis.privacyPolicyAndEULAConsent || areCookiesAllowed()) {
-        const savedValue = localStorage.getItem(key);
-        return savedValue;
-    } else {
-        console.log(`Could not retrieve "${key}" from storage, without cookie consent`);
-        return null;
-    }
+  if (globalThis.headless) {
+    // Headless server does not use storage
+    return null;
+  }
+  if (globalThis.privacyPolicyAndEULAConsent || areCookiesAllowed()) {
+    const savedValue = localStorage.getItem(key);
+    return savedValue;
+  } else {
+    console.log(`Could not retrieve "${key}" from storage, without cookie consent`);
+    return null;
+  }
 }
 export function getStoredMageTypeWinsKey(mageType: MageType): string {
-    return `${mageType || ''}-wins`;
+  return `${mageType || ''}-wins`;
 }
 export function getStoredMageTypeFarthestLevelKey(mageType: MageType): string {
-    return `${mageType || ''}-level`;
+  return `${mageType || ''}-level`;
 }
 
 globalThis.setCinematicCameraEnabled = (enabled: boolean, saveSetting: boolean = true) => {
-    globalThis.cinematicCameraEnabled = enabled;
-    if (saveSetting) {
-        assign(STORAGE_OPTIONS, { cinematicCameraEnabled: enabled });
-    }
+  globalThis.cinematicCameraEnabled = enabled;
+  if (saveSetting) {
+    assign(STORAGE_OPTIONS, { cinematicCameraEnabled: enabled });
+  }
 };
 globalThis.setFontOverride = (font: string) => {
-    assign(STORAGE_OPTIONS, { fontOverride: font });
-    if (font == 'arial') {
-        document.body.classList.toggle(`font-arial`, true);
-    } else {
-        document.body.classList.toggle(`font-arial`, false);
-    }
+  assign(STORAGE_OPTIONS, { fontOverride: font });
+  if (font == 'arial') {
+    document.body.classList.toggle(`font-arial`, true);
+  } else {
+    document.body.classList.toggle(`font-arial`, false);
+  }
 
 }
 globalThis.storageSet = set;


### PR DESCRIPTION
A refactor that improves the handling of game state and turn phases.
AKA issue #362 

___

# Fixes and Info
### From #362 
- Closes #319
- Closes #300
- Closes #354
- Closes #357
- Closes #343
- Closes #256
- Closes #206
- Closes #290
- Closes #321
- Closes #301
- Closes #404 

### Other
- Closes #255 with improved smart targeting
- Closes #271
- Closes #249
- Completing a level and dying within the same spell favors the player and progresses the level, instead of immediately ending the game
- Stat points earned in the early stages of the tutorial are auto-allocated to Max Health instead of being removed entirely, as to not make players' first sessions more difficult
- Players start the tutorial with target cone, slash, and push. This should speed up the tutorial, prevent unlucky or uneducated loadouts that might make the tutorial more difficult than intended, and prevent the player from being overwhelmed by lots of different spell choices and effects they might not understand before even learning how to move and cast.
- Tutorial tasks now show their explain-popups as intended
- Fixed a bug that caused the multicast tutorial to not always be completed when it should
- Fixed a bug that caused the tutorial tasks to appear late in a headless game, which prevented already completed tasks from being marked as completed
- Fixed a bug that prevented completed tutorial tasks from appearing in the completed task dropdown
- High Score is now properly tracked for hotseat players as well
- Planning view attention markers consider smart targeting
- Fixed an issue that caused extra players to be added when using the joinGameAsPlayer function
- Maybe some other stuff I've slept since then 😆 

___

# Remaining Issues
### From #362
- #316 - The cause of this issue does not seem related to turn phases, and there are tons of other stamina bugs right now, so I'm leaving it in for this PR.

### Other
- [In Master] Moving while a spell is in progress in headless multiplayer seems to cause significant desync (fixed w/ next syncPlayers())
- [In Master] The movement lerp that happens when another player moves is really bad and inaccurate, also causing positional desync
- [New in PR] Some game actions restore stamina in headless? Always seems to set it to = 90

___

# TODO (Other)
### Tasks
- Implement intentional desyncs around endedTurn, inPortal, etc.

### Test
- Tutorial
- Singleplayer
- Hotseat Multiplayer
- Headless Multiplayer
- Game Over State
- Save/Load
- Progression of game state with allies, waves, etc.
- 
- Freeze
- Clone/Split
- Purify
- Res
- Death
- Sync Death (complete a level/wave and die at the same time)
- End Turn
- Combinations of above ^