### PR TITLE
fix: Squiggly force move lines

### DIFF
--- a/src/effects/__test__/force_move.test.ts
+++ b/src/effects/__test__/force_move.test.ts
@@ -1,0 +1,25 @@
+import { ForceMove, ForceMoveType } from "../../jmath/moveWithCollision";
+import { sumForceMoves } from "../force_move";
+
+describe('forceMove', () => {
+    describe('sumForceMoves', () => {
+        it('Should sum the velocity', () => {
+            const pushedObject = { x: 0, y: 0, radius: 1, inLiquid: false, immovable: false, beingPushed: false };
+            const one: ForceMove = {
+                type: ForceMoveType.UNIT_OR_PICKUP,
+                pushedObject,
+                velocity: { x: 1, y: 0 }
+            }
+            const two: ForceMove = {
+                type: ForceMoveType.UNIT_OR_PICKUP,
+                pushedObject,
+                velocity: { x: 0, y: 1 }
+            }
+            sumForceMoves(one, two);
+            expect(one.velocity).toEqual({ x: 1, y: 1 });
+
+        })
+
+    })
+
+});

--- a/src/effects/force_move.ts
+++ b/src/effects/force_move.ts
@@ -1,8 +1,8 @@
 import { raceTimeout } from "../Promise";
 import Underworld from "../Underworld";
 import { HasSpace } from "../entity/Type";
-import { Vec2, multiply, normalized, subtract } from "../jmath/Vec";
-import { ForceMoveType, ForceMoveUnitOrPickup } from "../jmath/moveWithCollision";
+import { Vec2, multiply, normalized, subtract, add } from "../jmath/Vec";
+import { ForceMove, ForceMoveType, ForceMoveUnitOrPickup } from "../jmath/moveWithCollision";
 
 // TODO - Force moves need to be handled differently
 // such that they are consistent at different framerates and velocity falloffs
@@ -19,9 +19,6 @@ export async function forcePushDelta(pushedObject: HasSpace, deltaMovement: Vec2
 
   let forceMoveInst: ForceMoveUnitOrPickup;
   return await raceTimeout(2000, 'Push', new Promise<void>((resolve) => {
-    // Experiment: canCreateSecondOrderPushes now is ALWAYS disabled.
-    // I've had feedback that it's suprising - which is bad for a tactical game
-    // also I suspect it has significant performance costs for levels with many enemies
     forceMoveInst = { type: ForceMoveType.UNIT_OR_PICKUP, canCreateSecondOrderPushes: false, alreadyCollided: [], pushedObject, velocity, velocity_falloff, resolve }
     underworld.addForceMove(forceMoveInst, prediction);
   })).then(() => {
@@ -59,4 +56,9 @@ export async function forcePushToDestination(pushedObject: HasSpace, destination
 function movementToVelocity(deltaMovement: Vec2): Vec2 {
   let mult = (1 - velocity_falloff);
   return multiply(mult, deltaMovement);
+}
+// Adds the properties of a newForceMove onto a preexisting force move
+export function sumForceMoves(preExistingForceMove: ForceMove, newForceMove: ForceMove) {
+  preExistingForceMove.velocity = add(preExistingForceMove.velocity, newForceMove.velocity);
+
 }


### PR DESCRIPTION
when multiple forces were applied to the same object. Now forces get summed.

Also fix prediction and headless fully processing
forcemoves between units dying instead of letting all units die and then processing all the force moves (like the regular game client always has)