### PR TITLE
Fixed EndTurnEvents for new Units

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2640,7 +2640,8 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
 
     // End turn events, liquid damage, mana regen, etc.
-    await Unit.endTurnForUnits(units, this, false);
+    // Use new units list in case it has changed (I.E. summons)
+    await Unit.endTurnForUnits(this.units.filter(u => u.unitType == UnitType.AI && u.faction == faction), this, false);
   }
   // This function is invoked when all factions have finished their turns
   async endFullTurnCycle() {


### PR DESCRIPTION
Summoned units would not lose summoning sickness immediately because the EndTurnForUnits function would use the unit list created before unit actions are taken (I.E. wouldn't include summoned units). This PR resolves that.

Tested in Singleplayer