### PR TITLE
fix: Prevent SET_PHASE message from previous level...

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2969,6 +2969,11 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
 
       this.pie.sendData({
         type: MESSAGE_TYPES.SET_PHASE,
+        // Store the level index that this function was invoked on
+        // so that it can be sent along with the message so that if
+        // the level index changes, 
+        // the old SET_PHASE state won't overwrite the newer state
+        currentLevelIndex: this.levelIndex,
         phase: p,
         units: this.units.filter(u => !u.flaggedForRemoval).map(Unit.serialize),
         pickups: this.pickups.filter(p => !p.flaggedForRemoval).map(Pickup.serialize),

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -544,7 +544,7 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
     }
     case MESSAGE_TYPES.SET_PHASE: {
       console.log('sync: SET_PHASE; syncs units and players')
-      const { phase, units, players, pickups, lastUnitId, lastPickupId, RNGState } = payload as {
+      const { phase, units, players, pickups, lastUnitId, lastPickupId, RNGState, currentLevelIndex } = payload as {
         phase: turn_phase,
         // Sync data for players
         players?: Player.IPlayerSerialized[],
@@ -555,6 +555,11 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
         lastUnitId: number,
         lastPickupId: number,
         RNGState: SeedrandomState,
+        currentLevelIndex: number,
+      }
+      if (underworld.levelIndex !== currentLevelIndex) {
+        console.log('Discarding SET_PHASE message from old level')
+        return;
       }
       if (RNGState) {
         underworld.syncronizeRNG(RNGState);


### PR DESCRIPTION
...from overwriting new state.

There may be other places in the codebase where this happens but this is definitely the one that was causing the reported issues in #498.  Usually the queue handles this fine, but because the message didn't get sent until AFTER the create level fully executed it was getting by

Fixes: #498