### PR TITLE
Fixed Double Decoy Scaling

### DIFF
--- a/src/cards/summon_decoy.ts
+++ b/src/cards/summon_decoy.ts
@@ -62,12 +62,6 @@ const spell: Spell = {
           // Animate effect of unit spawning from the sky
           skyBeam(unit);
         }
-        if (unit.image) {
-          const quantityScaleModifier = 1 + 0.3 * (quantity - 1);
-          unit.image.sprite.scale.x = unit.image.sprite.scale.x * quantityScaleModifier;
-          unit.image.sprite.scale.y = unit.image.sprite.scale.y * quantityScaleModifier;
-        }
-
       } else {
         console.error(`Source unit ${unitId} is missing`);
       }


### PR DESCRIPTION
Closes #463 

Decoy sprite was being scaled multiple times: Once in Unit.Create() -> AdjustUnitDifficulty() using Strength, and another time in the Summon Decoy spell logic.

(This was fixed as part of PR #196, but never pulled. I may look through that old PR for other forgotten fixes soon 👍)