### PR TITLE
Fix: Teleport pickup prediction

### DIFF
--- a/src/effects/teleport.ts
+++ b/src/effects/teleport.ts
@@ -24,7 +24,7 @@ export function teleport(object: HasSpace, newLocation: Vec2, underworld: Underw
 
   if (Unit.isUnit(object)) {
     // Moves the unit to location and resets path
-    Unit.setLocation(object, newLocation, underworld);
+    Unit.setLocation(object, newLocation, underworld, prediction);
     // Check to see if unit interacts with liquid
     Obstacle.tryFallInOutOfLiquid(object, underworld, prediction);
   } else if (Pickup.isPickup(object)) {

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -486,7 +486,7 @@ export function resetPlayerForSpawn(player: IPlayer, underworld: Underworld) {
   // the client queue will get stuck
   player.unit.resolveDoneMoving(true);
   // Move "portaled" unit out of the way to prevent collisions and chaining while portaled
-  Unit.setLocation(player.unit, { x: NaN, y: NaN }, underworld);
+  Unit.setLocation(player.unit, { x: NaN, y: NaN }, underworld, false);
   player.isSpawned = false;
   if (player == globalThis.player) {
     globalThis.awaitingSpawn = false;

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -1322,12 +1322,12 @@ export function moveTowards(unit: IUnit, point: Vec2, underworld: Underworld): P
 // setLocation, unlike moveTo, simply sets a unit to a coordinate without
 // considering in-game blockers or changing any unit flags
 // Note: NOT TO BE USED FOR in-game collision-based movement
-export function setLocation(unit: IUnit, coordinates: Vec2, underworld: Underworld) {
+export function setLocation(unit: IUnit, coordinates: Vec2, underworld: Underworld, prediction: boolean) {
   // Set state instantly to new position
   unit.x = coordinates.x;
   unit.y = coordinates.y;
   unit.path = undefined;
-  underworld.checkPickupCollisions(unit, false);
+  underworld.checkPickupCollisions(unit, prediction);
 }
 export function changeFaction(unit: IUnit, faction: Faction) {
   unit.faction = faction;

--- a/src/modifierSoulShardOwner.ts
+++ b/src/modifierSoulShardOwner.ts
@@ -58,7 +58,7 @@ export default function registerSoulShardOwner() {
           if (nearestShardBearer.unitType != UnitType.PLAYER_CONTROLLED) {
             Unit.cleanup(nearestShardBearer, true);
           }
-          Unit.setLocation(unit, nearestShardBearer, underworld);
+          Unit.setLocation(unit, nearestShardBearer, underworld, prediction);
           Unit.resurrect(unit, underworld);
         } else {
           console.error("Unit had shard owner event, but no shard bearers were left. This should not happen ", unit);

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -752,7 +752,7 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
             }
             cameraAutoFollow(true);
           }
-          Unit.setLocation(fromPlayer.unit, payload, underworld);
+          Unit.setLocation(fromPlayer.unit, payload, underworld, false);
           // Trigger 'everyLevel' attributePerks
           // now that the player has spawned in at the new level
           const perkRandomGenerator = seedrandom(getUniqueSeedString(underworld, fromPlayer));
@@ -797,7 +797,7 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
       // of the host matches exactly the player position on the player's client
       if (isHost(overworld.pie)) {
         if (fromPlayer && fromPlayer.unit && payload.position.x !== undefined && payload.position.y !== undefined) {
-          Unit.setLocation(fromPlayer.unit, payload.position, underworld);
+          Unit.setLocation(fromPlayer.unit, payload.position, underworld, false);
           fromPlayer.unit.stamina = payload.stamina;
         }
       }


### PR DESCRIPTION
closes #643 

Fixes an issue that cause displace, teleport, and similar "set location" spells to trigger real world pickups while in prediction mode

## TODO
- Done