### PR TITLE
fix: Arrow spell should await all arrows' arrival

### DIFF
--- a/src/cards/arrow.ts
+++ b/src/cards/arrow.ts
@@ -100,6 +100,7 @@ export function arrowEffect(multiShotCount: number, collideFnKey: string, doesPi
       }
 
     }
+    await underworld.awaitForceMoves();
     return state;
   }
 }


### PR DESCRIPTION
Potentially resolves #399, needs more validation