### PR TITLE
Fixed Server Crash due to broken kill switch

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2365,8 +2365,9 @@ export default class Underworld {
       console.debug('[GAME] isGameOver?\nRemaining allies: ', remainingAllies);
     }
 
-    // Have allies made progress towards winning in the last X turns?
-    // If not, there might be a stalemate, so we need a kill switch.
+    // If players have not been able to act for X turns
+    // there may be a stalemate with ally and enemy NPC's
+    // so we need a kill switch to handle this scenario
     const useKillSwitch = this.allyNPCAttemptWinKillSwitch > 50;
     if (useKillSwitch) {
       console.log('[GAME] Game is Over\nKill Switch threshold reached');
@@ -2535,6 +2536,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     for (let player of connectedPlayers) {
       if (!this.hasCompletedTurn(player)) {
         // Log is handled in hasCompletedTurn()
+
+        // Any time the player is able to act
+        // we should reset the allyNPCAttemptWinKillSwitch
+        this.allyNPCAttemptWinKillSwitch = 0;
+
         return false;
       }
     }
@@ -2665,6 +2671,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
   async endFullTurnCycle() {
     // Increment the turn number now that it's starting over at the first phase
     this.turn_number++;
+    this.allyNPCAttemptWinKillSwitch++;
 
     // Clear cast this turn
     globalThis.castThisTurn = false;


### PR DESCRIPTION
Fixes the server crashing issue.

The ally NPC kill switch was not being incremented, which meant if all players were dead and the NPC units got into a stalemate, the server would run an infinite loop causing it to run out of memory.

This change will increment the kill switch every turn, and only reset it when the player has a chance to act.

## TODO
QA