### PR TITLE
Shatter and Radius Improvements

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3554,7 +3554,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       targetedPickups: [],
       castLocation,
       aggregator: {
-        radius: 0,
+        radiusBoost: 0,
       },
       initialTargetedUnitId,
       initialTargetedPickupId

--- a/src/cards/arrow_fork.ts
+++ b/src/cards/arrow_fork.ts
@@ -37,7 +37,7 @@ const spell: Spell = {
         for (let newAngle of [Math.PI / 12, -Math.PI / 12, 2 * Math.PI / 12, -2 * Math.PI / 12, 3 * Math.PI / 12, -3 * Math.PI / 12]) {
           const angle = getAngleBetweenVec2s(projectile.startPoint, unit) + newAngle;
           const castLocation = getEndpointOfMagnitudeAlongVector(unit, angle, 10_000);
-          arrowEffect(1, arrowCardId)({ cardIds: [regularArrow.card.id], shouldRefundLastSpell: false, casterPositionAtTimeOfCast: unit, targetedUnits: [], targetedPickups: [], casterUnit: unit, castLocation, aggregator: { radius: 0 }, initialTargetedPickupId: undefined, initialTargetedUnitId: undefined }, regularArrow.card, 1, underworld, prediction, false);
+          arrowEffect(1, arrowCardId)({ cardIds: [regularArrow.card.id], shouldRefundLastSpell: false, casterPositionAtTimeOfCast: unit, targetedUnits: [], targetedPickups: [], casterUnit: unit, castLocation, aggregator: { radiusBoost: 0 }, initialTargetedPickupId: undefined, initialTargetedUnitId: undefined }, regularArrow.card, 1, underworld, prediction, false);
         }
       }
     }

--- a/src/cards/bloat.ts
+++ b/src/cards/bloat.ts
@@ -38,7 +38,7 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity:
   if (!modifier.radius) {
     modifier.radius = 0;
   }
-  modifier.radius = extra && extra.radius || 0;
+  modifier.radius += extra && extra.radius || 0;
 
 }
 function remove(unit: IUnit, underworld: Underworld) {

--- a/src/cards/bone_shrapnel.ts
+++ b/src/cards/bone_shrapnel.ts
@@ -67,56 +67,59 @@ function makeShrapnelParticles(position: Vec2, size: number, prediction: boolean
     logNoTextureWarning('makeCorpseExplosion');
     return;
   }
-  const config =
-    particles.upgradeConfig({
-      autoUpdate: true,
-      "alpha": {
-        "start": 1,
-        "end": 0.5
-      },
-      "scale": {
-        "start": 0.5,
-        "end": 0.5,
-        "minimumScaleMultiplier": 1
-      },
-      "color": {
-        "start": "#707070",
-        "end": "#c2c2c2"
-      },
-      "speed": {
-        "start": 600,
-        "end": 600,
-        "minimumSpeedMultiplier": 1
-      },
-      "acceleration": {
-        "x": 0,
-        "y": 0
-      },
-      "maxSpeed": 0,
-      "startRotation": {
-        "min": 0,
-        "max": 360
-      },
-      "noRotation": false,
-      "rotationSpeed": {
-        "min": 50,
-        "max": 50
-      },
-      "lifetime": {
-        "min": 0.2 * size,
-        "max": 0.2 * size
-      },
-      "blendMode": "normal",
-      "frequency": 0.001,
-      "emitterLifetime": 0.1,
-      "maxParticles": 50,
-      "pos": {
-        "x": 0,
-        "y": 0
-      },
-      "addAtBack": true,
-      "spawnType": "point"
-    }, [texture]);
-  simpleEmitter(position, config);
+  const config = boneShrapnelParticleConfig;
+  config.lifetime.max *= size;
+  config.lifetime.min *= size;
+  simpleEmitter(position, particles.upgradeConfig(config, [texture]));
+}
+
+export const boneShrapnelParticleConfig = {
+  autoUpdate: true,
+  "alpha": {
+    "start": 1,
+    "end": 0.5
+  },
+  "scale": {
+    "start": 0.5,
+    "end": 0.5,
+    "minimumScaleMultiplier": 1
+  },
+  "color": {
+    "start": "#707070",
+    "end": "#c2c2c2"
+  },
+  "speed": {
+    "start": 600,
+    "end": 600,
+    "minimumSpeedMultiplier": 1
+  },
+  "acceleration": {
+    "x": 0,
+    "y": 0
+  },
+  "maxSpeed": 0,
+  "startRotation": {
+    "min": 0,
+    "max": 360
+  },
+  "noRotation": false,
+  "rotationSpeed": {
+    "min": 50,
+    "max": 50
+  },
+  "lifetime": {
+    "min": 0.2,
+    "max": 0.2
+  },
+  "blendMode": "normal",
+  "frequency": 0.001,
+  "emitterLifetime": 0.1,
+  "maxParticles": 50,
+  "pos": {
+    "x": 0,
+    "y": 0
+  },
+  "addAtBack": true,
+  "spawnType": "point"
 }
 export default spell;

--- a/src/cards/bone_shrapnel.ts
+++ b/src/cards/bone_shrapnel.ts
@@ -28,7 +28,8 @@ const spell: Spell = {
       // Only explode corpses at time of cast
       const targetedUnits = state.targetedUnits.filter(u => !u.alive);
       targetedUnits.forEach(unit => {
-        const adjustedRadius = baseRadius + (unit.modifiers[boneShrapnelCardId]?.radius || 0);
+        // +50% radius per radius boost
+        const adjustedRadius = baseRadius * (1 + (0.5 * state.aggregator.radiusBoost));
         if (prediction) {
           drawUICirclePrediction(unit, adjustedRadius, colors.healthRed, 'Explosion Radius');
         } else {

--- a/src/cards/bone_shrapnel.ts
+++ b/src/cards/bone_shrapnel.ts
@@ -67,59 +67,61 @@ function makeShrapnelParticles(position: Vec2, size: number, prediction: boolean
     logNoTextureWarning('makeCorpseExplosion');
     return;
   }
-  const config = boneShrapnelParticleConfig;
-  config.lifetime.max *= size;
-  config.lifetime.min *= size;
+  const config = {
+    autoUpdate: true,
+    "alpha": {
+      "start": 1,
+      "end": 0.5
+    },
+    "scale": {
+      "start": 0.5,
+      "end": 0.5,
+      "minimumScaleMultiplier": 1
+    },
+    "color": {
+      "start": "#707070",
+      "end": "#c2c2c2"
+    },
+    "speed": {
+      "start": 600,
+      "end": 600,
+      "minimumSpeedMultiplier": 1
+    },
+    "acceleration": {
+      "x": 0,
+      "y": 0
+    },
+    "maxSpeed": 0,
+    "startRotation": {
+      "min": 0,
+      "max": 360
+    },
+    "noRotation": false,
+    "rotationSpeed": {
+      "min": 50,
+      "max": 50
+    },
+    "lifetime": {
+      "min": 0.2,
+      "max": 0.2
+    },
+    "blendMode": "normal",
+    "frequency": 0.001,
+    "emitterLifetime": 0.1,
+    "maxParticles": 50,
+    "pos": {
+      "x": 0,
+      "y": 0
+    },
+    "addAtBack": true,
+    "spawnType": "point"
+  }
+  const scalar = Math.sqrt(size);
+  config.speed.start *= scalar;
+  config.speed.end *= scalar;
+  config.lifetime.min *= scalar;
+  config.lifetime.max *= scalar;
   simpleEmitter(position, particles.upgradeConfig(config, [texture]));
 }
 
-export const boneShrapnelParticleConfig = {
-  autoUpdate: true,
-  "alpha": {
-    "start": 1,
-    "end": 0.5
-  },
-  "scale": {
-    "start": 0.5,
-    "end": 0.5,
-    "minimumScaleMultiplier": 1
-  },
-  "color": {
-    "start": "#707070",
-    "end": "#c2c2c2"
-  },
-  "speed": {
-    "start": 600,
-    "end": 600,
-    "minimumSpeedMultiplier": 1
-  },
-  "acceleration": {
-    "x": 0,
-    "y": 0
-  },
-  "maxSpeed": 0,
-  "startRotation": {
-    "min": 0,
-    "max": 360
-  },
-  "noRotation": false,
-  "rotationSpeed": {
-    "min": 50,
-    "max": 50
-  },
-  "lifetime": {
-    "min": 0.2,
-    "max": 0.2
-  },
-  "blendMode": "normal",
-  "frequency": 0.001,
-  "emitterLifetime": 0.1,
-  "maxParticles": 50,
-  "pos": {
-    "x": 0,
-    "y": 0
-  },
-  "addAtBack": true,
-  "spawnType": "point"
-}
 export default spell;

--- a/src/cards/connect.ts
+++ b/src/cards/connect.ts
@@ -58,6 +58,9 @@ const spell: Spell = {
             }
           }
 
+          // Connect does not get extra radius from quantity,
+          // but can instead chain to more targets
+          // +25% range per radius boost
           const adjustedRadius = baseRadius * (1 + (0.25 * state.aggregator.radiusBoost))
 
           // Find all units touching the spell origin

--- a/src/cards/connect.ts
+++ b/src/cards/connect.ts
@@ -58,10 +58,12 @@ const spell: Spell = {
             }
           }
 
+          const adjustedRadius = baseRadius * (1 + (0.25 * state.aggregator.radiusBoost))
+
           // Find all units touching the spell origin
           const chained = await getConnectingEntities(
             target,
-            baseRadius + state.aggregator.radius,
+            adjustedRadius,
             limitTargetsLeft,
             targets,
             potentialTargets,

--- a/src/cards/contaminate.ts
+++ b/src/cards/contaminate.ts
@@ -49,8 +49,10 @@ interface CurseData {
 
 // separate function to handle synchronous recursion and animation - avoids long wait times
 async function contaminate(casterPlayer: IPlayer | undefined, unit: IUnit, quantity: number, radiusBoost: number, underworld: Underworld, prediction: boolean) {
-  const adjustedRadiusBoost = quantity - 1 + radiusBoost;
-  const adjustedRange = baseRange * (1 + (0.5 * adjustedRadiusBoost)) * (casterPlayer?.mageType == 'Witch' ? 1.5 : 1);
+  // Contaminate does not get extra radius from quantity,
+  // but can instead chain an additional time
+  // +25% range per radius boost
+  const adjustedRange = baseRange * (1 + (0.25 * radiusBoost)) * (casterPlayer?.mageType == 'Witch' ? 1.5 : 1);
 
   // the units to spread contaminate from
   // initally just this unit, then only the latest additions to the chain

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -54,6 +54,7 @@ import decoy from './summon_decoy';
 import summon_generic from './summon_generic';
 import explode from './bloat';
 import bone_shrapnel from './bone_shrapnel';
+import shatter from './shatter';
 import last_Will from './lastwill';
 import split from './split';
 import drown from './drown';
@@ -202,6 +203,7 @@ export function registerCards(overworld: Overworld) {
   registerSpell(drown, overworld);
   registerSpell(burst, overworld);
   registerSpell(bone_shrapnel, overworld);
+  registerSpell(shatter, overworld);
   registerSpell(arrow, overworld);
   registerSpell(arrow2, overworld);
   registerSpell(arrow3, overworld);

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -381,7 +381,7 @@ export interface EffectState {
   // aggregator carries extra information that can be passed
   // between card effects.
   aggregator: {
-    radius: number;
+    radiusBoost: number;
   };
   // initialTargetedUnitId and initialTargetedPickupId:
   // Used to ensure the castCards targets the right starting

--- a/src/cards/plus_radius.ts
+++ b/src/cards/plus_radius.ts
@@ -3,7 +3,7 @@ import { CardCategory, UnitSubType } from '../types/commonTypes';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 
 const id = 'Plus Radius';
-const radiusIncreaseAmount = 50;
+const radiusBoost = 1;
 const spell: Spell = {
   card: {
     id,
@@ -18,10 +18,10 @@ const spell: Spell = {
     description: 'spell_plus_radius',
     allowNonUnitTarget: true,
     effect: async (state, card, quantity, underworld, prediction, outOfRange) => {
-      const adjustedRadius = radiusIncreaseAmount * quantity;
-      state.aggregator.radius += adjustedRadius;
+      const adjustedRadiusBoost = radiusBoost * quantity;
+      state.aggregator.radiusBoost += adjustedRadiusBoost;
       state.targetedUnits.filter(u => u.unitSubType === UnitSubType.DOODAD).forEach(doodad => {
-        doodad.attackRange += adjustedRadius;
+        doodad.attackRange += adjustedRadiusBoost * 50;
       })
       return state;
     },

--- a/src/cards/potion_shatter.ts
+++ b/src/cards/potion_shatter.ts
@@ -11,7 +11,7 @@ import { makeParticleExplosion } from '../graphics/ParticleCollection';
 import { includes } from 'lodash';
 
 export const potionShatterId = 'Potion Shatter';
-const baseEffectRadius = 50; //baseExplosionRadius / x?
+const baseEffectRadius = 80; //baseExplosionRadius / x?
 const spell: Spell = {
   card: {
     id: potionShatterId,
@@ -32,7 +32,9 @@ const spell: Spell = {
         return state;
       }
 
-      const adjustedRadius = baseEffectRadius * quantity + state.aggregator.radius + COLLISION_MESH_RADIUS;
+      // +50% radius per radius boost
+      const adjustedRadiusBoost = quantity - 1 + state.aggregator.radiusBoost;
+      const adjustedRadius = baseEffectRadius * (1 + (0.5 * adjustedRadiusBoost));
       playDefaultSpellSFX(card, prediction);
       for (let potion of targets) {
         if (potion.flaggedForRemoval) continue;

--- a/src/cards/shatter.ts
+++ b/src/cards/shatter.ts
@@ -1,0 +1,128 @@
+import * as particles from '@pixi/particle-emitter'
+import * as Unit from '../entity/Unit';
+import { Spell, refundLastSpell } from './index';
+import { CardCategory } from '../types/commonTypes';
+import { createParticleTexture, logNoTextureWarning, simpleEmitter } from '../graphics/Particles';
+import { Vec2 } from '../jmath/Vec';
+import * as colors from '../graphics/ui/colors';
+import { CardRarity, probabilityMap } from '../types/commonTypes';
+import { freezeCardId } from './freeze';
+import { baseExplosionRadius, explode } from '../effects/explode';
+
+export const shatterCardId = 'Shatter';
+const damage = 40;
+const baseRadius = 100;
+
+const spell: Spell = {
+  card: {
+    id: shatterCardId,
+    requires: [freezeCardId],
+    category: CardCategory.Damage,
+    supportQuantity: true,
+    manaCost: 15,
+    healthCost: 0,
+    expenseScaling: 1,
+    probability: probabilityMap[CardRarity.UNCOMMON],
+    thumbnail: 'spellIconShatter.png',
+    description: `Shatters the ice surrounding a frozen unit, dealing ${damage} damage to it and all units nearby. Stackable to increase damage. Radius increases with freeze stacks.`,
+    effect: async (state, card, quantity, underworld, prediction) => {
+      // Only target frozen units
+      const targetedUnits = state.targetedUnits.filter(u => u.modifiers[freezeCardId]);
+      if (targetedUnits.length == 0) {
+        refundLastSpell(state, prediction, "Target a frozen unit!");
+        return state;
+      }
+
+      // We can't use a simple for-loop here, because one explosion may cause
+      // another unit to die and thus lose their freeze modifier before they shatter.
+      // Instead, we'll cache an array of locations and radii
+      // to create the explosions in a second for-loop
+      let explosions: { location: Vec2, radius: number }[] = [];
+      for (let unit of targetedUnits) {
+        const freezeMod = unit.modifiers[freezeCardId];
+        if (freezeMod) {
+          // Radius is +50% larger per stack of freeze removed
+          const adjustedRadius = baseRadius * (1 + (0.5 * (freezeMod?.quantity - 1))) + state.aggregator.radius;
+          explosions.push({ location: unit, radius: adjustedRadius });
+          Unit.removeModifier(unit, freezeCardId, underworld);
+        }
+      }
+      for (let { location, radius } of explosions) {
+        explode(location, radius, damage * quantity, 0,
+          underworld, prediction,
+          0x002c6e, 0x59deff);
+        makeShatterParticles(location, radius / baseRadius, prediction);
+      }
+      return state;
+    },
+  },
+  modifiers: {
+  },
+  events: {
+  }
+};
+
+// Copied from bone_shrapnel.ts
+function makeShatterParticles(position: Vec2, size: number, prediction: boolean) {
+  if (prediction || globalThis.headless) {
+    // Don't show if just a prediction
+    return;
+  }
+  const texture = createParticleTexture();
+  if (!texture) {
+    logNoTextureWarning('makeCorpseExplosion');
+    return;
+  }
+  const config =
+    particles.upgradeConfig({
+      autoUpdate: true,
+      "alpha": {
+        "start": 1,
+        "end": 0.5
+      },
+      "scale": {
+        "start": 0.5,
+        "end": 0.5,
+        "minimumScaleMultiplier": 1
+      },
+      "color": {
+        "start": "#707070",
+        "end": "#c2c2c2"
+      },
+      "speed": {
+        "start": 600,
+        "end": 600,
+        "minimumSpeedMultiplier": 1
+      },
+      "acceleration": {
+        "x": 0,
+        "y": 0
+      },
+      "maxSpeed": 0,
+      "startRotation": {
+        "min": 0,
+        "max": 360
+      },
+      "noRotation": false,
+      "rotationSpeed": {
+        "min": 50,
+        "max": 50
+      },
+      "lifetime": {
+        "min": 0.2 * size,
+        "max": 0.2 * size
+      },
+      "blendMode": "normal",
+      "frequency": 0.001,
+      "emitterLifetime": 0.1,
+      "maxParticles": 50,
+      "pos": {
+        "x": 0,
+        "y": 0
+      },
+      "addAtBack": true,
+      "spawnType": "point"
+    }, [texture]);
+  simpleEmitter(position, config);
+}
+export default spell;

--- a/src/cards/shatter.ts
+++ b/src/cards/shatter.ts
@@ -41,8 +41,9 @@ const spell: Spell = {
       for (let unit of targetedUnits) {
         const freezeMod = unit.modifiers[freezeCardId];
         if (freezeMod) {
-          // Radius is +50% larger per stack of freeze removed
-          const adjustedRadius = baseRadius * (1 + (0.5 * (freezeMod?.quantity - 1))) + state.aggregator.radius;
+          // +50% radius per radius boost
+          const adjustedRadiusBoost = freezeMod.quantity - 1 + state.aggregator.radiusBoost;
+          const adjustedRadius = baseRadius * (1 + (0.5 * adjustedRadiusBoost));
           explosions.push({ location: unit, radius: adjustedRadius });
           Unit.removeModifier(unit, freezeCardId, underworld);
         }

--- a/src/cards/shatter.ts
+++ b/src/cards/shatter.ts
@@ -8,7 +8,6 @@ import * as colors from '../graphics/ui/colors';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { freezeCardId } from './freeze';
 import { baseExplosionRadius, explode } from '../effects/explode';
-import { boneShrapnelParticleConfig } from './bone_shrapnel';
 
 export const shatterCardId = 'Shatter';
 const damage = 40;
@@ -71,79 +70,70 @@ function makeShatterParticles(position: Vec2, size: number, prediction: boolean)
     return;
   }
 
-  //
-  const textureBoneShrapnel = createParticleTexture();
-  if (!textureBoneShrapnel) {
-    logNoTextureWarning('makeCorpseExplosion');
-    return;
-  }
-  const configBoneShrapnel = boneShrapnelParticleConfig;
-  configBoneShrapnel.lifetime.max *= size;
-  configBoneShrapnel.lifetime.min *= size;
-  simpleEmitter(position, particles.upgradeConfig(configBoneShrapnel, [textureBoneShrapnel]));
-
-  const textureIceExplosion = createParticleTexture();
-  if (!textureIceExplosion) {
+  const texture = createParticleTexture();
+  if (!texture) {
     logNoTextureWarning('makeIceExplosion');
     return;
   }
-  const configIceExplosion = iceExplosionConfig;
-  configIceExplosion.lifetime.max *= size;
-  configIceExplosion.lifetime.min *= size;
-  simpleEmitter(position, particles.upgradeConfig(configIceExplosion, [textureIceExplosion]));
-}
 
-const iceExplosionConfig = {
-  autoUpdate: true,
-  "alpha": {
-    "start": 1,
-    "end": 0
-  },
-  "scale": {
-    "start": 2,
-    "end": 1,
-  },
-  "color": {
-    "start": colors.convertToHashColor(0x002c6e),
-    "end": colors.convertToHashColor(0x59deff)
-  },
-  "speed": {
-    "start": 500,
-    "end": 50,
-    "minimumSpeedMultiplier": 1
-  },
-  "acceleration": {
-    "x": 0,
-    "y": 0
-  },
-  "maxSpeed": 0,
-  "startRotation": {
-    "min": 0,
-    "max": 360
-  },
-  "noRotation": false,
-  "rotationSpeed": {
-    "min": 0,
-    "max": 300
-  },
-  "lifetime": {
-    "min": 0.5,
-    "max": 0.5
-  },
-  "blendMode": "normal",
-  "frequency": 0.0001,
-  "emitterLifetime": 0.1,
-  "maxParticles": 300,
-  "pos": {
-    "x": 0,
-    "y": 0
-  },
-  "addAtBack": true,
-  "spawnType": "circle",
-  "spawnCircle": {
-    "x": 0,
-    "y": 0,
-    "r": 0
-  }
+  const config = {
+    "alpha": {
+      "start": 0.8,
+      "end": 0.8
+    },
+    "scale": {
+      "start": 1,
+      "end": 0.5,
+      "minimumScaleMultiplier": 0.4
+    },
+    "color": {
+      "start": "#a1e3f7",
+      "end": "#a1e3f7"
+    },
+    "speed": {
+      "start": 300,
+      "end": 300,
+      "minimumSpeedMultiplier": 0.8
+    },
+    "acceleration": {
+      "x": 0,
+      "y": 0
+    },
+    "maxSpeed": 0,
+    "startRotation": {
+      "min": 0,
+      "max": 360
+    },
+    "noRotation": false,
+    "rotationSpeed": {
+      "min": 0,
+      "max": 0
+    },
+    "lifetime": {
+      "min": 0.4,
+      "max": 0.4
+    },
+    "blendMode": "normal",
+    "frequency": 0.003,
+    "emitterLifetime": 0.1,
+    "maxParticles": 500,
+    "pos": {
+      "x": 0,
+      "y": 0
+    },
+    "addAtBack": false,
+    "spawnType": "circle",
+    "spawnCircle": {
+      "x": 0,
+      "y": 0,
+      "r": 0
+    }
+  };
+  const scalar = Math.sqrt(size);
+  config.speed.start *= scalar;
+  config.speed.end *= scalar;
+  config.lifetime.min *= scalar;
+  config.lifetime.max *= scalar;
+  simpleEmitter(position, particles.upgradeConfig(config, [texture]));
 }
 export default spell;

--- a/src/cards/shatter.ts
+++ b/src/cards/shatter.ts
@@ -8,6 +8,7 @@ import * as colors from '../graphics/ui/colors';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { freezeCardId } from './freeze';
 import { baseExplosionRadius, explode } from '../effects/explode';
+import { boneShrapnelParticleConfig } from './bone_shrapnel';
 
 export const shatterCardId = 'Shatter';
 const damage = 40;
@@ -51,8 +52,7 @@ const spell: Spell = {
       }
       for (let { location, radius } of explosions) {
         explode(location, radius, damage * quantity, 0,
-          underworld, prediction,
-          0x002c6e, 0x59deff);
+          underworld, prediction);
         makeShatterParticles(location, radius / baseRadius, prediction);
       }
       return state;
@@ -70,61 +70,80 @@ function makeShatterParticles(position: Vec2, size: number, prediction: boolean)
     // Don't show if just a prediction
     return;
   }
-  const texture = createParticleTexture();
-  if (!texture) {
+
+  //
+  const textureBoneShrapnel = createParticleTexture();
+  if (!textureBoneShrapnel) {
     logNoTextureWarning('makeCorpseExplosion');
     return;
   }
-  const config =
-    particles.upgradeConfig({
-      autoUpdate: true,
-      "alpha": {
-        "start": 1,
-        "end": 0.5
-      },
-      "scale": {
-        "start": 0.5,
-        "end": 0.5,
-        "minimumScaleMultiplier": 1
-      },
-      "color": {
-        "start": "#707070",
-        "end": "#c2c2c2"
-      },
-      "speed": {
-        "start": 600,
-        "end": 600,
-        "minimumSpeedMultiplier": 1
-      },
-      "acceleration": {
-        "x": 0,
-        "y": 0
-      },
-      "maxSpeed": 0,
-      "startRotation": {
-        "min": 0,
-        "max": 360
-      },
-      "noRotation": false,
-      "rotationSpeed": {
-        "min": 50,
-        "max": 50
-      },
-      "lifetime": {
-        "min": 0.2 * size,
-        "max": 0.2 * size
-      },
-      "blendMode": "normal",
-      "frequency": 0.001,
-      "emitterLifetime": 0.1,
-      "maxParticles": 50,
-      "pos": {
-        "x": 0,
-        "y": 0
-      },
-      "addAtBack": true,
-      "spawnType": "point"
-    }, [texture]);
-  simpleEmitter(position, config);
+  const configBoneShrapnel = boneShrapnelParticleConfig;
+  configBoneShrapnel.lifetime.max *= size;
+  configBoneShrapnel.lifetime.min *= size;
+  simpleEmitter(position, particles.upgradeConfig(configBoneShrapnel, [textureBoneShrapnel]));
+
+  const textureIceExplosion = createParticleTexture();
+  if (!textureIceExplosion) {
+    logNoTextureWarning('makeIceExplosion');
+    return;
+  }
+  const configIceExplosion = iceExplosionConfig;
+  configIceExplosion.lifetime.max *= size;
+  configIceExplosion.lifetime.min *= size;
+  simpleEmitter(position, particles.upgradeConfig(configIceExplosion, [textureIceExplosion]));
+}
+
+const iceExplosionConfig = {
+  autoUpdate: true,
+  "alpha": {
+    "start": 1,
+    "end": 0
+  },
+  "scale": {
+    "start": 2,
+    "end": 1,
+  },
+  "color": {
+    "start": colors.convertToHashColor(0x002c6e),
+    "end": colors.convertToHashColor(0x59deff)
+  },
+  "speed": {
+    "start": 500,
+    "end": 50,
+    "minimumSpeedMultiplier": 1
+  },
+  "acceleration": {
+    "x": 0,
+    "y": 0
+  },
+  "maxSpeed": 0,
+  "startRotation": {
+    "min": 0,
+    "max": 360
+  },
+  "noRotation": false,
+  "rotationSpeed": {
+    "min": 0,
+    "max": 300
+  },
+  "lifetime": {
+    "min": 0.5,
+    "max": 0.5
+  },
+  "blendMode": "normal",
+  "frequency": 0.0001,
+  "emitterLifetime": 0.1,
+  "maxParticles": 300,
+  "pos": {
+    "x": 0,
+    "y": 0
+  },
+  "addAtBack": true,
+  "spawnType": "circle",
+  "spawnCircle": {
+    "x": 0,
+    "y": 0,
+    "r": 0
+  }
 }
 export default spell;

--- a/src/cards/shatter.ts
+++ b/src/cards/shatter.ts
@@ -41,6 +41,7 @@ const spell: Spell = {
       for (let unit of targetedUnits) {
         const freezeMod = unit.modifiers[freezeCardId];
         if (freezeMod) {
+          // Every additional stack of freeze counts towards radius boost
           // +50% radius per radius boost
           const adjustedRadiusBoost = freezeMod.quantity - 1 + state.aggregator.radiusBoost;
           const adjustedRadius = baseRadius * (1 + (0.5 * adjustedRadiusBoost));

--- a/src/cards/target_circle.ts
+++ b/src/cards/target_circle.ts
@@ -27,9 +27,10 @@ const spell: Spell = {
     description: 'spell_target_circle',
     allowNonUnitTarget: true,
     effect: async (state, card, quantity, underworld, prediction, outOfRange) => {
-      // +100% range per radius boost
-      const adjustedRadiusBoost = quantity - 1 + state.aggregator.radiusBoost;
-      const adjustedRange = baseRadius * (1 + (1 * adjustedRadiusBoost));
+      // Slightly different / unique formula for balance purposes:
+      // +100% range per quantity, +50% range per radius boost
+      const adjustedRange = baseRadius * (quantity + (0.5 * state.aggregator.radiusBoost));
+
       // Note: This loop must NOT be a for..of and it must cache the length because it
       // mutates state.targetedUnits as it iterates.  Otherwise it will continue to loop as it grows
       let targets: Vec2[] = getCurrentTargets(state);

--- a/src/cards/target_circle.ts
+++ b/src/cards/target_circle.ts
@@ -27,7 +27,9 @@ const spell: Spell = {
     description: 'spell_target_circle',
     allowNonUnitTarget: true,
     effect: async (state, card, quantity, underworld, prediction, outOfRange) => {
-      const adjustedRange = baseRadius * quantity + state.aggregator.radius / 2;
+      // +100% range per radius boost
+      const adjustedRadiusBoost = quantity - 1 + state.aggregator.radiusBoost;
+      const adjustedRange = baseRadius * (1 + (1 * adjustedRadiusBoost));
       // Note: This loop must NOT be a for..of and it must cache the length because it
       // mutates state.targetedUnits as it iterates.  Otherwise it will continue to loop as it grows
       let targets: Vec2[] = getCurrentTargets(state);

--- a/src/cards/target_column.ts
+++ b/src/cards/target_column.ts
@@ -31,8 +31,9 @@ const spell: Spell = {
     description: 'spell_target_column',
     allowNonUnitTarget: true,
     effect: async (state, card, quantity, underworld, prediction, outOfRange) => {
-      // Range increases linearly with each quantity
-      const depth = (range + state.aggregator.radius) * (0.5 + 0.5 * quantity);
+      // +50% depth per radius boost
+      const adjustedRadiusBoost = quantity - 1 + state.aggregator.radiusBoost;
+      const depth = range * (1 + (0.5 * adjustedRadiusBoost));
       // Width doubles up to 4 casts, capping at 8x multiplier: 1 > 2 > 4 > 8
       const width = baseWidth * Math.pow(2, Math.min(quantity, 4)) / 2;
 

--- a/src/cards/target_cone.ts
+++ b/src/cards/target_cone.ts
@@ -29,8 +29,9 @@ const spell: Spell = {
     description: 'spell_target_cone',
     allowNonUnitTarget: true,
     effect: async (state, card, quantity, underworld, prediction, outOfRange) => {
-      // Range increases linearly with each quantity
-      const adjustedRange = (range + state.aggregator.radius) * (0.75 + 0.25 * quantity);
+      // +25% range per radius boost
+      const adjustedRadiusBoost = quantity - 1 + state.aggregator.radiusBoost;
+      const adjustedRange = range * (1 + (0.25 * adjustedRadiusBoost));
       // Angle doubles up to 4 casts, capping at 360 degrees: 45 > 90 > 180 > full circle
       const adjustedAngle = coneAngle * Math.pow(2, Math.min(quantity, 4)) / 2;
 

--- a/src/effects/explode.ts
+++ b/src/effects/explode.ts
@@ -7,20 +7,26 @@ import { IUnit, takeDamage } from "../entity/Unit";
 import { forcePushAwayFrom } from "./force_move";
 
 export const baseExplosionRadius = 140
-export function explode(location: Vec2, radius: number, damage: number, pushDistance: number, underworld: Underworld, prediction: boolean, colorstart: number, colorEnd: number): IUnit[] {
+export function explode(location: Vec2, radius: number, damage: number, pushDistance: number, underworld: Underworld, prediction: boolean, colorstart?: number, colorEnd?: number, useDefaultSound: boolean = true): IUnit[] {
   if (prediction) {
     drawUICirclePrediction(location, radius, colors.healthRed, 'Explosion Radius');
   } else {
-    playSFXKey('bloatExplosion');
-    makeParticleExplosion(location, radius / baseExplosionRadius, colorstart, colorEnd, prediction);
+    if (useDefaultSound) {
+      playSFXKey('bloatExplosion');
+    }
+    if (colorstart && colorEnd) {
+      makeParticleExplosion(location, radius / baseExplosionRadius, colorstart, colorEnd, prediction);
+    }
   }
 
   const units = underworld.getUnitsWithinDistanceOfTarget(location, radius, prediction);
 
-  units.forEach(u => {
-    // Deal damage to units
-    takeDamage(u, damage, u, underworld, prediction);
-  });
+  if (damage != 0) {
+    units.forEach(u => {
+      // Deal damage to units
+      takeDamage(u, damage, u, underworld, prediction);
+    });
+  }
 
   if (pushDistance > 0) {
     units.forEach(u => {


### PR DESCRIPTION
Closes #476 
- Implemented a version of Shatter: Removes freeze from target unit to deal 40 damage to it and all surrounding units. Damage increased by quantity. Explosion radius increased by freeze stacks.

Closes #456 
- Plus Radius will now additively stack on separate applications of bloat.

Extra:
- Also improves `state.aggregator.radius` handling, allowing "Plus Radius" to have a variety of effects on different spells.
  - Instead of aggregating a flat radius increase, the aggregated radius boost is now more like a "counter", counting how many times the radius has been boosted, and this number can be used to situationally increase the radius of other spells (additively, multiplicatively, with percentages, stacked linearly with quantity or other variables, etc.)
  - Instead of Plus Radius adding+50 radius to all spells equally, it now adds one radius boost, which is interpreted differently by each spell. This ensures Plus Radius is useful with all "area" spells, instead of being mandatory on low range spells (potion shatter) and near useless on long range spells (target column)
  - This also allows for linear stacking with quantity where preferred, I.E. The radius of Shatter or Potion shatter will increase by some amount per quantity or plus radius, with each granting the same radius increase, making it more predictable

## TODO
- i18 Description?