### PR TITLE
Await Cleanup for ProgressGameState

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2487,7 +2487,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
     const firstPlayer = this.players[0];
     if (firstPlayer) {
-      this.changeToHotseatPlayer(firstPlayer)
+      await this.changeToHotseatPlayer(firstPlayer)
     }
     else {
       console.error('[GAME] Turn Phase\nFirst hotseat player does not exist');

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2540,10 +2540,10 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
 
     await Unit.endTurnForUnits(this.players.map(p => p.unit), this, false);
-    await this.endPlayerTurnCleanup();
+    this.endPlayerTurnCleanup();
     return true;
   }
-  async endPlayerTurnCleanup() {
+  endPlayerTurnCleanup() {
     console.log('[GAME] Turn Phase\nEnd player turn phase');
 
     for (let p of this.players) {
@@ -2821,7 +2821,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       player.endedTurn = true;
       console.log('[GAME] Turn Phase\nPlayer ended turn: ', player);
       this.syncTurnMessage();
-      this.progressGameState();
+      await this.progressGameState();
     } else {
       console.error('[GAME] Turn Phase\nturn_phase must be PlayerTurns to end turn. Cannot be ', this.turn_phase);
     }
@@ -3732,7 +3732,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
     stopAndDestroyForeverEmitter(castingParticleEmitter);
     if (!prediction) {
-      this.progressGameState();
+      await this.progressGameState();
     }
     return effectState;
   }

--- a/src/entity/__test__/faction.test.ts
+++ b/src/entity/__test__/faction.test.ts
@@ -1,6 +1,6 @@
-import { Faction } from "../../types/commonTypes.ts";
-import { getFactionsOf } from "../Player.ts";
-import { livingUnitsInSameFaction, livingUnitsInDifferentFaction } from "../Unit.ts";
+import { Faction } from "../../types/commonTypes";
+import { getFactionsOf } from "../Player";
+import { livingUnitsInSameFaction, livingUnitsInDifferentFaction } from "../Unit";
 
 describe('getFactionsOf', () => {
   it('should return an array of factions', () => {

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -757,7 +757,7 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       }
       Player.syncLobby(underworld);
       underworld.tryRestartTurnPhaseLoop();
-      underworld.progressGameState();
+      await underworld.progressGameState();
       underworld.assertDemoExit();
       break;
     }


### PR DESCRIPTION
Added await to the end of castCards, to endPlayerTurn before a syncLobby() call, and to the SpawnPlayer network message

QA - Singleplayer, Headless, Loading

## TODO
Please review that await changes make logical sense. Still getting used to async functions :)