### PR TITLE
Mana Vampire Changes

### DIFF
--- a/src/cards/add_heal.ts
+++ b/src/cards/add_heal.ts
@@ -5,13 +5,14 @@ import { CardCategory } from '../types/commonTypes';
 import { playDefaultSpellSFX } from './cardUtils';
 import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
+import { healUnits } from '../effects/heal';
 
-export const heal_id = 'heal';
+export const healCardId = 'heal';
 const healAmount = 30;
 
 const spell: Spell = {
   card: {
-    id: heal_id,
+    id: healCardId,
     category: CardCategory.Blessings,
     sfx: 'heal',
     supportQuantity: true,
@@ -23,25 +24,7 @@ const spell: Spell = {
     animationPath: 'spell-effects/potionPickup',
     description: ['spell_heal', healAmount.toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
-      // Since all targets are animated simultaneously we only need to await
-      // the latest one, no need to use Promise.all
-      let animationPromise = Promise.resolve();
-      // .filter: only target living units
-      for (let unit of state.targetedUnits.filter(u => u.alive)) {
-        const damage = -healAmount * quantity;
-        if (!prediction && quantity > 1) {
-          for (let unit of state.targetedUnits) {
-            floatingText({
-              coords: unit,
-              text: `+${Math.abs(damage)} Health`
-            });
-          }
-        }
-        playDefaultSpellSFX(card, prediction);
-        Unit.takeDamage(unit, damage, undefined, underworld, prediction, state);
-        animationPromise = Image.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, { loop: false, animationSpeed: 0.3 });
-      }
-      await animationPromise;
+      await healUnits(state.targetedUnits, healAmount * quantity, underworld, prediction, state);
       return state;
     },
   },

--- a/src/cards/heal_greater.ts
+++ b/src/cards/heal_greater.ts
@@ -5,15 +5,16 @@ import { CardCategory } from '../types/commonTypes';
 import { playDefaultSpellSFX } from './cardUtils';
 import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
-import { heal_id } from './add_heal';
+import { healCardId } from './add_heal';
+import { healUnits } from '../effects/heal';
 
-export const heal_greater_id = 'Greater Heal';
+export const healGreaterId = 'Greater Heal';
 const healAmount = 80;
 
 const spell: Spell = {
   card: {
-    id: heal_greater_id,
-    replaces: [heal_id],
+    id: healGreaterId,
+    replaces: [healCardId],
     category: CardCategory.Blessings,
     sfx: 'heal',
     supportQuantity: true,
@@ -25,25 +26,7 @@ const spell: Spell = {
     animationPath: 'spell-effects/potionPickup',
     description: ['spell_heal', healAmount.toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
-      // Since all targets are animated simultaneously we only need to await
-      // the latest one, no need to use Promise.all
-      let animationPromise = Promise.resolve();
-      // .filter: only target living units
-      for (let unit of state.targetedUnits.filter(u => u.alive)) {
-        const damage = -healAmount * quantity;
-        if (!prediction && quantity > 1) {
-          for (let unit of state.targetedUnits) {
-            floatingText({
-              coords: unit,
-              text: `+${Math.abs(damage)} Health`
-            });
-          }
-        }
-        playDefaultSpellSFX(card, prediction);
-        Unit.takeDamage(unit, damage, undefined, underworld, prediction, state);
-        animationPromise = Image.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, { loop: false, animationSpeed: 0.3 });
-      }
-      await animationPromise;
+      await healUnits(state.targetedUnits, healAmount * quantity, underworld, prediction, state);
       return state;
     },
   },

--- a/src/cards/heal_mass.ts
+++ b/src/cards/heal_mass.ts
@@ -5,7 +5,8 @@ import { CardCategory } from '../types/commonTypes';
 import { playDefaultSpellSFX } from './cardUtils';
 import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
-import { heal_greater_id } from './heal_greater';
+import { healGreaterId } from './heal_greater';
+import { healUnits } from '../effects/heal';
 
 export const heal_mass_id = 'Mass Heal';
 const healAmount = 10;
@@ -15,7 +16,7 @@ const spell: Spell = {
     id: heal_mass_id,
     // Mass heal doesn't require a target
     allowNonUnitTarget: true,
-    requires: [heal_greater_id],
+    requires: [healGreaterId],
     category: CardCategory.Blessings,
     sfx: 'heal',
     supportQuantity: true,
@@ -27,25 +28,9 @@ const spell: Spell = {
     animationPath: 'spell-effects/potionPickup',
     description: ['spell_heal_mass', healAmount.toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
-      // Since all targets are animated simultaneously we only need to await
-      // the latest one, no need to use Promise.all
-      let animationPromise = Promise.resolve();
-      // .filter: only target living units
-      for (let unit of (prediction ? underworld.unitsPrediction : underworld.units).filter(u => u.alive && u.faction == state.casterUnit.faction)) {
-        const damage = -healAmount * quantity;
-        if (!prediction && quantity > 1) {
-          for (let unit of state.targetedUnits) {
-            floatingText({
-              coords: unit,
-              text: `+${Math.abs(damage)} Health`
-            });
-          }
-        }
-        playDefaultSpellSFX(card, prediction);
-        Unit.takeDamage(unit, damage, undefined, underworld, prediction, state);
-        animationPromise = Image.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, { loop: false, animationSpeed: 0.3 });
-      }
-      await animationPromise;
+      const units = (prediction ? underworld.unitsPrediction : underworld.units)
+        .filter(u => u.alive && u.faction == state.casterUnit.faction);
+      await healUnits(units, healAmount * quantity, underworld, prediction, state);
       return state;
     },
   },

--- a/src/cards/mana_steal.ts
+++ b/src/cards/mana_steal.ts
@@ -1,15 +1,10 @@
+import * as config from '../config';
 import { refundLastSpell, Spell } from './index';
-import floatingText from '../graphics/FloatingText';
-import { addPixiSpriteAnimated } from '../graphics/PixiUtils';
-import { manaBlue } from '../graphics/ui/colors';
-import { MultiColorReplaceFilter } from '@pixi/filter-multi-color-replace';
 import { makeManaTrail } from '../graphics/Particles';
 import { CardCategory } from '../types/commonTypes';
-import { playDefaultSpellSFX } from './cardUtils';
-import * as config from '../config';
-import { explain, EXPLAIN_OVERFILL } from '../graphics/Explain';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { manaBurnCardId } from './mana_burn';
+import { healManaUnit } from '../effects/heal';
 
 const id = 'Mana Steal';
 const base_mana_stolen = 60;
@@ -44,62 +39,19 @@ const spell: Spell = {
           const unitManaStolen = Math.min(unit.mana, Math.ceil(remainingManaToSteal / (targets.length - i)));
           remainingManaToSteal -= unitManaStolen;
           unit.mana -= unitManaStolen;
-          const manaTrailPromises = [];
           if (!prediction) {
             for (let i = 0; i < quantity; i++) {
-              manaTrailPromises.push(makeManaTrail(unit, caster, underworld, '#e4f9ff', '#3fcbff'));
+              promises.push(makeManaTrail(unit, caster, underworld, '#e4f9ff', '#3fcbff'));
             }
           }
-          promises.push((prediction ? Promise.resolve() : Promise.all(manaTrailPromises)));
         }
       }
+      await Promise.all(promises)
+
       // In case there wasn't enough mana to steal
       totalManaStolen -= remainingManaToSteal;
-      await Promise.all(promises).then(() => {
-        state.casterUnit.mana += totalManaStolen;
-        if (!prediction) {
-          playDefaultSpellSFX(card, prediction);
-          // Animate
-          if (state.casterUnit.image) {
-            // Note: This uses the lower-level addPixiSpriteAnimated directly so that it can get a reference to the sprite
-            // and add a filter; however, addOneOffAnimation is the higher level and more common for adding a simple
-            // "one off" animated sprite.  Use it instead of addPixiSpriteAnimated unless you need more direct control like
-            // we do here
-            const animationSprite = addPixiSpriteAnimated('spell-effects/potionPickup', state.casterUnit.image.sprite, {
-              loop: false,
-              onComplete: () => {
-                if (animationSprite?.parent) {
-                  animationSprite.parent.removeChild(animationSprite);
-                }
-              }
-            });
-            if (animationSprite) {
-
-              if (!animationSprite.filters) {
-                animationSprite.filters = [];
-              }
-              // Change the health color to blue
-              animationSprite.filters.push(
-                new MultiColorReplaceFilter(
-                  [
-                    [0xff0000, manaBlue],
-                  ],
-                  0.1
-                )
-              );
-            }
-          }
-          explain(EXPLAIN_OVERFILL);
-        }
-      });
       if (totalManaStolen > 0) {
-        if (!prediction) {
-          floatingText({
-            coords: caster,
-            text: `+ ${totalManaStolen} Mana`,
-            style: { fill: 'blue', ...config.PIXI_TEXT_DROP_SHADOW }
-          });
-        }
+        await healManaUnit(state.casterUnit, totalManaStolen, underworld, prediction, state);
       } else {
         refundLastSpell(state, prediction, 'No targets have mana to steal\nHealth cost refunded')
       }

--- a/src/cards/sacrifice.ts
+++ b/src/cards/sacrifice.ts
@@ -1,8 +1,6 @@
 import { refundLastSpell, Spell } from './index';
 import floatingText from '../graphics/FloatingText';
 import { addPixiSpriteAnimated } from '../graphics/PixiUtils';
-import { manaBlue } from '../graphics/ui/colors';
-import { MultiColorReplaceFilter } from '@pixi/filter-multi-color-replace';
 import { makeManaTrail } from '../graphics/Particles';
 import { CardCategory, UnitSubType } from '../types/commonTypes';
 import { playDefaultSpellSFX } from './cardUtils';
@@ -10,6 +8,7 @@ import * as config from '../config';
 import { explain, EXPLAIN_OVERFILL } from '../graphics/Explain';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { die } from '../entity/Unit';
+import * as Image from '../graphics/Image';
 
 const damage = config.UNIT_BASE_HEALTH; //40 at time of writing
 export const consumeAllyCardId = 'Sacrifice';
@@ -44,27 +43,7 @@ const spell: Spell = {
             healthTrailPromises.push(makeManaTrail(unit, caster, underworld, '#ff6767n', '#ff0000').then(() => {
               if (!prediction) {
                 playDefaultSpellSFX(card, prediction);
-                // Animate
-                if (state.casterUnit.image) {
-                  // Note: This uses the lower-level addPixiSpriteAnimated directly so that it can get a reference to the sprite
-                  // and add a filter; however, addOneOffAnimation is the higher level and more common for adding a simple
-                  // "one off" animated sprite.  Use it instead of addPixiSpriteAnimated unless you need more direct control like
-                  // we do here
-                  const animationSprite = addPixiSpriteAnimated('spell-effects/potionPickup', state.casterUnit.image.sprite, {
-                    loop: false,
-                    onComplete: () => {
-                      if (animationSprite?.parent) {
-                        animationSprite.parent.removeChild(animationSprite);
-                      }
-                    }
-                  });
-                  if (animationSprite) {
-
-                    if (!animationSprite.filters) {
-                      animationSprite.filters = [];
-                    }
-                  }
-                }
+                Image.addOneOffAnimation(state.casterUnit, 'spell-effects/potionPickup', {}, { loop: false });
                 explain(EXPLAIN_OVERFILL);
               }
             })

--- a/src/cards/send_mana.ts
+++ b/src/cards/send_mana.ts
@@ -1,23 +1,17 @@
 import * as Unit from '../entity/Unit';
-import floatingText from '../graphics/FloatingText';
-import * as Image from '../graphics/Image';
+import * as config from '../config';
 import { CardCategory } from '../types/commonTypes';
-import { playDefaultSpellSFX } from './cardUtils';
 import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { makeManaTrail } from '../graphics/Particles';
-import { addPixiSpriteAnimated } from '../graphics/PixiUtils';
-import { manaBlue } from '../graphics/ui/colors';
-import { MultiColorReplaceFilter } from '@pixi/filter-multi-color-replace';
-import * as config from '../config';
-import { explain, EXPLAIN_OVERFILL } from '../graphics/Explain';
+import { healManaUnits } from '../effects/heal';
 
-export const id = 'Send Mana';
+export const sendManaCardId = 'Send Mana';
 const amount = 20;
 
 const spell: Spell = {
   card: {
-    id: id,
+    id: sendManaCardId,
     category: CardCategory.Mana,
     sfx: 'potionPickupMana',
     supportQuantity: true,
@@ -32,60 +26,15 @@ const spell: Spell = {
       const targets = state.targetedUnits.filter(u => u.alive);
       let promises = [];
       for (let unit of targets) {
-        const manaTrailPromises = [];
         if (!prediction) {
-          manaTrailPromises.push(makeManaTrail(state.casterUnit, unit, underworld, '#e4f9ff', '#3fcbff'));
-        }
-        promises.push((prediction ? Promise.resolve() : Promise.all(manaTrailPromises)));
-      }
-      await Promise.all(promises).then(() => {
-        const finalManaSent = Math.floor(amount * quantity / targets.length);
-        for (let unit of targets) {
-          unit.mana += finalManaSent;
-        }
-        if (!prediction) {
-          playDefaultSpellSFX(card, prediction);
-          // Animate
-          for (let unit of targets) {
-            if (unit.image) {
-              // Note: This uses the lower-level addPixiSpriteAnimated directly so that it can get a reference to the sprite
-              // and add a filter; however, addOneOffAnimation is the higher level and more common for adding a simple
-              // "one off" animated sprite.  Use it instead of addPixiSpriteAnimated unless you need more direct control like
-              // we do here
-              const animationSprite = addPixiSpriteAnimated('spell-effects/potionPickup', unit.image.sprite, {
-                loop: false,
-                onComplete: () => {
-                  if (animationSprite?.parent) {
-                    animationSprite.parent.removeChild(animationSprite);
-                  }
-                }
-              });
-              if (animationSprite) {
-
-                if (!animationSprite.filters) {
-                  animationSprite.filters = [];
-                }
-                // Change the health color to blue
-                animationSprite.filters.push(
-                  new MultiColorReplaceFilter(
-                    [
-                      [0xff0000, manaBlue],
-                    ],
-                    0.1
-                  )
-                );
-              }
-            }
-
-            floatingText({
-              coords: unit,
-              text: `+ ${finalManaSent} Mana`,
-              style: { fill: 'blue', ...config.PIXI_TEXT_DROP_SHADOW }
-            });
+          for (let i = 0; i < quantity; i++) {
+            promises.push(makeManaTrail(state.casterUnit, unit, underworld, '#e4f9ff', '#3fcbff'));
           }
-          explain(EXPLAIN_OVERFILL);
         }
-      });
+      }
+      await Promise.all(promises);
+      const finalManaSent = Math.floor(amount * quantity / targets.length);
+      await healManaUnits(targets, finalManaSent, underworld, prediction, state);
       //refund if no targets ?
       return state;
     },

--- a/src/effects/heal.ts
+++ b/src/effects/heal.ts
@@ -59,6 +59,7 @@ export async function healManaUnits(units: Unit.IUnit[], amount: number, underwo
       unit.mana += amount;
       explain(EXPLAIN_OVERFILL);
       // TODO - Create mana version of this healing effect or improve support for colorfilter
+      // https://github.com/jdoleary/Spellmasons/pull/423
       animationPromise = Image.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, animationOptions);
     }
     await animationPromise;

--- a/src/effects/heal.ts
+++ b/src/effects/heal.ts
@@ -1,0 +1,39 @@
+import Underworld from "../Underworld";
+import * as Unit from '../entity/Unit';
+import * as colors from '../graphics/ui/colors';
+import floatingText from "../graphics/FloatingText";
+import * as Image from '../graphics/Image';
+import { playDefaultSpellSFX } from "../cards/cardUtils";
+import { healCardId } from "../cards/add_heal";
+import { EffectState } from "../cards";
+
+export async function healUnits(units: Unit.IUnit[], amount: number, underworld: Underworld, prediction: boolean, state?: EffectState, useHealFx: boolean = true) {
+  units = units.filter(u => u.alive);
+  if (units.length == 0) return;
+
+  if (useHealFx && !prediction) {
+    if (allCards) {
+      playDefaultSpellSFX(allCards[healCardId], prediction);
+    }
+    let animationPromise = undefined;
+    for (let unit of units) {
+      // All heals animate simultaneously, so just await the last promise
+      // Instead of using Promise.All()
+      floatingText({ coords: unit, text: `+${Math.abs(amount)} Health` });
+      Unit.takeDamage(unit, -amount, undefined, underworld, prediction, state);
+      animationPromise = Image.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, { loop: false, animationSpeed: 0.3 });
+    }
+    await animationPromise;
+    return state;
+  } else {
+    for (let unit of units) {
+      Unit.takeDamage(unit, -amount, undefined, underworld, prediction, state);
+    }
+    return state;
+  }
+}
+
+export async function healUnit(unit: Unit.IUnit, amount: number, underworld: Underworld, prediction: boolean, state?: EffectState, useHealFx: boolean = true) {
+  const units = [unit];
+  return await healUnits(units, amount, underworld, prediction, state, useHealFx);
+}

--- a/src/effects/heal.ts
+++ b/src/effects/heal.ts
@@ -3,15 +3,20 @@ import * as Unit from '../entity/Unit';
 import * as colors from '../graphics/ui/colors';
 import floatingText from "../graphics/FloatingText";
 import * as Image from '../graphics/Image';
+import * as config from '../config';
 import { playDefaultSpellSFX } from "../cards/cardUtils";
 import { healCardId } from "../cards/add_heal";
 import { EffectState } from "../cards";
+import { sendManaCardId } from "../cards/send_mana";
+import { EXPLAIN_OVERFILL, explain } from "../graphics/Explain";
 
-export async function healUnits(units: Unit.IUnit[], amount: number, underworld: Underworld, prediction: boolean, state?: EffectState, useHealFx: boolean = true) {
+const animationOptions = { loop: false, animationSpeed: 0.3 };
+
+export async function healUnits(units: Unit.IUnit[], amount: number, underworld: Underworld, prediction: boolean, state?: EffectState, useFx: boolean = true) {
   units = units.filter(u => u.alive);
-  if (units.length == 0) return;
+  if (units.length == 0 || amount == 0) return;
 
-  if (useHealFx && !prediction) {
+  if (useFx && !prediction) {
     if (allCards) {
       playDefaultSpellSFX(allCards[healCardId], prediction);
     }
@@ -21,7 +26,7 @@ export async function healUnits(units: Unit.IUnit[], amount: number, underworld:
       // Instead of using Promise.All()
       floatingText({ coords: unit, text: `+${Math.abs(amount)} Health` });
       Unit.takeDamage(unit, -amount, undefined, underworld, prediction, state);
-      animationPromise = Image.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, { loop: false, animationSpeed: 0.3 });
+      animationPromise = Image.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, animationOptions);
     }
     await animationPromise;
     return state;
@@ -33,7 +38,40 @@ export async function healUnits(units: Unit.IUnit[], amount: number, underworld:
   }
 }
 
-export async function healUnit(unit: Unit.IUnit, amount: number, underworld: Underworld, prediction: boolean, state?: EffectState, useHealFx: boolean = true) {
+export async function healUnit(unit: Unit.IUnit, amount: number, underworld: Underworld, prediction: boolean, state?: EffectState, useFx: boolean = true) {
   const units = [unit];
-  return await healUnits(units, amount, underworld, prediction, state, useHealFx);
+  return await healUnits(units, amount, underworld, prediction, state, useFx);
+}
+
+export async function healManaUnits(units: Unit.IUnit[], amount: number, underworld: Underworld, prediction: boolean, state?: EffectState, useFx: boolean = true) {
+  units = units.filter(u => u.alive);
+  if (units.length == 0 || amount == 0) return;
+
+  if (useFx && !prediction) {
+    if (allCards) {
+      playDefaultSpellSFX(allCards[sendManaCardId], prediction);
+    }
+    let animationPromise = undefined;
+    for (let unit of units) {
+      // All heals animate simultaneously, so just await the last promise
+      // Instead of using Promise.All()
+      floatingText({ coords: unit, text: `+ ${amount} Mana`, style: { fill: 'blue', ...config.PIXI_TEXT_DROP_SHADOW } });
+      unit.mana += amount;
+      explain(EXPLAIN_OVERFILL);
+      // TODO - Create mana version of this healing effect or improve support for colorfilter
+      animationPromise = Image.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, animationOptions);
+    }
+    await animationPromise;
+    return state;
+  } else {
+    for (let unit of units) {
+      unit.mana += amount;
+    }
+    return state;
+  }
+}
+
+export async function healManaUnit(unit: Unit.IUnit, amount: number, underworld: Underworld, prediction: boolean, state?: EffectState, useFx: boolean = true) {
+  const units = [unit];
+  return await healManaUnits(units, amount, underworld, prediction, state, useFx);
 }

--- a/src/entity/Pickup.ts
+++ b/src/entity/Pickup.ts
@@ -629,35 +629,11 @@ export const pickups: IPickupSource[] = [
           playSFXKey('potionPickupMana');
         }
         // Animate
-        if (unit.image) {
-          // Note: This uses the lower-level addPixiSpriteAnimated directly so that it can get a reference to the sprite
-          // and add a filter; however, addOneOffAnimation is the higher level and more common for adding a simple
-          // "one off" animated sprite.  Use it instead of addPixiSpriteAnimated unless you need more direct control like
-          // we do here
-          const animationSprite = addPixiSpriteAnimated('spell-effects/potionPickup', unit.image.sprite, {
-            loop: false,
-            animationSpeed: 0.3,
-            onComplete: () => {
-              if (animationSprite && animationSprite.parent) {
-                animationSprite.parent.removeChild(animationSprite);
-              }
-            }
-          });
-          if (animationSprite) {
-            if (!animationSprite.filters) {
-              animationSprite.filters = [];
-            }
-            // Change the health color to yellow 
-            animationSprite.filters.push(
-              new MultiColorReplaceFilter(
-                [
-                  [0xff0000, stamina],
-                ],
-                0.15
-              )
-            );
-          }
-        }
+        Image.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, {
+          loop: false,
+          animationSpeed: 0.3,
+          colorReplace: { colors: [[0xff0000, stamina]], epsilon: 0.15 },
+        });
       }
     },
   },
@@ -680,35 +656,12 @@ export const pickups: IPickupSource[] = [
           playSFXKey('potionPickupMana');
         }
         // Animate
-        if (unit.image) {
-          // Note: This uses the lower-level addPixiSpriteAnimated directly so that it can get a reference to the sprite
-          // and add a filter; however, addOneOffAnimation is the higher level and more common for adding a simple
-          // "one off" animated sprite.  Use it instead of addPixiSpriteAnimated unless you need more direct control like
-          // we do here
-          const animationSprite = addPixiSpriteAnimated('spell-effects/potionPickup', unit.image.sprite, {
-            loop: false,
-            animationSpeed: 0.3,
-            onComplete: () => {
-              if (animationSprite && animationSprite.parent) {
-                animationSprite.parent.removeChild(animationSprite);
-              }
-            }
-          });
-          if (animationSprite) {
-            if (!animationSprite.filters) {
-              animationSprite.filters = [];
-            }
-            // Change the health color to blue
-            animationSprite.filters.push(
-              new MultiColorReplaceFilter(
-                [
-                  [0xff0000, manaBlue],
-                ],
-                0.15
-              )
-            );
-          }
-        }
+        // Animate
+        Image.addOneOffAnimation(unit, 'spell-effects/potionPickup', {}, {
+          loop: false,
+          animationSpeed: 0.3,
+          colorReplace: { colors: [[0xff0000, manaBlue]], epsilon: 0.15 },
+        });
       }
     },
   },

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -21,7 +21,7 @@ import { lightenColor } from '../graphics/ui/colorUtil';
 import { AttributePerk } from '../Perk';
 import { setPlayerNameUI } from '../PlayerUtils';
 import { arrowCardId } from '../cards/arrow';
-import { heal_id } from '../cards/add_heal';
+import { healCardId } from '../cards/add_heal';
 import { contaminate_id } from '../cards/contaminate';
 
 const elInGameLobby = document.getElementById('in-game-lobby') as (HTMLElement | undefined);
@@ -147,7 +147,7 @@ export function changeMageType(type: MageType, player?: IPlayer, underworld?: Un
         break;
       case 'Cleric':
         {
-          const upgrade = Upgrade.getUpgradeByTitle(heal_id);
+          const upgrade = Upgrade.getUpgradeByTitle(healCardId);
           if (upgrade) {
             underworld.forceUpgrade(player, upgrade, true);
           } else {

--- a/src/entity/units/manaVampire.ts
+++ b/src/entity/units/manaVampire.ts
@@ -6,8 +6,9 @@ import { meleeAction, meleeTryAttackClosestEnemy, withinMeleeRange } from './act
 import Underworld from '../../Underworld';
 import { bloodVampire } from '../../graphics/ui/colors';
 import floatingText from '../../graphics/FloatingText';
+import { healUnit } from '../../effects/heal';
 
-const manaToSteal = 50;
+const manaToSteal = 40;
 export const MANA_VAMPIRE_ID = 'Mana Vampire';
 const unit: UnitSource = {
   id: MANA_VAMPIRE_ID,
@@ -61,11 +62,11 @@ const unit: UnitSource = {
         }
       }
     })
-    const missingHealth = unit.healthMax - unit.health;
-    if (missingHealth > 0) {
-      const healthToRestore = Math.min(unit.mana, missingHealth);
+    // Will restore up to 40 missing hp if the unit has mana to do so
+    const healthToRestore = Math.min(40, unit.mana, unit.healthMax - unit.health);
+    if (healthToRestore > 0) {
       unit.mana -= healthToRestore;
-      Unit.takeDamage(unit, -healthToRestore, undefined, underworld, false, undefined);
+      await healUnit(unit, healthToRestore, underworld, false);
     }
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {

--- a/src/entity/units/vampire.ts
+++ b/src/entity/units/vampire.ts
@@ -18,14 +18,14 @@ const unit: UnitSource = {
     subtype: UnitSubType.MELEE,
   },
   unitProps: {
-    damage: 50,
-    healthMax: 70,
+    damage: 40,
+    healthMax: 80,
     manaMax: 0,
     bloodColor: 0x293a1b,
   },
   spawnParams: {
     probability: 15,
-    budgetCost: 5,
+    budgetCost: 6,
     unavailableUntilLevelIndex: 5,
   },
   animations: {


### PR DESCRIPTION
Closes #350 

Mana Vampire now steals mana instead of mana max, and uses that mana to heal itself each turn.

Also modularized restoration effects for healing and mana.

Tested in Singleplayer and w/ loading

## TODO
- Update Mana Vampire description to fit new behavior