### PR TITLE
Fix Targeting Unspawned Players

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3632,7 +3632,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       if (effectState.initialTargetedUnitId !== undefined) {
         const initialTargetUnit = this.units.find(u => u.id === effectState.initialTargetedUnitId);
         if (initialTargetUnit) {
-          Cards.addTarget(initialTargetUnit, effectState);
+          Cards.addTarget(initialTargetUnit, effectState, this);
         } else {
           console.error('effectState.initialTargetedUnitId was defined but the unit was not found');
         }
@@ -3640,14 +3640,14 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
         const unitAtCastLocation = unitsAtCastLocation[0];
         if (unitAtCastLocation) {
           effectState.initialTargetedUnitId = unitAtCastLocation.id;
-          Cards.addTarget(unitAtCastLocation, effectState);
+          Cards.addTarget(unitAtCastLocation, effectState, this);
         }
       }
       // Get first pickup at cast location
       if (effectState.initialTargetedPickupId !== undefined) {
         const initialTargetPickup = this.pickups.find(p => p.id === effectState.initialTargetedPickupId);
         if (initialTargetPickup) {
-          Cards.addTarget(initialTargetPickup, effectState);
+          Cards.addTarget(initialTargetPickup, effectState, this);
         } else {
           console.error('effectState.initialTargetedPickupId was defined but the unit was not found');
         }
@@ -3655,7 +3655,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
         const pickupAtCastLocation = this.getPickupAt(castLocation, prediction);
         if (pickupAtCastLocation) {
           effectState.initialTargetedPickupId = pickupAtCastLocation.id;
-          Cards.addTarget(pickupAtCastLocation, effectState);
+          Cards.addTarget(pickupAtCastLocation, effectState, this);
         }
       }
     }

--- a/src/cards/clone.ts
+++ b/src/cards/clone.ts
@@ -74,7 +74,7 @@ const spell: Spell = {
                 // Clones don't provide experience when killed
                 clone.originalLife = false;
                 // Add clones to target list
-                addTarget(clone, state);
+                addTarget(clone, state, underworld);
               }
             }
             if (Pickup.isPickup(target)) {
@@ -88,7 +88,7 @@ const spell: Spell = {
                     Pickup.setPosition(clone, validSpawnCoords.x, validSpawnCoords.y);
                   }
                   // Add clones to target list
-                  addTarget(clone, state);
+                  addTarget(clone, state, underworld);
                 } else {
                   console.log('Pickup', target);
                   console.error('Could not clone pickup because source could not be found');

--- a/src/cards/connect.ts
+++ b/src/cards/connect.ts
@@ -88,7 +88,7 @@ const spell: Spell = {
             animationPromises.push(animationPromise);
           }
           // Update effectState targets
-          chained.forEach(u => addTarget(u.entity, state))
+          chained.forEach(u => addTarget(u.entity, state, underworld))
         }
       }
       await Promise.all(animationPromises).then(() => {

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -522,6 +522,7 @@ export function addTarget(target: any, effectState: EffectState, underworld: Und
   if (Unit.isUnit(target)) {
     if (underworld.players.filter(p => !p.isSpawned).map(p => p.unit).includes(target)) {
       // Do not allow targeting unspawned players
+      console.warn("Tried to add an unspawned player to the targets list: ", target);
       return;
     }
     addUnitTarget(target, effectState);

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -518,11 +518,10 @@ export function getCardsFromIds(cardIds: string[]): ICard[] {
   return _getCardsFromIds(cardIds, allCards);
 }
 
-export function addTarget(target: any, effectState: EffectState) {
+export function addTarget(target: any, effectState: EffectState, underworld: Underworld) {
   if (Unit.isUnit(target)) {
-    if (globalThis.player && globalThis.player.unit == target && !globalThis.player.isSpawned) {
-      // Do not allow targeting self when self isn't spawned
-      // (Note, this only needs to run locally because the positional change when choosing a spawn isn't networked)
+    if (underworld.players.filter(p => !p.isSpawned).map(p => p.unit).includes(target)) {
+      // Do not allow targeting unspawned players
       return;
     }
     addUnitTarget(target, effectState);

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -520,7 +520,7 @@ export function getCardsFromIds(cardIds: string[]): ICard[] {
 
 export function addTarget(target: any, effectState: EffectState, underworld: Underworld) {
   if (Unit.isUnit(target)) {
-    if (underworld.players.filter(p => !p.isSpawned).map(p => p.unit).includes(target)) {
+    if (underworld.players.filter(p => !p.isSpawned).map(p => p.unit.id).includes(target.id)) {
       // Do not allow targeting unspawned players
       console.warn("Tried to add an unspawned player to the targets list: ", target);
       return;

--- a/src/cards/recall.ts
+++ b/src/cards/recall.ts
@@ -61,7 +61,7 @@ const spell: Spell = {
               pickupSource,
               logSource: 'recall.ts'
             }, underworld, prediction);
-            addTarget(pickupInst, state);
+            addTarget(pickupInst, state, underworld);
           }
         }
       }

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -181,7 +181,7 @@ const spell: Spell = {
                 // Clones don't provide experience when killed
                 clone.originalLife = false;
                 // Add the clone as a target
-                addTarget(clone, state);
+                addTarget(clone, state, underworld);
 
                 // Add the curse to both the target and the clone
                 Unit.addModifier(target, id, underworld, prediction, quantity);

--- a/src/cards/target_all.ts
+++ b/src/cards/target_all.ts
@@ -68,7 +68,7 @@ const spell: Spell = {
           animators.push({ pos: target, newTargets: newTargets });
         }
         for (let newTarget of newTargets) {
-          addTarget(newTarget, state);
+          addTarget(newTarget, state, underworld);
         }
       }
 

--- a/src/cards/target_arrow.ts
+++ b/src/cards/target_arrow.ts
@@ -55,7 +55,7 @@ const spell: Spell = {
           if (prediction) {
             if (Unit.isUnit(firstTarget)) {
               addedNewTarget = true;
-              addTarget(firstTarget, state);
+              addTarget(firstTarget, state, underworld);
             }
           } else {
             promises.push(createVisualFlyingProjectile(
@@ -65,7 +65,7 @@ const spell: Spell = {
             ).then(() => {
               if (Unit.isUnit(firstTarget)) {
                 addedNewTarget = true;
-                addTarget(firstTarget, state);
+                addTarget(firstTarget, state, underworld);
                 // Animations do not occur on headless
                 if (!globalThis.headless) {
                   return new Promise<void>((resolve) => {

--- a/src/cards/target_circle.ts
+++ b/src/cards/target_circle.ts
@@ -60,7 +60,7 @@ const spell: Spell = {
         // Sort by distance to circle center
         withinRadius.sort(sortCosestTo(target));
         // Add entities to target
-        withinRadius.forEach(e => addTarget(e, state));
+        withinRadius.forEach(e => addTarget(e, state, underworld));
       }
       await animate(animateCircles, underworld);
 

--- a/src/cards/target_column.ts
+++ b/src/cards/target_column.ts
@@ -67,7 +67,7 @@ const spell: Spell = {
           distanceAlongColumn(a, target, vector)
           - distanceAlongColumn(b, target, vector));
         // Add entities to target
-        withinColumn.forEach(e => addTarget(e, state));
+        withinColumn.forEach(e => addTarget(e, state, underworld));
       }
       await animate(animateColumns, underworld);
 

--- a/src/cards/target_cone.ts
+++ b/src/cards/target_cone.ts
@@ -64,7 +64,7 @@ const spell: Spell = {
         // Sort by distance to cone start
         withinRadiusAndAngle.sort(sortCosestTo(target));
         // Add entities to target
-        withinRadiusAndAngle.forEach(e => addTarget(e, state));
+        withinRadiusAndAngle.forEach(e => addTarget(e, state, underworld));
       }
       await animate(animatedCones, underworld);
 

--- a/src/cards/target_injured.ts
+++ b/src/cards/target_injured.ts
@@ -42,7 +42,7 @@ const spell: Spell = {
 
       if (addedTargets.length) {
         for (const target of addedTargets) {
-          addTarget(target, state);
+          addTarget(target, state, underworld);
         }
         if (!prediction && !globalThis.headless) {
           playSFXKey('targeting');

--- a/src/cards/target_similar.ts
+++ b/src/cards/target_similar.ts
@@ -71,7 +71,7 @@ export function targetSimilarEffect(numberOfTargets: number) {
         animators.push({ pos: target, newTargets: newTargets });
       }
       for (let newTarget of newTargets) {
-        addTarget(newTarget, state);
+        addTarget(newTarget, state, underworld);
       }
     }
 

--- a/src/cards/target_similar.ts
+++ b/src/cards/target_similar.ts
@@ -50,8 +50,9 @@ export function targetSimilarEffect(numberOfTargets: number) {
         // @ts-ignore Find similar units by unitSourceId, find similar pickups by name
         .filter(t => {
           if (isUnit(target) && isUnit(t) && t.unitSourceId == target.unitSourceId) {
-            if (underworld.players.filter(p => !p.isSpawned).map(p => p.unit).includes(target)) {
+            if (underworld.players.filter(p => !p.isSpawned).map(p => p.unit.id).includes(t.id)) {
               // Do not allow targeting unspawned players
+              console.log("Filtered out unspawned player from target similar's potential targets");
               return false;
             }
             if (target.alive) {

--- a/src/cards/target_similar.ts
+++ b/src/cards/target_similar.ts
@@ -50,6 +50,10 @@ export function targetSimilarEffect(numberOfTargets: number) {
         // @ts-ignore Find similar units by unitSourceId, find similar pickups by name
         .filter(t => {
           if (isUnit(target) && isUnit(t) && t.unitSourceId == target.unitSourceId) {
+            if (underworld.players.filter(p => !p.isSpawned).map(p => p.unit).includes(target)) {
+              // Do not allow targeting unspawned players
+              return false;
+            }
             if (target.alive) {
               // Match living units of the same faction
               return t.alive && t.faction == target.faction;


### PR DESCRIPTION
closes #550 

Fixes a bug that allowed unspawned players to be targeted, which could cause a desync in the game over state. Adds further support for additional universal targeting catches by passing underworld as a parameter to the addTarget() function

QA Complete