### PR TITLE
Added progress... to pickups and die command

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3747,7 +3747,9 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     }
 
     stopAndDestroyForeverEmitter(castingParticleEmitter);
-    if (!prediction) {
+    if (!prediction && casterPlayer) {
+      // We should only progress the game state if the caster is a player.
+      // AI handles progress game state at the end of each entire NPC Turn.
       await this.progressGameState();
     }
     return effectState;

--- a/src/entity/Pickup.ts
+++ b/src/entity/Pickup.ts
@@ -365,6 +365,7 @@ export function triggerPickup(pickup: IPickup, unit: IUnit, player: Player.IPlay
     // Now that the players attributes may have changed, sync UI
     syncPlayerHealthManaUI(underworld);
   }
+  underworld.progressGameState();
 }
 export function tryTriggerPickup(pickup: IPickup, unit: IUnit, underworld: Underworld, prediction: boolean) {
   if (pickup.flaggedForRemoval) {

--- a/src/entity/Pickup.ts
+++ b/src/entity/Pickup.ts
@@ -365,7 +365,11 @@ export function triggerPickup(pickup: IPickup, unit: IUnit, player: Player.IPlay
     // Now that the players attributes may have changed, sync UI
     syncPlayerHealthManaUI(underworld);
   }
-  underworld.progressGameState();
+  // We exclude purple portals because they are not removed and
+  // Send many progress game state messages
+  if (pickup.name !== PORTAL_PURPLE_NAME) {
+    underworld.progressGameState();
+  }
 }
 export function tryTriggerPickup(pickup: IPickup, unit: IUnit, underworld: Underworld, prediction: boolean) {
   if (pickup.flaggedForRemoval) {

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -1181,6 +1181,7 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
         for (let unit of overworld.underworld.units.filter(u => u.faction == Faction.ENEMY)) {
           Unit.die(unit, overworld.underworld, false);
         }
+        overworld.underworld.progressGameState();
       },
       supportInMultiplayer: true,
       domQueryContainer: '#menu-global'
@@ -1413,10 +1414,10 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
         const unit = overworld.underworld.units.find(u => u.id == selectedUnitid);
         if (unit) {
           Unit.die(unit, overworld.underworld, false);
+          overworld.underworld.progressGameState();
         } else {
           centeredFloatingText('You must select a unit first', 'red');
         }
-
       },
       supportInMultiplayer: true,
       domQueryContainer: '#menu-selected-unit'


### PR DESCRIPTION
Closes #500 
Closes #501 

Additionally: Cast Cards will only progressGameState if the caster was a player, since the turn logic already handles progress game state at the end of the AI turns.

Tested in Singleplayer: "Die" and "Kill All" commands progress game state, dying to traps is handled, getting a pickup after all enemies have been deleted will spawn portals, priests and similar "cast cards" units no longer send progress game state