### PR TITLE
Plus Radius can now be cast on its own

### DIFF
--- a/src/cards/plus_radius.ts
+++ b/src/cards/plus_radius.ts
@@ -14,7 +14,6 @@ const spell: Spell = {
     expenseScaling: 1,
     probability: probabilityMap[CardRarity.UNCOMMON],
     thumbnail: 'spellIconPlusRadius.png',
-    requiresFollowingCard: true,
     description: 'spell_plus_radius',
     allowNonUnitTarget: true,
     effect: async (state, card, quantity, underworld, prediction, outOfRange) => {

--- a/src/cards/plus_radius.ts
+++ b/src/cards/plus_radius.ts
@@ -1,4 +1,4 @@
-import { Spell } from './index';
+import { Spell, refundLastSpell } from './index';
 import { CardCategory, UnitSubType } from '../types/commonTypes';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 
@@ -19,9 +19,15 @@ const spell: Spell = {
     effect: async (state, card, quantity, underworld, prediction, outOfRange) => {
       const adjustedRadiusBoost = radiusBoost * quantity;
       state.aggregator.radiusBoost += adjustedRadiusBoost;
-      state.targetedUnits.filter(u => u.unitSubType === UnitSubType.DOODAD).forEach(doodad => {
+      const urns = state.targetedUnits.filter(u => u.unitSubType === UnitSubType.DOODAD);
+      urns.forEach(doodad => {
         doodad.attackRange += adjustedRadiusBoost * 50;
       })
+
+      // Plus radius requires other cards unless used to target an urn
+      if (!(state.cardIds.some(c => c != id) || urns.length != 0)) {
+        refundLastSpell(state, prediction);
+      }
       return state;
     },
   },


### PR DESCRIPTION
closes #762 

Which lets players increase Urn Radius without needing another spell

## TODO
- Is there a clean way to improve refund logic? (I.E. should [Plus Radius + Slash] refund plus radius since it has no effect on the spell?)
- Done otherwise