### PR TITLE
fix: await endPlayerTurn

### DIFF
--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -857,7 +857,7 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
           fromPlayer.clientConnected = true;
           console.error('Unexpected: Player ended turn while not connected.');
         }
-        underworld.endPlayerTurn(fromPlayer);
+        await underworld.endPlayerTurn(fromPlayer);
       } else {
         console.error('Unable to end turn because caster is undefined');
       }


### PR DESCRIPTION
This is not in response to a bug, but I noticed that endPlayerTurn is async and not being awaited.
Based on a visual inspection this only effects hotseat

Tested in hotseat