### PR TITLE
Deathmason On Death Event Fix

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -4226,6 +4226,7 @@ async function introduceBoss(unit: UnitSource, underworld: Underworld) {
     unit.unitProps,
     underworld
   );
+  newBossUnitInstance.originalLife = true;
   skyBeam(newBossUnitInstance);
   // Wait again for the players to digest that the boss appeared
   await new Promise((resolve) => {

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -1332,11 +1332,11 @@ export default class Underworld {
       console.error('Could not find pickup with index', index);
     }
   }
-  spawnEnemy(id: string, coords: Vec2, isMiniboss: boolean) {
+  spawnEnemy(id: string, coords: Vec2, isMiniboss: boolean): Unit.IUnit | undefined {
     const sourceUnit = allUnits[id];
     if (!sourceUnit) {
       console.error('Unit with id', id, 'does not exist.  Have you registered it in src/units/index.ts?');
-      return;
+      return undefined;
     }
     if (globalThis.enemyEncountered && !globalThis.enemyEncountered.includes(id)) {
       globalThis.enemyEncountered.push(id);
@@ -1355,10 +1355,10 @@ export default class Underworld {
       sourceUnit.info.image,
       UnitType.AI,
       sourceUnit.info.subtype,
-      { ...sourceUnit.unitProps, isMiniboss },
+      { ...sourceUnit.unitProps, isMiniboss, originalLife: true },
       this
     );
-    unit.originalLife = true;
+    return unit;
   }
   testLevelData(): LevelData {
     const baseTileValues = Object.values(baseTiles);
@@ -1969,13 +1969,6 @@ export default class Underworld {
     }
     for (let e of enemies) {
       this.spawnEnemy(e.id, e.coord, e.isMiniboss);
-    }
-
-    if (levelData.levelIndex == config.LAST_LEVEL_INDEX) {
-      const deathmason = this.units.find(u => u.unitSourceId == bossmasonUnitId);
-      if (deathmason) {
-        deathmason.onDeathEvents = [ORIGINAL_DEATHMASON_DEATH];
-      }
     }
 
     // Show text in center of screen for the new level
@@ -4205,6 +4198,8 @@ async function introduceBoss(unit: UnitSource, underworld: Underworld) {
       break;
     }
   }
+
+  // Play boss intro FX
   const elCinematic = document.getElementById('deathmason-cinematic');
   if (elCinematic) {
     elCinematic.classList.toggle('show', true);
@@ -4214,28 +4209,29 @@ async function introduceBoss(unit: UnitSource, underworld: Underworld) {
   await new Promise((resolve) => {
     setTimeout(resolve, 2000);
   });
-  const newBossUnitInstance = Unit.create(
-    unit.id,
-    // Start the unit at the summoners location
-    coords.x,
-    coords.y,
-    Faction.ENEMY,
-    unit.info.image,
-    UnitType.AI,
-    unit.info.subtype,
-    unit.unitProps,
-    underworld
-  );
-  newBossUnitInstance.originalLife = true;
-  skyBeam(newBossUnitInstance);
+
+  const newBossUnitInstance = underworld.spawnEnemy(unit.id, coords, false);
+  if (newBossUnitInstance) {
+    skyBeam(newBossUnitInstance);
+
+    // We add the Deathmason onDeathEvent here instead of in Deathmason's init()
+    // because we only want to add it in this special case/boss sequence
+    // and not any other time (I.E. admin/player summoned Deathmasons)
+    if (newBossUnitInstance.unitSourceId == bossmasonUnitId) {
+      newBossUnitInstance.onDeathEvents.push(ORIGINAL_DEATHMASON_DEATH);
+    }
+  } else {
+    console.error("Failed to spawn newBossUnitInstance for id: ", unit.id);
+  }
+
   // Wait again for the players to digest that the boss appeared
+  // Remove boss intro FX
   await new Promise((resolve) => {
     setTimeout(resolve, 500);
   });
   if (elCinematic) {
     elCinematic.classList.toggle('show', false);
   }
-
 }
 
 // Explicit list of biome types

--- a/src/entity/units/deathmason.ts
+++ b/src/entity/units/deathmason.ts
@@ -196,6 +196,7 @@ export const ORIGINAL_DEATHMASON_DEATH = 'ORIGINAL_DEATHMASON_DEATH';
 export function registerDeathmasonEvents() {
   registerEvents(ORIGINAL_DEATHMASON_DEATH, {
     onDeath: async (unit: Unit.IUnit, underworld: Underworld, prediction: boolean) => {
+      console.log("Deathmason onDeath() has been called");
       // For the bossmason level, if the original deathmason dies spawn 3 more:
       if (underworld.levelIndex === config.LAST_LEVEL_INDEX) {
         if (unit.unitSourceId == bossmasonUnitId && unit.originalLife && unit.name == undefined) {
@@ -215,6 +216,7 @@ export function registerDeathmasonEvents() {
               const seed = seedrandom(`${underworld.seed}-${underworld.turn_number}-${unit.id}`);
               const coords = findRandomGroundLocation(underworld, unit, seed);
               if (!coords) {
+                console.warn("Deathmason onDeath() spawning failed attempt: ", retryAttempts);
                 retryAttempts++;
                 i--;
                 continue;

--- a/src/entity/units/deathmason.ts
+++ b/src/entity/units/deathmason.ts
@@ -49,7 +49,6 @@ const deathmason: UnitSource = {
   },
   init: (unit: Unit.IUnit, underworld: Underworld) => {
     if (unit.image) {
-
       const adjustmentFilter = new AdjustmentFilter({
         saturation: 0.4,
         contrast: 5,


### PR DESCRIPTION
Closes #449

Ensures bosses spawned with introduceBoss use the normal spawnEnemy function and have originalLife = true
Moves the Deathmason onDeathEvent from the level gen logic to the introduceBoss logic, since it's no longer spawned during level gen.

QA: Singleplayer, Loading

Note: If a player loads a save in which the Deathmason has already spawned without the onDeathEvent, it will not be added.

## TODO
Done