### PR TITLE
Fix Level Regen

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -1932,6 +1932,7 @@ export default class Underworld {
     this.hasSpawnedBoss = false;
   }
   postSetupLevel() {
+    runPredictions(this); // Removes prediction overlay from last level
     document.body?.classList.toggle('loading', false);
     runCinematicLevelCamera(this).then(() => {
       console.log('Cinematic Cam: Finished');
@@ -2013,6 +2014,9 @@ export default class Underworld {
       for (let player of this.players) {
         const points = player.mageType == 'Spellmason' ? 4 : 3;
         player.statPointsUnspent += points;
+        console.log("Setup: Gave player: [" + player.clientId + "] " + points + " upgrade points for level index: " + levelIndex);
+        if (player.statPointsUnspent > 4) console.error("Setup: Player has more stat points than expected: ", player);
+
         // If the player hasn't completed first steps, autospend stat points on health
         // We don't want to cause information overload during tutorial
         if (!isTutorialFirstStepsComplete()) {
@@ -2073,8 +2077,7 @@ export default class Underworld {
       document.body?.classList.toggle('loading', true);
       // Add timeout so that loading can update dom
       setTimeout(() => {
-        this.createLevelSyncronous(levelData);
-        resolve();
+        resolve(this.createLevelSyncronous(levelData));
       }, 10);
     });
   }
@@ -2085,6 +2088,7 @@ export default class Underworld {
     do {
       // Invoke generateRandomLevel again until it succeeds
       level = this.generateRandomLevelData(levelIndex);
+      if (level == undefined) console.log("Undefined level. Regenerating");
     } while (level === undefined);
     this.pie.sendData({
       type: MESSAGE_TYPES.CREATE_LEVEL,

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -350,6 +350,7 @@ export function resetPlayerForNextLevel(player: IPlayer, underworld: Underworld)
   }
 
   Unit.resetUnitStats(player.unit, underworld);
+  Unit.syncPlayerHealthManaUI(underworld);
 }
 // Keep a global reference to the current client's player
 export function updateGlobalRefToPlayerIfCurrentClient(player: IPlayer) {


### PR DESCRIPTION
WIP #554 

Update: I was able to repro this by casting a few spells before going through the portal. Might work better with high delay spells like arrows, bleed, and debilitate. Require at least 1 spell queued up and not currently simulating. The repro is consistent under these conditions.

## TODO
- Identify source of bug
  - createLevelSyncronous() being called multiple times?
  - Does failed level generation queue/resolve multiple "create level" network messages
  - Is this because the last player entering the portal can trigger it several times, queueing up several network messages?