### PR TITLE
Fix Deathmason spawn on load

### DIFF
--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -1043,8 +1043,9 @@ async function handleLoadGameState(payload: {
   // Check it carefully before manually syncronizing properties
   await underworld.createLevel(level, underworld.gameMode);
 
-  // Unlike turn_number, hasSpawnedBoss is per-level, 
-  // so it has to go after createLevel() as to not be overwritten by cleanUpLevel()
+  // Unlike turn_number, these variables are tracked per-level, 
+  // they have to go after createLevel() as to not be overwritten by cleanUpLevel()
+  underworld.wave = loadedGameState.wave;
   underworld.hasSpawnedBoss = loadedGameState.hasSpawnedBoss;
 
   // Since level data has pickups stored in it and since those pickups' locations

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -1043,6 +1043,10 @@ async function handleLoadGameState(payload: {
   // Check it carefully before manually syncronizing properties
   await underworld.createLevel(level, underworld.gameMode);
 
+  // Unlike turn_number, hasSpawnedBoss is per-level, 
+  // so it has to go after createLevel() as to not be overwritten by cleanUpLevel()
+  underworld.hasSpawnedBoss = loadedGameState.hasSpawnedBoss;
+
   // Since level data has pickups stored in it and since those pickups' locations
   // for existance may have changed between when the level was created and when
   // the gamestate was saved, remove all pickups and spawn pickups from the pickups array


### PR DESCRIPTION
Closes #604 

Underworld wave counter and hasSpawned boss variables are now saved and loaded correctly.

[Reported by @Viz / vizoe](https://discord.com/channels/1032294536640200766/1227661345663488081/1227661345663488081) 