### PR TITLE
Waves Fix

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2337,7 +2337,7 @@ export default class Underworld {
       console.log('[GAME] Game is Over\nNo connected players in player list: ', this.players);
       return true;
     } else {
-      console.log('[GAME] isGameOver?\nConnected Players: ', connectedPlayers);
+      console.debug('[GAME] isGameOver?\nConnected Players: ', connectedPlayers);
     }
 
     // Are any of those players or their allies alive?
@@ -2348,7 +2348,7 @@ export default class Underworld {
       console.log('[GAME] Game is Over\nNo allies remain');
       return true;
     } else {
-      console.log('[GAME] isGameOver?\nRemaining allies: ', remainingAllies);
+      console.debug('[GAME] isGameOver?\nRemaining allies: ', remainingAllies);
     }
 
     // Have allies made progress towards winning in the last X turns?
@@ -2358,7 +2358,7 @@ export default class Underworld {
       console.log('[GAME] Game is Over\nKill Switch threshold reached');
       return true;
     } else {
-      console.log('[GAME] isGameOver?\nKill Switch Counter: ', this.allyNPCAttemptWinKillSwitch);
+      console.debug('[GAME] isGameOver?\nKill Switch Counter: ', this.allyNPCAttemptWinKillSwitch);
     }
 
     console.log('[GAME] isGameOver = false\nGame is not over');

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2126,20 +2126,24 @@ export default class Underworld {
     return { x, y };
   }
   getPlayerFactions() {
-    // Returns all players' current faction
-    return this.players.filter(p => p.clientConnected).map(p => p.unit.faction);
+    // Returns all factions that currently contain at least one player
+    const factions = this.players.filter(p => p.clientConnected).map(p => p.unit.faction);
+    // This removes all duplicate entries from the list
+    return [...new Set(factions)];
   }
   getRemainingPlayerUnits(): Unit.IUnit[] {
     // Returns all living units currently controlled by a player
-    return this.players.filter(p => p.isSpawned).map(p => p.unit).filter(u => u.alive);
+    return this.players.filter(p => p.clientConnected && p.isSpawned).map(p => p.unit).filter(u => u.alive);
   }
   getRemainingAllies(): Unit.IUnit[] {
     // Returns all living units that share a faction with a player
-    return this.units.filter(u => u.alive && this.getPlayerFactions().includes(u.faction) && u.unitSubType != UnitSubType.DOODAD);
+    const playerFactions = this.getPlayerFactions();
+    return this.units.filter(u => u.alive && playerFactions.includes(u.faction) && u.unitSubType != UnitSubType.DOODAD);
   }
   getRemainingEnemies(): Unit.IUnit[] {
     // Returns all living units that don't share a faction with a player
-    return this.units.filter(u => u.alive && !this.getPlayerFactions().includes(u.faction) && u.unitSubType != UnitSubType.DOODAD);
+    const playerFactions = this.getPlayerFactions();
+    return this.units.filter(u => u.alive && !playerFactions.includes(u.faction) && u.unitSubType != UnitSubType.DOODAD);
   }
   // Handles level completion, game over, turn phases, and hotseat
   async progressGameState() {

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2287,7 +2287,7 @@ export default class Underworld {
     return true;
   }
   trySpawnPortals(): boolean {
-    const remainingPlayers = this.getRemainingPlayerUnits();
+    const remainingPlayers = this.getRemainingPlayerUnits().filter(u => Unit.canAct(u));
     if (remainingPlayers.length == 0) {
       console.debug('[GAME] TrySpawnPortals()...\nNo players to spawn portals for: ', this.players);
       return false;

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2125,24 +2125,18 @@ export default class Underworld {
     );
     return { x, y };
   }
-  getPlayerFactions() {
-    // Returns all factions that currently contain at least one player
-    const factions = this.players.filter(p => p.clientConnected).map(p => p.unit.faction);
-    // This removes all duplicate entries from the list
-    return [...new Set(factions)];
-  }
   getRemainingPlayerUnits(): Unit.IUnit[] {
     // Returns all living units currently controlled by a player
     return this.players.filter(p => p.clientConnected && p.isSpawned).map(p => p.unit).filter(u => u.alive);
   }
-  getRemainingAllies(): Unit.IUnit[] {
+  getRemainingPlayerAllies(): Unit.IUnit[] {
     // Returns all living units that share a faction with a player
-    const playerFactions = this.getPlayerFactions();
+    const playerFactions = Player.getFactionsOf(this.players);
     return this.units.filter(u => u.alive && playerFactions.includes(u.faction) && u.unitSubType != UnitSubType.DOODAD);
   }
-  getRemainingEnemies(): Unit.IUnit[] {
+  getRemainingPlayerEnemies(): Unit.IUnit[] {
     // Returns all living units that don't share a faction with a player
-    const playerFactions = this.getPlayerFactions();
+    const playerFactions = Player.getFactionsOf(this.players);
     return this.units.filter(u => u.alive && !playerFactions.includes(u.faction) && u.unitSubType != UnitSubType.DOODAD);
   }
   // Handles level completion, game over, turn phases, and hotseat
@@ -2230,7 +2224,7 @@ export default class Underworld {
       return false;
     }
 
-    const remainingEnemies = this.getRemainingEnemies();
+    const remainingEnemies = this.getRemainingPlayerEnemies();
     if (remainingEnemies.length > 0) {
       console.debug('[GAME] Can\'t Spawn Next Wave\nRemaining enemies: ', remainingEnemies);
       return false;
@@ -2271,7 +2265,7 @@ export default class Underworld {
   }
   isLevelComplete(): boolean {
     // The level is complete if all enemies, waves, and bosses have been killed
-    const remainingEnemies = this.getRemainingEnemies();
+    const remainingEnemies = this.getRemainingPlayerEnemies();
     if (remainingEnemies.length > 0) {
       console.debug('[GAME] Level Incomplete...\nEnemies remain...');
       return false;
@@ -2370,7 +2364,7 @@ export default class Underworld {
       console.debug('[GAME] isGameOver?\nConnected Players: ', connectedPlayers);
     }
 
-    const remainingAllies = this.getRemainingAllies();
+    const remainingAllies = this.getRemainingPlayerAllies();
     if (remainingAllies.length == 0) {
       console.log('[GAME] Game is Over\nNo allies remain');
       return true;

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -615,9 +615,7 @@ export function setSpellmasonsToChannellingAnimation(player: IPlayer) {
       );
       Image.addOneOffAnimation(player.unit, 'units/playerBookIdleMagic', { doRemoveWhenPrimaryAnimationChanges: true }, { loop: true });
     }
-
   });
-
 }
 // This function fully deletes the cards from the player's hand
 export function removeCardsFromHand(player: IPlayer, cards: string[], underworld: Underworld) {
@@ -630,4 +628,10 @@ export function removeCardsFromHand(player: IPlayer, cards: string[], underworld
     });
   }
   CardUI.recalcPositionForCards(player, underworld);
+}
+export function getFactionsOf(players: { clientConnected: boolean, unit: { faction: Faction } }[]): Faction[] {
+  // Returns all factions that currently contain at least one player
+  const factions = players.filter(p => p.clientConnected).map(p => p.unit.faction);
+  // This removes all duplicate entries from the list
+  return [...new Set(factions)];
 }

--- a/src/entity/__test__/entity.test.ts
+++ b/src/entity/__test__/entity.test.ts
@@ -1,0 +1,32 @@
+import { Faction } from "../../types/commonTypes.ts";
+import { getFactionsOf } from "../Player.ts";
+
+describe('getFactionsOf', () => {
+  it('should return an array of factions', () => {
+    const players = [
+      { clientConnected: true, unit: { faction: Faction.ALLY } },
+      { clientConnected: true, unit: { faction: Faction.ENEMY } }]
+    const actual = getFactionsOf(players);
+    const expected = [Faction.ALLY, Faction.ENEMY];
+    expect(expected).toEqual(actual);
+  });
+  it('should return a deduplicated array', () => {
+    const players = [
+      { clientConnected: true, unit: { faction: Faction.ALLY } },
+      { clientConnected: true, unit: { faction: Faction.ALLY } },
+      { clientConnected: true, unit: { faction: Faction.ALLY } },]
+    const actual = getFactionsOf(players);
+    const expected = [Faction.ALLY];
+    expect(expected).toEqual(actual);
+  });
+  it('should return NOT include disconnected players', () => {
+    const players = [
+      { clientConnected: true, unit: { faction: Faction.ALLY } },
+      { clientConnected: true, unit: { faction: Faction.ALLY } },
+      { clientConnected: false, unit: { faction: Faction.ENEMY } },
+      { clientConnected: false, unit: { faction: Faction.ALLY } },]
+    const actual = getFactionsOf(players);
+    const expected = [Faction.ALLY];
+    expect(expected).toEqual(actual);
+  });
+});

--- a/src/entity/__test__/faction.test.ts
+++ b/src/entity/__test__/faction.test.ts
@@ -1,5 +1,6 @@
 import { Faction } from "../../types/commonTypes.ts";
 import { getFactionsOf } from "../Player.ts";
+import { livingUnitsInSameFaction } from "../Unit.ts";
 
 describe('getFactionsOf', () => {
   it('should return an array of factions', () => {

--- a/src/entity/__test__/faction.test.ts
+++ b/src/entity/__test__/faction.test.ts
@@ -1,6 +1,6 @@
 import { Faction } from "../../types/commonTypes.ts";
 import { getFactionsOf } from "../Player.ts";
-import { livingUnitsInSameFaction } from "../Unit.ts";
+import { livingUnitsInSameFaction, livingUnitsInDifferentFaction } from "../Unit.ts";
 
 describe('getFactionsOf', () => {
   it('should return an array of factions', () => {
@@ -31,3 +31,6 @@ describe('getFactionsOf', () => {
     expect(expected).toEqual(actual);
   });
 });
+
+// TODO - Implement Unit Tests for livingUnitsInSameFaction, livingUnitsInDifferentFaction,
+// and other similar functions

--- a/src/entity/units/actions/rangedAction.ts
+++ b/src/entity/units/actions/rangedAction.ts
@@ -7,58 +7,58 @@ import * as config from '../../../config';
 
 // closest: Sort targets closest to farthest
 export function getBestRangedLOSTarget(unit: Unit.IUnit, underworld: Underworld, closest: boolean = true): Unit.IUnit[] {
-    const enemies = Unit.livingUnitsInDifferentFaction(unit, underworld);
-    const attackableEnemies = enemies.filter(enemy => {
-        return Unit.inRange(unit, enemy) && underworld.hasLineOfSight(unit, enemy);
-    }).map(enemy => {
-        return { enemy, distance: math.distance(unit, enemy) };
-    });
-    const sortedByDistanceAttackableEnemies = attackableEnemies.sort((a, b) => {
-        return closest ? a.distance - b.distance : b.distance - a.distance;
-    });
-    return sortedByDistanceAttackableEnemies.map(e => e.enemy)
-        .filter(Unit.filterSmartTarget)
+  const enemies = Unit.livingUnitsInDifferentFaction(unit, underworld.units);
+  const attackableEnemies = enemies.filter(enemy => {
+    return Unit.inRange(unit, enemy) && underworld.hasLineOfSight(unit, enemy);
+  }).map(enemy => {
+    return { enemy, distance: math.distance(unit, enemy) };
+  });
+  const sortedByDistanceAttackableEnemies = attackableEnemies.sort((a, b) => {
+    return closest ? a.distance - b.distance : b.distance - a.distance;
+  });
+  return sortedByDistanceAttackableEnemies.map(e => e.enemy)
+    .filter(Unit.filterSmartTarget)
 }
 
 export async function rangedLOSMovement(unit: Unit.IUnit, underworld: Underworld) {
-    // Movement:
-    const closestEnemy = Unit.findClosestUnitInDifferentFaction(unit, underworld);
-    // Intelligently move the archer to a position where it can see the enemy
-    if (closestEnemy) {
-        const moveOptions = Unit.findLOSLocation(unit, closestEnemy, underworld);
-        const moveChoice = moveOptions.reduce<{ dist: number, pos: Vec2 | undefined }>((closest, cur) => {
-            const dist = math.distance(cur, unit);
-            if (dist < closest.dist) {
-                return { dist, pos: cur }
-            } else {
-                return closest
-            }
-        }, { dist: Number.MAX_SAFE_INTEGER, pos: undefined });
+  // Movement:
+  const closestEnemy = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
+  // Intelligently move the archer to a position where it can see the enemy
+  if (closestEnemy) {
+    const moveOptions = Unit.findLOSLocation(unit, closestEnemy, underworld);
+    const moveChoice = moveOptions.reduce<{ dist: number, pos: Vec2 | undefined }>((closest, cur) => {
+      const dist = math.distance(cur, unit);
+      if (dist < closest.dist) {
+        return { dist, pos: cur }
+      } else {
+        return closest
+      }
+    }, { dist: Number.MAX_SAFE_INTEGER, pos: undefined });
 
-        if (moveChoice.pos && !underworld.hasLineOfSight(unit, closestEnemy)) {
-            // TODO: archer movement issue: sometimes moveChoice.pos is through a wall
-            // findPath is just returning one point, it fails to find a path. Oh it's because it's
-            // trying to path to a point on a wall, not in walkable space
-            if (underworld.hasLineOfSight(unit, moveChoice.pos)) {
-                // Generally if an archer doesn't have line of sight on the enemy,
-                // it will use findLOSLocation to check in an arc around the enemy for a point where there
-                // is line of sight.  If the point on that arc is within LOS of the archer, move to that point
-                // if not..
-                await Unit.moveTowards(unit, moveChoice.pos, underworld);
-            } else {
-                // ...then just move towards the enemy.  This prevents weird behavior where
-                // the archer tries to path toward a point ON a wall (which is technically inaccessible),
-                // and the archer will just walk forward awkardly until it hits a wall instead of pathing
-                // towards the enemy
-                await Unit.moveTowards(unit, closestEnemy, underworld);
-            }
-        } else {
-            // Move closer until in range (or out of stamina)
-            const distanceToEnemy = math.distance(unit, closestEnemy);
-            // Find a point directly towards the enemy that is closer but only just enough to be in attacking range
-            const closerUntilInRangePoint = add(unit, math.similarTriangles(closestEnemy.x - unit.x, closestEnemy.y - unit.y, distanceToEnemy, distanceToEnemy + config.COLLISION_MESH_RADIUS - unit.attackRange));
-            await Unit.moveTowards(unit, closerUntilInRangePoint, underworld);
-        }
+    if (moveChoice.pos && !underworld.hasLineOfSight(unit, closestEnemy)) {
+      // TODO: archer movement issue: sometimes moveChoice.pos is through a wall
+      // findPath is just returning one point, it fails to find a path. Oh it's because it's
+      // trying to path to a point on a wall, not in walkable space
+      if (underworld.hasLineOfSight(unit, moveChoice.pos)) {
+        // Generally if an archer doesn't have line of sight on the enemy,
+        // it will use findLOSLocation to check in an arc around the enemy for a point where there
+        // is line of sight.  If the point on that arc is within LOS of the archer, move to that point
+        // if not..
+        await Unit.moveTowards(unit, moveChoice.pos, underworld);
+      } else {
+        // ...then just move towards the enemy.  This prevents weird behavior where
+        // the archer tries to path toward a point ON a wall (which is technically inaccessible),
+        // and the archer will just walk forward awkardly until it hits a wall instead of pathing
+        // towards the enemy
+        await Unit.moveTowards(unit, closestEnemy, underworld);
+      }
+    } else {
+      // Move closer until in range (or out of stamina)
+      const distanceToEnemy = math.distance(unit, closestEnemy);
+      // Find a point directly towards the enemy that is closer but only just enough to be in attacking range
+      const closerUntilInRangePoint = add(unit, math.similarTriangles(closestEnemy.x - unit.x, closestEnemy.y - unit.y, distanceToEnemy, distanceToEnemy + config.COLLISION_MESH_RADIUS - unit.attackRange));
+      await Unit.moveTowards(unit, closerUntilInRangePoint, underworld);
     }
+  }
 
 }

--- a/src/entity/units/ancient.ts
+++ b/src/entity/units/ancient.ts
@@ -66,7 +66,7 @@ const unit: UnitSource = {
     }
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
-    return Unit.livingUnitsInDifferentFaction(unit, underworld)
+    return Unit.livingUnitsInDifferentFaction(unit, underworld.units)
       .filter(u => Unit.inRange(unit, u))
       .sort(math.sortCosestTo(unit))
       .slice(0, numberOfTargets);

--- a/src/entity/units/bloodGolem.ts
+++ b/src/entity/units/bloodGolem.ts
@@ -63,7 +63,7 @@ const unit: UnitSource = {
     })
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
-    const closestUnit = Unit.findClosestUnitInDifferentFaction(unit, underworld);
+    const closestUnit = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
     if (closestUnit) {
       return [closestUnit];
     } else {

--- a/src/entity/units/darkPriest.ts
+++ b/src/entity/units/darkPriest.ts
@@ -86,7 +86,7 @@ const unit: UnitSource = {
     }
     if (!didAction) {
       // Move to closest enemy
-      const closestEnemy = Unit.findClosestUnitInDifferentFaction(unit, underworld);
+      const closestEnemy = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
       if (closestEnemy) {
         const distanceToEnemy = math.distance(unit, closestEnemy);
         // The following is a hacky way to make them not move too close to the enemy
@@ -96,7 +96,7 @@ const unit: UnitSource = {
     }
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
-    return Unit.livingUnitsInDifferentFaction(unit, underworld)
+    return Unit.livingUnitsInDifferentFaction(unit, underworld.units)
       .filter(u => Unit.inRange(unit, u))
       .sort(math.sortCosestTo(unit))
       .slice(0, NUMBER_OF_GEYSERS);

--- a/src/entity/units/deathmason.ts
+++ b/src/entity/units/deathmason.ts
@@ -120,7 +120,7 @@ const deathmason: UnitSource = {
           unit.mana -= sacrificeCost.manaCost;
           // Consume allies if hurt
           // Note: Do not allow Deathmason to siphon allied player units
-          const closestUnit = Unit.livingUnitsInSameFaction(unit, underworld).filter(u => u.unitType !== UnitType.PLAYER_CONTROLLED && u.unitSourceId !== bossmasonUnitId && Unit.inRange(unit, u))[0]
+          const closestUnit = Unit.livingUnitsInSameFaction(unit, underworld.units).filter(u => u.unitType !== UnitType.PLAYER_CONTROLLED && u.unitSourceId !== bossmasonUnitId && Unit.inRange(unit, u))[0]
           if (closestUnit) {
             const keyMoment = () => underworld.castCards({
               casterCardUsage: {},

--- a/src/entity/units/glop.ts
+++ b/src/entity/units/glop.ts
@@ -79,7 +79,7 @@ const unit: UnitSource = {
     }
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
-    const closestUnit = Unit.findClosestUnitInDifferentFaction(unit, underworld);
+    const closestUnit = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
     if (closestUnit) {
       return [closestUnit];
     } else {

--- a/src/entity/units/golem.ts
+++ b/src/entity/units/golem.ts
@@ -44,7 +44,7 @@ const unit: UnitSource = {
     })
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
-    const closestUnit = Unit.findClosestUnitInDifferentFaction(unit, underworld);
+    const closestUnit = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
     if (closestUnit) {
       return [closestUnit];
     } else {

--- a/src/entity/units/greenGlop.ts
+++ b/src/entity/units/greenGlop.ts
@@ -102,7 +102,7 @@ const unit: UnitSource = {
       });
     } else {
       // Movement:
-      const closestEnemy = Unit.findClosestUnitInDifferentFaction(unit, underworld);
+      const closestEnemy = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
       if (closestEnemy) {
         const distanceToEnemy = math.distance(unit, closestEnemy);
         // The following is a hacky way to make them not move too close to the enemy
@@ -112,7 +112,7 @@ const unit: UnitSource = {
     }
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
-    return Unit.livingUnitsInDifferentFaction(unit, underworld)
+    return Unit.livingUnitsInDifferentFaction(unit, underworld.units)
       .filter(u => Unit.inRange(unit, u))
       .sort(math.sortCosestTo(unit))
       .slice(0, numberOfTargets);

--- a/src/entity/units/manaVampire.ts
+++ b/src/entity/units/manaVampire.ts
@@ -71,7 +71,7 @@ const unit: UnitSource = {
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
     // Maybe the mana vampire should prioritize units with more mana?
-    const closestUnit = Unit.findClosestUnitInDifferentFaction(unit, underworld);
+    const closestUnit = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
     if (closestUnit) {
       return [closestUnit];
     } else {

--- a/src/entity/units/playerUnit.ts
+++ b/src/entity/units/playerUnit.ts
@@ -32,7 +32,7 @@ const playerUnit: UnitSource = {
       await Unit.playComboAnimation(unit, 'playerAttackSmall', keyMoment, { animationSpeed: 0.2, loop: false });
     }
     // Movement:
-    const closestEnemy = Unit.findClosestUnitInDifferentFaction(unit, underworld);
+    const closestEnemy = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
     if (closestEnemy) {
       const distanceToEnemy = math.distance(unit, closestEnemy);
       // Trick to make the unit only move as far as will put them in range but no closer
@@ -42,7 +42,7 @@ const playerUnit: UnitSource = {
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
     if (unit.unitType == UnitType.AI) {
-      const closestUnit = Unit.findClosestUnitInDifferentFaction(unit, underworld);
+      const closestUnit = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
       if (closestUnit) {
         return [closestUnit];
       } else {

--- a/src/entity/units/poisoner.ts
+++ b/src/entity/units/poisoner.ts
@@ -79,7 +79,7 @@ const unit: UnitSource = {
     }
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
-    const closestUnit = Unit.findClosestUnitInDifferentFaction(unit, underworld);
+    const closestUnit = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
     if (closestUnit) {
       return [closestUnit];
     } else {

--- a/src/entity/units/vampire.ts
+++ b/src/entity/units/vampire.ts
@@ -81,7 +81,7 @@ const unit: UnitSource = {
     })
   },
   getUnitAttackTargets: (unit: Unit.IUnit, underworld: Underworld) => {
-    const closestUnit = Unit.findClosestUnitInDifferentFaction(unit, underworld);
+    const closestUnit = Unit.findClosestUnitInDifferentFactionSmartTarget(unit, underworld.units);
     if (closestUnit) {
       return [closestUnit];
     } else {


### PR DESCRIPTION
Closes #452

Separates handleLevelProgress() into smaller/more dedicated functions and moves wave spawning to endTurnFullCycle() alongside boss spawning. Reasoning: New waves shouldn't interrupt the progression of the game state like portal spawning or game over logic does, and should only really occur between turns.

Also improves logging and added a couple helper functions to get remaining units and players

Things to note:
- Wave counter now starts at 1 instead of 0
- Some console logs have been changed from .log to .debug, so they are only visible when needed / when verbose logging is selected. Broader progression logs are still shown as normal

QA - Singleplayer, Multiplayer, Loading, Waves, Deathmason level, combinations of on death/freeze/etc. killing last enemy and player at the same time

## TODO
Done