### PR TITLE
Spell Damage / Functional Player Damage

### DIFF
--- a/src/cards/add_heal.ts
+++ b/src/cards/add_heal.ts
@@ -2,9 +2,10 @@ import { CardCategory } from '../types/commonTypes';
 import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { healSfx, healUnits } from '../effects/heal';
+import { GetSpellDamage } from '../entity/Unit';
 
 export const healCardId = 'heal';
-const healAmount = 30;
+const healMult = 1.5;
 
 const spell: Spell = {
   card: {
@@ -18,9 +19,9 @@ const spell: Spell = {
     probability: probabilityMap[CardRarity.COMMON],
     thumbnail: 'spellIconHeal.png',
     animationPath: 'spell-effects/potionPickup',
-    description: ['spell_heal', healAmount.toString()],
+    description: ['spell_heal', GetSpellDamage(undefined, healMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
-      await healUnits(state.targetedUnits, healAmount * quantity, state.casterUnit, underworld, prediction, state);
+      await healUnits(state.targetedUnits, GetSpellDamage(state.casterUnit.damage, healMult) * quantity, state.casterUnit, underworld, prediction, state);
       return state;
     },
   },

--- a/src/cards/arrow.ts
+++ b/src/cards/arrow.ts
@@ -52,7 +52,7 @@ const spell: Spell = {
     }
   }
 };
-export function arrowEffect(multiShotCount: number, collideFnKey: string, doesPierce: boolean = false) {
+export function arrowEffect(multiShotCount: number, collideFnKey: string, doesPierce: boolean = false, extraIgnoreUnitIds: number[] = []) {
   return async (state: EffectState, card: ICard, quantity: number, underworld: Underworld, prediction: boolean, outOfRange?: boolean) => {
     let targets: Vec2[] = state.targetedUnits;
     const path = findArrowPath(state.casterPositionAtTimeOfCast, state.castLocation, underworld)
@@ -91,6 +91,8 @@ export function arrowEffect(multiShotCount: number, collideFnKey: string, doesPi
             immovable: false,
             beingPushed: false
           }
+
+          const ignoreUnitIds = extraIgnoreUnitIds.concat(state.casterUnit.id);
           makeForceMoveProjectile({
             sourceUnit: state.casterUnit,
             pushedObject,
@@ -98,7 +100,7 @@ export function arrowEffect(multiShotCount: number, collideFnKey: string, doesPi
             endPoint: endPoint,
             speed: 1.5,
             doesPierce,
-            ignoreUnitIds: [state.casterUnit.id],
+            ignoreUnitIds,
             collideFnKey
           }, underworld, prediction);
 

--- a/src/cards/arrow.ts
+++ b/src/cards/arrow.ts
@@ -15,7 +15,7 @@ import { makeForceMoveProjectile, moveAlongVector, normalizedVector } from '../j
 import { addPixiSpriteAnimated, containerProjectiles } from '../graphics/PixiUtils';
 
 export const arrowCardId = 'Arrow';
-const damage = 10;
+const damageMult = 0.5;
 const spell: Spell = {
   card: {
     id: arrowCardId,
@@ -31,19 +31,23 @@ const spell: Spell = {
     ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
-    description: ['spell_arrow', damage.toString()],
+    description: ['spell_arrow', Unit.GetSpellDamage(undefined, damageMult).toString()],
     effect: arrowEffect(1, arrowCardId)
   },
   events: {
     onProjectileCollision: ({ unit, underworld, projectile, prediction }) => {
       if (unit) {
-        Unit.takeDamage({
-          unit: unit,
-          amount: damage,
-          sourceUnit: projectile.sourceUnit,
-          fromVec2: projectile.startPoint,
-          thinBloodLine: true,
-        }, underworld, prediction);
+        if (projectile.sourceUnit) {
+          Unit.takeDamage({
+            unit: unit,
+            amount: Unit.GetSpellDamage(projectile.sourceUnit.damage, damageMult),
+            sourceUnit: projectile.sourceUnit,
+            fromVec2: projectile.startPoint,
+            thinBloodLine: true,
+          }, underworld, prediction);
+        } else {
+          console.error("No source unit for projectile: ", projectile);
+        }
       }
     }
   }

--- a/src/cards/arrow2.ts
+++ b/src/cards/arrow2.ts
@@ -2,10 +2,10 @@ import { CardCategory } from '../types/commonTypes';
 import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { arrowCardId, arrowEffect } from './arrow';
-import { takeDamage } from '../entity/Unit';
+import { GetSpellDamage, takeDamage } from '../entity/Unit';
 
 export const arrow2CardId = 'Arrow 2';
-const damageDone = 20;
+const damageMult = 1;
 const spell: Spell = {
   card: {
     id: arrow2CardId,
@@ -22,19 +22,23 @@ const spell: Spell = {
     ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
-    description: ['spell_arrow', damageDone.toString()],
+    description: ['spell_arrow', GetSpellDamage(undefined, damageMult).toString()],
     effect: arrowEffect(1, arrow2CardId)
   },
   events: {
     onProjectileCollision: ({ unit, underworld, projectile, prediction }) => {
       if (unit) {
-        takeDamage({
-          unit: unit,
-          amount: damageDone,
-          sourceUnit: projectile.sourceUnit,
-          fromVec2: projectile.startPoint,
-          thinBloodLine: true,
-        }, underworld, prediction);
+        if (projectile.sourceUnit) {
+          takeDamage({
+            unit: unit,
+            amount: GetSpellDamage(projectile.sourceUnit.damage, damageMult),
+            sourceUnit: projectile.sourceUnit,
+            fromVec2: projectile.startPoint,
+            thinBloodLine: true,
+          }, underworld, prediction);
+        } else {
+          console.error("No source unit for projectile: ", projectile);
+        }
       }
     }
   }

--- a/src/cards/arrow3.ts
+++ b/src/cards/arrow3.ts
@@ -3,10 +3,10 @@ import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { arrowEffect } from './arrow';
 import { arrow2CardId } from './arrow2';
-import { takeDamage } from '../entity/Unit';
+import { GetSpellDamage, takeDamage } from '../entity/Unit';
 
 export const arrow3CardId = 'Arrow3';
-const damageDone = 30;
+const damageMult = 1.5;
 const spell: Spell = {
   card: {
     id: arrow3CardId,
@@ -23,19 +23,23 @@ const spell: Spell = {
     ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
-    description: ['spell_arrow', damageDone.toString()],
+    description: ['spell_arrow', GetSpellDamage(undefined, damageMult).toString()],
     effect: arrowEffect(1, arrow3CardId),
   },
   events: {
     onProjectileCollision: ({ unit, underworld, projectile, prediction }) => {
       if (unit) {
-        takeDamage({
-          unit: unit,
-          amount: damageDone,
-          sourceUnit: projectile.sourceUnit,
-          fromVec2: projectile.startPoint,
-          thinBloodLine: true,
-        }, underworld, prediction);
+        if (projectile.sourceUnit) {
+          takeDamage({
+            unit: unit,
+            amount: GetSpellDamage(projectile.sourceUnit.damage, damageMult),
+            sourceUnit: projectile.sourceUnit,
+            fromVec2: projectile.startPoint,
+            thinBloodLine: true,
+          }, underworld, prediction);
+        } else {
+          console.error("No source unit for projectile: ", projectile);
+        }
       }
     }
   }

--- a/src/cards/arrow_fork.ts
+++ b/src/cards/arrow_fork.ts
@@ -40,15 +40,15 @@ const spell: Spell = {
             fromVec2: projectile.startPoint,
             thinBloodLine: true,
           }, underworld, prediction);
+
+          // Now fork into regular arrows that fire in directions
+          for (let newAngle of [Math.PI / 12, -Math.PI / 12, 2 * Math.PI / 12, -2 * Math.PI / 12, 3 * Math.PI / 12, -3 * Math.PI / 12]) {
+            const angle = getAngleBetweenVec2s(projectile.startPoint, unit) + newAngle;
+            const castLocation = getEndpointOfMagnitudeAlongVector(unit, angle, 10_000);
+            arrowEffect(1, arrowCardId, false, [unit.id])({ cardIds: [regularArrow.card.id], shouldRefundLastSpell: false, casterPositionAtTimeOfCast: unit, targetedUnits: [], targetedPickups: [], casterUnit: projectile.sourceUnit, castLocation, aggregator: { radiusBoost: 0 }, initialTargetedPickupId: undefined, initialTargetedUnitId: undefined }, regularArrow.card, 1, underworld, prediction, false);
+          }
         } else {
           console.error("No source unit for projectile: ", projectile);
-        }
-
-        // Now fork into regular arrows that fire in directions
-        for (let newAngle of [Math.PI / 12, -Math.PI / 12, 2 * Math.PI / 12, -2 * Math.PI / 12, 3 * Math.PI / 12, -3 * Math.PI / 12]) {
-          const angle = getAngleBetweenVec2s(projectile.startPoint, unit) + newAngle;
-          const castLocation = getEndpointOfMagnitudeAlongVector(unit, angle, 10_000);
-          arrowEffect(1, arrowCardId)({ cardIds: [regularArrow.card.id], shouldRefundLastSpell: false, casterPositionAtTimeOfCast: unit, targetedUnits: [], targetedPickups: [], casterUnit: unit, castLocation, aggregator: { radiusBoost: 0 }, initialTargetedPickupId: undefined, initialTargetedUnitId: undefined }, regularArrow.card, 1, underworld, prediction, false);
         }
       }
     }

--- a/src/cards/arrow_fork.ts
+++ b/src/cards/arrow_fork.ts
@@ -9,7 +9,7 @@ import { raceTimeout } from '../Promise';
 import { arrowTripleCardId } from './arrow_triple';
 
 export const arrowForkCardId = 'Shatter Arrow';
-const damageDone = 30;
+const damageMult = 1.5;
 const spell: Spell = {
   card: {
     id: arrowForkCardId,
@@ -26,19 +26,23 @@ const spell: Spell = {
     ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
-    description: ['spell_arrow_fork', damageDone.toString()],
+    description: ['spell_arrow_fork', Unit.GetSpellDamage(undefined, damageMult).toString()],
     effect: arrowEffect(1, arrowForkCardId)
   },
   events: {
     onProjectileCollision: ({ unit, underworld, projectile, prediction }) => {
       if (unit) {
-        Unit.takeDamage({
-          unit: unit,
-          amount: damageDone,
-          sourceUnit: projectile.sourceUnit,
-          fromVec2: projectile.startPoint,
-          thinBloodLine: true,
-        }, underworld, prediction);
+        if (projectile.sourceUnit) {
+          Unit.takeDamage({
+            unit: unit,
+            amount: Unit.GetSpellDamage(projectile.sourceUnit.damage, damageMult),
+            sourceUnit: projectile.sourceUnit,
+            fromVec2: projectile.startPoint,
+            thinBloodLine: true,
+          }, underworld, prediction);
+        } else {
+          console.error("No source unit for projectile: ", projectile);
+        }
 
         // Now fork into regular arrows that fire in directions
         for (let newAngle of [Math.PI / 12, -Math.PI / 12, 2 * Math.PI / 12, -2 * Math.PI / 12, 3 * Math.PI / 12, -3 * Math.PI / 12]) {

--- a/src/cards/arrow_multi.ts
+++ b/src/cards/arrow_multi.ts
@@ -3,10 +3,10 @@ import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { arrowTripleCardId } from './arrow_triple';
 import { arrowEffect } from './arrow';
-import { takeDamage } from '../entity/Unit';
+import { GetSpellDamage, takeDamage } from '../entity/Unit';
 
 export const arrowMultiCardId = 'Multi Arrow';
-const damageDone = 10;
+const damageMult = 0.5;
 const arrowCount = 5;
 const spell: Spell = {
   card: {
@@ -24,19 +24,23 @@ const spell: Spell = {
     ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
-    description: ['spell_arrow_many', arrowCount.toString(), damageDone.toString()],
+    description: ['spell_arrow_many', arrowCount.toString(), GetSpellDamage(undefined, damageMult).toString()],
     effect: arrowEffect(arrowCount, arrowMultiCardId)
   },
   events: {
     onProjectileCollision: ({ unit, underworld, projectile, prediction }) => {
       if (unit) {
-        takeDamage({
-          unit: unit,
-          amount: damageDone,
-          sourceUnit: projectile.sourceUnit,
-          fromVec2: projectile.startPoint,
-          thinBloodLine: true,
-        }, underworld, prediction);
+        if (projectile.sourceUnit) {
+          takeDamage({
+            unit: unit,
+            amount: GetSpellDamage(projectile.sourceUnit.damage, damageMult),
+            sourceUnit: projectile.sourceUnit,
+            fromVec2: projectile.startPoint,
+            thinBloodLine: true,
+          }, underworld, prediction);
+        } else {
+          console.error("No source unit for projectile: ", projectile);
+        }
       }
     }
   }

--- a/src/cards/arrow_triple.ts
+++ b/src/cards/arrow_triple.ts
@@ -3,10 +3,10 @@ import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { arrowEffect } from './arrow';
 import { arrow2CardId } from './arrow2';
-import { takeDamage } from '../entity/Unit';
+import { GetSpellDamage, takeDamage } from '../entity/Unit';
 
 export const arrowTripleCardId = 'Triple Arrow';
-const damageDone = 10;
+const damageMult = 0.5;
 const arrowCount = 3;
 const spell: Spell = {
   card: {
@@ -24,19 +24,23 @@ const spell: Spell = {
     ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
-    description: ['spell_arrow_many', arrowCount.toString(), damageDone.toString()],
+    description: ['spell_arrow_many', arrowCount.toString(), GetSpellDamage(undefined, damageMult).toString()],
     effect: arrowEffect(arrowCount, arrowTripleCardId)
   },
   events: {
     onProjectileCollision: ({ unit, underworld, projectile, prediction }) => {
       if (unit) {
-        takeDamage({
-          unit: unit,
-          amount: damageDone,
-          sourceUnit: projectile.sourceUnit,
-          fromVec2: projectile.startPoint,
-          thinBloodLine: true,
-        }, underworld, prediction);
+        if (projectile.sourceUnit) {
+          takeDamage({
+            unit: unit,
+            amount: GetSpellDamage(projectile.sourceUnit.damage, damageMult),
+            sourceUnit: projectile.sourceUnit,
+            fromVec2: projectile.startPoint,
+            thinBloodLine: true,
+          }, underworld, prediction);
+        } else {
+          console.error("No source unit for projectile: ", projectile);
+        }
       }
     }
   }

--- a/src/cards/bloat.ts
+++ b/src/cards/bloat.ts
@@ -13,7 +13,7 @@ import { addScaleModifier, removeScaleModifier, setScaleFromModifiers } from '..
 
 const id = 'Bloat';
 const imageName = 'explode-on-death.png';
-const damage = 40;
+const damageMult = 2;
 function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity: number, extra?: any) {
   const modifier = getOrInitModifier(unit, id, {
     isCurse: true, quantity,
@@ -52,11 +52,11 @@ const spell: Spell = {
     expenseScaling: 1,
     probability: probabilityMap[CardRarity.COMMON],
     thumbnail: 'spellIconBloat.png',
-    description: ['spell_bloat', id, damage.toString(), id],
+    description: ['spell_bloat', id, Unit.GetSpellDamage(undefined, damageMult).toString(), id],
     effect: async (state, card, quantity, underworld, prediction) => {
       // .filter: only target living units
       for (let unit of state.targetedUnits.filter(u => u.alive)) {
-        Unit.addModifier(unit, id, underworld, prediction, quantity, { radiusBoost: state.aggregator.radiusBoost, sourceUnitId: state.casterUnit.id });
+        Unit.addModifier(unit, id, underworld, prediction, Unit.GetSpellDamage(state.casterUnit.damage, damageMult) * quantity, { radiusBoost: state.aggregator.radiusBoost, sourceUnitId: state.casterUnit.id });
       }
       return state;
     },
@@ -89,7 +89,7 @@ const spell: Spell = {
       const radiusBoost = modifier.radiusBoost;
       const sourceUnit = underworld.getUnitById(modifier.sourceUnitId, prediction);
       const adjustedRadius = getAdjustedRadius(radiusBoost);
-      explode(unit, adjustedRadius, damage * quantity, getAdjustedPushDist(radiusBoost),
+      explode(unit, adjustedRadius, quantity, getAdjustedPushDist(radiusBoost),
         sourceUnit,
         underworld, prediction,
         colors.bloatExplodeStart, colors.bloatExplodeEnd);

--- a/src/cards/blood_bath.ts
+++ b/src/cards/blood_bath.ts
@@ -6,7 +6,7 @@ import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { drownCardId } from './drown';
 
 export const bloodBathId = 'Blood Bath';
-const damageDone = 40;
+const damageMult = 2;
 const spell: Spell = {
   card: {
     id: bloodBathId,
@@ -21,7 +21,7 @@ const spell: Spell = {
     probability: probabilityMap[CardRarity.SPECIAL],
     thumbnail: 'spellIconDrown2.png',
     sfx: 'drown',
-    description: ['spell_blood_bath', damageDone.toString()],
+    description: ['spell_blood_bath', Unit.GetSpellDamage(undefined, damageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       // .filter: target all living units that are submerged
       const targets = (prediction ? underworld.unitsPrediction : underworld.units).filter(u => u.alive && u.inLiquid);
@@ -33,7 +33,7 @@ const spell: Spell = {
         for (let unit of targets) {
           Unit.takeDamage({
             unit: unit,
-            amount: damageDone * quantity,
+            amount: Unit.GetSpellDamage(state.casterUnit.damage, damageMult) * quantity,
             sourceUnit: state.casterUnit,
             fromVec2: state.casterUnit,
           }, underworld, prediction);

--- a/src/cards/bolt.ts
+++ b/src/cards/bolt.ts
@@ -10,7 +10,7 @@ import { playDefaultSpellSFX } from './cardUtils';
 import { raceTimeout } from '../Promise';
 
 const id = 'Bolt';
-const damage = 8;
+const damageMult = 0.4;
 const baseRadius = config.PLAYER_BASE_ATTACK_RANGE / 2;
 const spell: Spell = {
   card: {
@@ -24,7 +24,7 @@ const spell: Spell = {
     sfx: 'bolt',
     supportQuantity: true,
     requiresFollowingCard: false,
-    description: ['spell_bolt', damage.toString()],
+    description: ['spell_bolt', Unit.GetSpellDamage(undefined, damageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       // Bolt has functionally unlimited targets
       let limitTargetsLeft = 10_000;
@@ -82,7 +82,7 @@ const spell: Spell = {
         if (Unit.isUnit(u)) {
           Unit.takeDamage({
             unit: u,
-            amount: damage * quantity,
+            amount: Unit.GetSpellDamage(state.casterUnit.damage, damageMult) * quantity,
             sourceUnit: state.casterUnit,
           }, underworld, prediction);
         }

--- a/src/cards/bone_shrapnel.ts
+++ b/src/cards/bone_shrapnel.ts
@@ -10,7 +10,7 @@ import * as colors from '../graphics/ui/colors';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 
 export const boneShrapnelCardId = 'Bone Shrapnel';
-const damage = 30;
+const damageMult = 1.5;
 export const boneShrapnelRadius = 140;
 
 const spell: Spell = {
@@ -23,7 +23,7 @@ const spell: Spell = {
     expenseScaling: 1,
     probability: probabilityMap[CardRarity.COMMON],
     thumbnail: 'spellIconCorpseExplosion.png',
-    description: [`spell_bone_shrapnel`, damage.toString()],
+    description: [`spell_bone_shrapnel`, Unit.GetSpellDamage(undefined, damageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       // Only explode corpses at time of cast
       const targetedUnits = state.targetedUnits.filter(u => !u.alive);
@@ -49,7 +49,7 @@ const spell: Spell = {
           // Deal damage to units
           Unit.takeDamage({
             unit: u,
-            amount: damage * quantity,
+            amount: Unit.GetSpellDamage(state.casterUnit.damage, damageMult) * quantity,
             sourceUnit: state.casterUnit,
             fromVec2: unit,
           }, underworld, prediction);

--- a/src/cards/burst.ts
+++ b/src/cards/burst.ts
@@ -15,9 +15,9 @@ function calculateDamage(casterDamage: number, casterAttackRange: number, distan
   // Damage scales linearly with distance
   // - Collision Radius = Max Damage
   // - Max range = 0 damage
-  const damageRatio = (distance - config.COLLISION_MESH_RADIUS) / casterAttackRange;
+  const damageRatio = 1 - ((distance - config.COLLISION_MESH_RADIUS) / casterAttackRange);
   const maxDamage = Unit.GetSpellDamage(casterDamage, maxDamageMult);
-  return Math.ceil(maxDamage * damageRatio) * quantity;
+  return Math.ceil(lerp(0, maxDamage, damageRatio)) * quantity;
 }
 const spell: Spell = {
   card: {

--- a/src/cards/burst.ts
+++ b/src/cards/burst.ts
@@ -10,10 +10,14 @@ import { makeBurstParticles } from '../graphics/ParticleCollection';
 import { raceTimeout } from '../Promise';
 
 export const burstCardId = 'Burst';
-const maxDamage = 50;
-function calculateDamage(stack: number, caster: Vec2, casterAttackRange: number, target: Vec2): number {
-  const dist = distance(caster, target)
-  return Math.ceil(lerp(maxDamage, 0, (dist - config.COLLISION_MESH_RADIUS) / casterAttackRange) * stack);
+const maxDamageMult = 2.5;
+function calculateDamage(casterDamage: number, casterAttackRange: number, distance: number, quantity: number): number {
+  // Damage scales linearly with distance
+  // - Collision Radius = Max Damage
+  // - Max range = 0 damage
+  const damageRatio = (distance - config.COLLISION_MESH_RADIUS) / casterAttackRange;
+  const maxDamage = Unit.GetSpellDamage(casterDamage, maxDamageMult);
+  return Math.ceil(maxDamage * damageRatio) * quantity;
 }
 const spell: Spell = {
   card: {
@@ -27,7 +31,7 @@ const spell: Spell = {
     thumbnail: 'spellIconBurst.png',
     animationPath: '',
     sfx: 'burst',
-    description: ['spell_burst', maxDamage.toString()],
+    description: ['spell_burst', Unit.GetSpellDamage(undefined, maxDamageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       await raceTimeout(1000, 'Burst timeout', new Promise<void>((resolve) => {
         // .filter: only target living units
@@ -36,7 +40,8 @@ const spell: Spell = {
           if (targets.length) {
             playDefaultSpellSFX(card, prediction);
             for (let unit of targets) {
-              const damage = calculateDamage(quantity, state.casterUnit, state.casterUnit.attackRange, unit);
+              const dist = distance(state.casterUnit, unit);
+              const damage = calculateDamage(state.casterUnit.damage, state.casterUnit.attackRange, dist, quantity);
               if (damage > 0) {
                 Unit.takeDamage({
                   unit: unit,
@@ -45,7 +50,7 @@ const spell: Spell = {
                   fromVec2: state.casterUnit,
                 }, underworld, prediction);
                 // Animate:
-                makeBurstParticles(unit, lerp(0.1, 1, damage / maxDamage), prediction, resolve);
+                makeBurstParticles(unit, lerp(0.1, 1, dist / state.casterUnit.attackRange), prediction, resolve);
               }
             }
           } else {
@@ -55,7 +60,8 @@ const spell: Spell = {
           }
         } else {
           for (let unit of targets) {
-            const damage = calculateDamage(quantity, state.casterUnit, state.casterUnit.attackRange, unit);
+            const dist = distance(state.casterUnit, unit);
+            const damage = calculateDamage(state.casterUnit.damage, state.casterUnit.attackRange, dist, quantity);
             Unit.takeDamage({
               unit: unit,
               amount: damage,

--- a/src/cards/drown.ts
+++ b/src/cards/drown.ts
@@ -5,7 +5,7 @@ import * as Unit from '../entity/Unit';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 
 export const drownCardId = 'Drown';
-const damageDone = 40;
+const damageMult = 2;
 const spell: Spell = {
   card: {
     id: drownCardId,
@@ -17,7 +17,7 @@ const spell: Spell = {
     probability: probabilityMap[CardRarity.SPECIAL],
     thumbnail: 'spellIconDrown.png',
     sfx: 'drown',
-    description: ['spell_drown', damageDone.toString()],
+    description: ['spell_drown', Unit.GetSpellDamage(undefined, damageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       // .filter: only target living units that are submerged
       const targets = state.targetedUnits.filter(u => u.alive && u.inLiquid);
@@ -29,7 +29,7 @@ const spell: Spell = {
         for (let unit of targets) {
           Unit.takeDamage({
             unit: unit,
-            amount: damageDone * quantity,
+            amount: Unit.GetSpellDamage(undefined, damageMult) * quantity,
             sourceUnit: state.casterUnit,
             fromVec2: state.casterUnit,
           }, underworld, prediction);

--- a/src/cards/empower.ts
+++ b/src/cards/empower.ts
@@ -62,12 +62,7 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
     //no first time setup
   });
 
-  // Special balance case: Poisoner applies 1 stack of poison per damage
-  if (unit.unitSourceId == POISONER_ID) {
-    unit.damage += quantity;
-  } else {
-    unit.damage += statChange * quantity;
-  }
+  unit.damage += statChange * quantity;
 }
 
 function remove(unit: Unit.IUnit, underworld: Underworld) {
@@ -77,12 +72,7 @@ function remove(unit: Unit.IUnit, underworld: Underworld) {
     return
   }
 
-  // Special balance case: Poisoner applies 1 stack of poison per damage
-  if (unit.unitSourceId == POISONER_ID) {
-    unit.damage -= modifier.quantity;
-  } else {
-    unit.damage -= statChange * modifier.quantity;
-  }
+  unit.damage -= statChange * modifier.quantity;
 }
 
 export default spell;

--- a/src/cards/enfeeble.ts
+++ b/src/cards/enfeeble.ts
@@ -62,12 +62,7 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
     //no first time setup
   });
 
-  // Special balance case: Poisoner applies 1 stack of poison per damage
-  if (unit.unitSourceId == POISONER_ID) {
-    unit.damage -= quantity;
-  } else {
-    unit.damage -= statChange * quantity;
-  }
+  unit.damage -= statChange * quantity;
 }
 
 function remove(unit: Unit.IUnit, underworld: Underworld) {
@@ -77,12 +72,7 @@ function remove(unit: Unit.IUnit, underworld: Underworld) {
     return
   }
 
-  // Special balance case: Poisoner applies 1 stack of poison per damage
-  if (unit.unitSourceId == POISONER_ID) {
-    unit.damage += modifier.quantity;
-  } else {
-    unit.damage += statChange * modifier.quantity;
-  }
+  unit.damage += statChange * modifier.quantity;
 }
 
 export default spell;

--- a/src/cards/explosive_arrow.ts
+++ b/src/cards/explosive_arrow.ts
@@ -9,9 +9,9 @@ import { explode } from '../effects/explode';
 import { defaultPushDistance } from '../effects/force_move';
 
 export const explosiveArrowCardId = 'Explosive Arrow';
-const damageDone = 10;
+const arrowDamageMult = 0.5;
+const explodeDamageMult = 2;
 const explodeRange = 140;
-const explodeDamage = 40;
 const spell: Spell = {
   card: {
     id: explosiveArrowCardId,
@@ -28,23 +28,28 @@ const spell: Spell = {
     ignoreRange: true,
     animationPath: '',
     sfx: 'arrow',
-    description: ['spell_arrow_explosive', damageDone.toString(), explodeDamage.toString()],
+    description: ['spell_arrow_explosive', Unit.GetSpellDamage(undefined, arrowDamageMult).toString(), Unit.GetSpellDamage(undefined, explodeDamageMult).toString()],
     effect: arrowEffect(1, explosiveArrowCardId)
   },
   events: {
     onProjectileCollision: ({ unit, underworld, projectile, prediction }) => {
       if (unit) {
-        Unit.takeDamage({
-          unit: unit,
-          amount: damageDone,
-          sourceUnit: projectile.sourceUnit,
-          fromVec2: projectile.startPoint,
-          thinBloodLine: true,
-        }, underworld, prediction);
-        explode(unit, explodeRange, explodeDamage, defaultPushDistance,
-          projectile.sourceUnit,
-          underworld, prediction,
-          colors.bloatExplodeStart, colors.bloatExplodeEnd);
+        if (projectile.sourceUnit) {
+          Unit.takeDamage({
+            unit: unit,
+            amount: Unit.GetSpellDamage(projectile.sourceUnit.damage, arrowDamageMult),
+            sourceUnit: projectile.sourceUnit,
+            fromVec2: projectile.startPoint,
+            thinBloodLine: true,
+          }, underworld, prediction);
+
+          explode(unit, explodeRange, Unit.GetSpellDamage(projectile.sourceUnit.damage, explodeDamageMult), defaultPushDistance,
+            projectile.sourceUnit,
+            underworld, prediction,
+            colors.bloatExplodeStart, colors.bloatExplodeEnd);
+        } else {
+          console.error("No source unit for projectile: ", projectile);
+        }
       }
     }
   }

--- a/src/cards/heal_greater.ts
+++ b/src/cards/heal_greater.ts
@@ -9,7 +9,7 @@ import { healCardId } from './add_heal';
 import { healSfx, healUnits } from '../effects/heal';
 
 export const healGreaterId = 'Greater Heal';
-const healAmount = 80;
+const healMult = 4;
 
 const spell: Spell = {
   card: {
@@ -24,9 +24,9 @@ const spell: Spell = {
     probability: probabilityMap[CardRarity.UNCOMMON],
     thumbnail: 'spellIconHeal2.png',
     animationPath: 'spell-effects/potionPickup',
-    description: ['spell_heal', healAmount.toString()],
+    description: ['spell_heal', Unit.GetSpellDamage(undefined, healMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
-      await healUnits(state.targetedUnits, healAmount * quantity, state.casterUnit, underworld, prediction, state);
+      await healUnits(state.targetedUnits, Unit.GetSpellDamage(state.casterUnit.damage, healMult) * quantity, state.casterUnit, underworld, prediction, state);
       return state;
     },
   },

--- a/src/cards/heal_mass.ts
+++ b/src/cards/heal_mass.ts
@@ -9,7 +9,7 @@ import { healGreaterId } from './heal_greater';
 import { healSfx, healUnits } from '../effects/heal';
 
 export const heal_mass_id = 'Mass Heal';
-const healAmount = 10;
+const healMult = 0.5;
 
 const spell: Spell = {
   card: {
@@ -26,11 +26,11 @@ const spell: Spell = {
     probability: probabilityMap[CardRarity.FORBIDDEN],
     thumbnail: 'spellIconHeal3.png',
     animationPath: 'spell-effects/potionPickup',
-    description: ['spell_heal_mass', healAmount.toString()],
+    description: ['spell_heal_mass', Unit.GetSpellDamage(undefined, healMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       const units = (prediction ? underworld.unitsPrediction : underworld.units)
         .filter(u => u.alive && u.faction == state.casterUnit.faction);
-      await healUnits(units, healAmount * quantity, state.casterUnit, underworld, prediction, state);
+      await healUnits(units, Unit.GetSpellDamage(state.casterUnit.damage, healMult) * quantity, state.casterUnit, underworld, prediction, state);
       return state;
     },
   },

--- a/src/cards/heavy_slash.ts
+++ b/src/cards/heavy_slash.ts
@@ -2,9 +2,10 @@ import { CardCategory } from '../types/commonTypes';
 import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { slashCardId, slashEffect } from './slash';
+import { GetSpellDamage } from '../entity/Unit';
 
 export const heavyslashCardId = 'Heavy Slash';
-const damageDone = 40;
+const damageMult = 2;
 const slashScale = 2;
 const spell: Spell = {
   card: {
@@ -19,9 +20,9 @@ const spell: Spell = {
     thumbnail: 'spellIconHeavySlash.png',
     animationPath: 'spell-effects/spellHurtCuts',
     sfx: 'hurt2',
-    description: ['spell_slash', damageDone.toString()],
+    description: ['spell_slash', GetSpellDamage(undefined, damageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
-      return await slashEffect(state, card, quantity, underworld, prediction, damageDone, slashScale);
+      return await slashEffect(state, card, quantity, underworld, prediction, GetSpellDamage(state.casterUnit.damage, damageMult), slashScale);
     },
   },
 };

--- a/src/cards/mana_burn.ts
+++ b/src/cards/mana_burn.ts
@@ -6,7 +6,8 @@ import { Spell } from './index';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 
 export const manaBurnCardId = 'mana_burn';
-const mana_burnt = 30;
+// How much mana is burnt, based on player's spell damage
+const spellDamageMult = 1.5;
 const health_burn_ratio = 1;
 const spell: Spell = {
   card: {
@@ -19,7 +20,7 @@ const spell: Spell = {
     probability: probabilityMap[CardRarity.UNCOMMON],
     thumbnail: 'spellIconManaBurn.png',
     animationPath: 'spell-effects/spellManaBurn',
-    description: ['spell_mana_burn', mana_burnt.toString()],
+    description: ['spell_mana_burn', Unit.GetSpellDamage(undefined, spellDamageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       // .filter: only target living units
       const targets = state.targetedUnits.filter(u => u.alive && u.mana > 0);
@@ -33,7 +34,7 @@ const spell: Spell = {
       await animationPromise;
       // Take damage and remove mana AFTER the animation and sfx has finished
       for (let unit of targets) {
-        const unitManaBurnt = Math.min(unit.mana, mana_burnt);
+        const unitManaBurnt = Math.min(unit.mana, Unit.GetSpellDamage(state.casterUnit.damage, spellDamageMult));
         unit.mana -= unitManaBurnt;
         const damage = Math.ceil(unitManaBurnt * health_burn_ratio);
         Unit.takeDamage({

--- a/src/cards/mana_steal.ts
+++ b/src/cards/mana_steal.ts
@@ -7,8 +7,9 @@ import { manaBurnCardId } from './mana_burn';
 import { healManaUnit } from '../effects/heal';
 
 const id = 'Mana Steal';
-const base_mana_stolen = 60;
-const health_burn = 30;
+// How much total mana is stolen, per quantity
+const manaStolen = 60;
+const healthCost = 30;
 const spell: Spell = {
   card: {
     id,
@@ -17,18 +18,18 @@ const spell: Spell = {
     requires: [manaBurnCardId],
     supportQuantity: true,
     manaCost: 0,
-    healthCost: health_burn,
+    healthCost: healthCost,
     expenseScaling: 1,
     probability: probabilityMap[CardRarity.RARE],
     thumbnail: 'spellIconManaSteal.png',
-    description: ['spell_mana_steal', base_mana_stolen.toString()],
+    description: ['spell_mana_steal', manaStolen.toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       // .filter: only target living units
       const targets = state.targetedUnits.filter(u => u.alive && u.mana > 0);
       const caster = state.casterUnit;
       let promises = [];
       // Start with the amount we intend to steal, adjust after for loop
-      let totalManaStolen = base_mana_stolen * quantity;
+      let totalManaStolen = manaStolen * quantity;
       let remainingManaToSteal = totalManaStolen;
 
       // sort targets by current mana to carry remainder, in case you try to steal more mana than a unit has

--- a/src/cards/mega_slash.ts
+++ b/src/cards/mega_slash.ts
@@ -6,7 +6,7 @@ import { slashEffect } from './slash';
 import { heavyslashCardId } from './heavy_slash';
 
 export const megaSlashCardId = 'Mega Slash';
-const damageDone = 80;
+const damageMult = 4;
 const slashScale = 3;
 const spell: Spell = {
   card: {
@@ -21,9 +21,9 @@ const spell: Spell = {
     thumbnail: 'spellIconMegaSlash.png',
     animationPath: 'spell-effects/spellHurtCuts',
     sfx: 'hurt3',
-    description: ['spell_slash', damageDone.toString()],
+    description: ['spell_slash', Unit.GetSpellDamage(undefined, damageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
-      return await slashEffect(state, card, quantity, underworld, prediction, damageDone, slashScale);
+      return await slashEffect(state, card, quantity, underworld, prediction, Unit.GetSpellDamage(state.casterUnit.damage, damageMult), slashScale);
     },
   },
 };

--- a/src/cards/meteor.ts
+++ b/src/cards/meteor.ts
@@ -16,9 +16,10 @@ import * as particles from '@pixi/particle-emitter';
 import { createParticleTexture, logNoTextureWarning, wrappedEmitter } from '../graphics/Particles';
 import { stopAndDestroyForeverEmitter } from '../graphics/ParticleCollection';
 import { raceTimeout } from '../Promise';
+import { GetSpellDamage } from '../entity/Unit';
 
 export const meteorCardId = 'meteor';
-const damage = 60;
+const damageMult = 3;
 const baseRadius = 100;
 const basePushDistance = 100;
 const spell: Spell = {
@@ -33,7 +34,7 @@ const spell: Spell = {
     allowNonUnitTarget: true,
     probability: probabilityMap[CardRarity.RARE],
     thumbnail: 'spellIconMeteor.png',
-    description: ['spell_meteor', damage.toString()],
+    description: ['spell_meteor', GetSpellDamage(undefined, damageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       // We should create a meteor at each targeted unit
       // Or if no targeted units, at the cast location
@@ -67,7 +68,7 @@ const spell: Spell = {
 
       const adjustedRadius = baseRadius * (1 + (0.25 * state.aggregator.radiusBoost));
       for (let meteorLocation of meteorLocations) {
-        explode(meteorLocation, adjustedRadius, damage * quantity, basePushDistance,
+        explode(meteorLocation, adjustedRadius, GetSpellDamage(state.casterUnit.damage, damageMult) * quantity, basePushDistance,
           state.casterUnit,
           underworld, prediction,
           colors.bloatExplodeStart, colors.bloatExplodeEnd)

--- a/src/cards/phantom_arrow.ts
+++ b/src/cards/phantom_arrow.ts
@@ -5,7 +5,7 @@ import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { arrowEffect } from './arrow';
 
 export const phantomArrowCardId = 'Phantom Arrow';
-const damageDone = 30;
+const damageMult = 1.5;
 const spell: Spell = {
   card: {
     id: phantomArrowCardId,
@@ -21,19 +21,23 @@ const spell: Spell = {
     ignoreRange: true,
     animationPath: '',
     sfx: 'phantomArrow',
-    description: ['spell_phantom_arrow', damageDone.toString()],
+    description: ['spell_phantom_arrow', Unit.GetSpellDamage(undefined, damageMult).toString()],
     effect: arrowEffect(1, phantomArrowCardId, true)
   },
   events: {
     onProjectileCollision: ({ unit, underworld, projectile, prediction }) => {
       if (unit) {
-        Unit.takeDamage({
-          unit: unit,
-          amount: damageDone,
-          sourceUnit: projectile.sourceUnit,
-          fromVec2: projectile.startPoint,
-          thinBloodLine: true,
-        }, underworld, prediction);
+        if (projectile.sourceUnit) {
+          Unit.takeDamage({
+            unit: unit,
+            amount: Unit.GetSpellDamage(projectile.sourceUnit.damage, damageMult),
+            sourceUnit: projectile.sourceUnit,
+            fromVec2: projectile.startPoint,
+            thinBloodLine: true,
+          }, underworld, prediction);
+        } else {
+          console.error("No source unit for projectile: ", projectile);
+        }
       }
     }
   }

--- a/src/cards/rend.ts
+++ b/src/cards/rend.ts
@@ -9,13 +9,14 @@ import { clone, Vec2 } from '../jmath/Vec';
 import { raceTimeout } from '../Promise';
 
 export const rendCardId = 'Rend';
-function calculateRendDamage(stack: number): number {
-  let damage = 0;
-  for (let i = 1; i < stack + 1; i++) {
-    damage += i;
+function calculateRendDamage(baseDamage: number, quantity: number): number {
+  let stackDamageMult = 0;
+  for (let i = 1; i < quantity + 1; i++) {
+    stackDamageMult += i;
   }
-  return damage * 10;
+  return baseDamage * stackDamageMult;
 }
+const baseDamageMult = 0.5;
 const spellRendAnimationHeight = 10;
 const animationPath = 'spell-effects/spellRend';
 const spell: Spell = {
@@ -30,9 +31,9 @@ const spell: Spell = {
     thumbnail: 'spellIconRend.png',
     animationPath,
     sfx: 'rend',
-    description: ['spell_rend', `${calculateRendDamage(1)}, ${calculateRendDamage(2)}, ${calculateRendDamage(3)}, ${calculateRendDamage(4)}, ${calculateRendDamage(5)}, ${calculateRendDamage(6)}, ${calculateRendDamage(7)}, ${calculateRendDamage(8)}, ${calculateRendDamage(9)}, ${calculateRendDamage(10)}`],
+    description: ['spell_rend', rendDescription()],
     effect: async (state, card, quantity, underworld, prediction) => {
-      const damage = calculateRendDamage(quantity);
+      const damage = calculateRendDamage(Unit.GetSpellDamage(state.casterUnit.damage, baseDamageMult), quantity);
       // .filter: only target living units
       const targets = state.targetedUnits.filter(u => u.alive)
       if (!prediction) {
@@ -51,6 +52,13 @@ const spell: Spell = {
     },
   },
 };
+
+// Returns damage values for the first 10 stacks of rend
+function rendDescription(): string {
+  const baseDamage = Unit.GetSpellDamage(undefined, baseDamageMult);
+  return `${calculateRendDamage(baseDamage, 1)}, ${calculateRendDamage(baseDamage, 2)}, ${calculateRendDamage(baseDamage, 3)}, ${calculateRendDamage(baseDamage, 4)}, ${calculateRendDamage(baseDamage, 5)}, ${calculateRendDamage(baseDamage, 6)}, ${calculateRendDamage(baseDamage, 7)}, ${calculateRendDamage(baseDamage, 8)}, ${calculateRendDamage(baseDamage, 9)}, ${calculateRendDamage(baseDamage, 10)}`
+}
+
 export default spell;
 function animateRend(targets: Vec2[], quantity: number, prediction: boolean): Promise<void> {
   if (prediction || globalThis.headless) {

--- a/src/cards/sacrifice.ts
+++ b/src/cards/sacrifice.ts
@@ -7,10 +7,10 @@ import { playDefaultSpellSFX } from './cardUtils';
 import * as config from '../config';
 import { explain, EXPLAIN_OVERFILL } from '../graphics/Explain';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
-import { die } from '../entity/Unit';
+import { die, GetSpellDamage } from '../entity/Unit';
 import * as Image from '../graphics/Image';
 
-const damage = config.UNIT_BASE_HEALTH; //40 at time of writing
+const damageMult = 2;
 export const consumeAllyCardId = 'Sacrifice';
 const spell: Spell = {
   card: {
@@ -23,7 +23,7 @@ const spell: Spell = {
     expenseScaling: 1,
     probability: probabilityMap[CardRarity.RARE],
     thumbnail: 'spellIconSacrifice.png',
-    description: ['spell_sacrifice', damage.toString()],
+    description: ['spell_sacrifice', GetSpellDamage(undefined, damageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       const caster = state.casterUnit;
       // .filter: only target living units of the same faction
@@ -31,7 +31,7 @@ const spell: Spell = {
       let promises = [];
       let totalHealthStolen = 0;
       for (let unit of targets) {
-        const unitHealthStolen = Math.min(unit.health, damage * quantity);
+        const unitHealthStolen = Math.min(unit.health, GetSpellDamage(state.casterUnit.damage, damageMult) * quantity);
         // This instead of takeDamage() -> ignores shield, not modified by damage mitigation/prevention, doesn't trigger onDamage event
         unit.health -= unitHealthStolen;
         totalHealthStolen += unitHealthStolen;

--- a/src/cards/shatter.ts
+++ b/src/cards/shatter.ts
@@ -11,7 +11,7 @@ import { baseExplosionRadius, explode } from '../effects/explode';
 import { playDefaultSpellSFX } from './cardUtils';
 
 export const shatterCardId = 'Shatter';
-const damage = 40;
+const damageMult = 2;
 const baseRadius = 100;
 
 const spell: Spell = {
@@ -26,7 +26,7 @@ const spell: Spell = {
     probability: probabilityMap[CardRarity.UNCOMMON],
     sfx: 'shatter',
     thumbnail: 'spellIconShatter.png',
-    description: [`spell_shatter`, damage.toString()],
+    description: [`spell_shatter`, Unit.GetSpellDamage(undefined, damageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       // Only target frozen units
       const targetedUnits = state.targetedUnits.filter(u => u.modifiers[freezeCardId]);
@@ -53,7 +53,7 @@ const spell: Spell = {
         }
       }
       for (let { location, radius } of explosions) {
-        explode(location, radius, damage * quantity, 0,
+        explode(location, radius, Unit.GetSpellDamage(state.casterUnit.damage, damageMult) * quantity, 0,
           state.casterUnit,
           underworld, prediction);
         makeShatterParticles(location, radius / baseRadius, prediction);

--- a/src/cards/slash.ts
+++ b/src/cards/slash.ts
@@ -8,7 +8,7 @@ import { CardRarity, probabilityMap } from '../types/commonTypes';
 import Underworld from '../Underworld';
 
 export const slashCardId = 'Slash';
-const damageDone = 20;
+const damageMult = 1;
 const delayBetweenAnimationsStart = 400;
 const animationPath = 'spell-effects/spellHurtCuts';
 const spell: Spell = {
@@ -23,9 +23,9 @@ const spell: Spell = {
     thumbnail: 'spellIconHurt.png',
     animationPath,
     sfx: 'hurt',
-    description: ['spell_slash', damageDone.toString()],
+    description: ['spell_slash', Unit.GetSpellDamage(undefined, damageMult).toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
-      return await slashEffect(state, card, quantity, underworld, prediction, damageDone, 1);
+      return await slashEffect(state, card, quantity, underworld, prediction, Unit.GetSpellDamage(state.casterUnit.damage, damageMult), 1);
     },
   },
 };

--- a/src/cards/stomp.ts
+++ b/src/cards/stomp.ts
@@ -9,7 +9,7 @@ import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { forcePushAwayFrom, forcePushTowards } from '../effects/force_move';
 import { Vec2 } from '../jmath/Vec';
 import Underworld from '../Underworld';
-import { IUnit, takeDamage } from '../entity/Unit';
+import { GetSpellDamage, IUnit, takeDamage } from '../entity/Unit';
 import { makeParticleExplosion } from '../graphics/ParticleCollection';
 import { createParticleTexture, logNoTextureWarning, simpleEmitter } from '../graphics/Particles';
 import * as particles from '@pixi/particle-emitter'
@@ -18,7 +18,7 @@ import { baseExplosionRadius } from '../effects/explode';
 export const stompCardId = 'stomp';
 const stompMoveDistance = 100;
 const stompRadius = 100;
-const stompDamage = 20;
+const damageMult = 1;
 const spell: Spell = {
   card: {
     id: stompCardId,
@@ -62,7 +62,7 @@ const spell: Spell = {
         }
 
         // Stomp does damage * quantity and pushback = base stomp radius
-        stompExplode(state.casterUnit, radius, stompDamage * quantity, stompRadius, underworld, prediction);
+        stompExplode(state.casterUnit, radius, GetSpellDamage(state.casterUnit.damage, damageMult) * quantity, stompRadius, underworld, prediction);
         await underworld.awaitForceMoves(prediction);
       }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ export const UNIT_UI_BAR_WIDTH = 36;
 
 export const LOB_PROJECTILE_SPEED = 800; // in millis
 export const UNIT_SIZE = COLLISION_MESH_RADIUS * 2;
-export const UNIT_BASE_DAMAGE = 30;
+export const UNIT_BASE_DAMAGE = 20;
 // Primarily for melee Units
 export const UNIT_BASE_RANGE = 10 + COLLISION_MESH_RADIUS * 2;
 export const UNIT_BASE_STAMINA = 300;

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -899,6 +899,14 @@ export function composeOnTakeDamageEvents(damageArgs: damageArgs, underworld: Un
   return amount;
 }
 
+export function GetSpellDamage(baseDamage: number | undefined, multiplier: number) {
+  if (baseDamage == undefined) {
+    // Use to automatically update tooltips where applicable
+    baseDamage = globalThis.player?.unit.damage || config.UNIT_BASE_DAMAGE;
+  }
+  return Math.floor(baseDamage * multiplier);
+}
+
 interface damageArgs {
   unit: IUnit,
   amount: number,

--- a/src/entity/units/goru.ts
+++ b/src/entity/units/goru.ts
@@ -133,7 +133,6 @@ const unit: UnitSource = {
                   unit.healthMax += 10;
                   unit.staminaMax += 10;
                   unit.manaMax += 10;
-                  // TODO - Doesn't scale bone shrapnel damage. Should it?
                   unit.damage += 10;
                   unit.attackRange += 10;
                   unit.strength += 1;

--- a/src/entity/units/poisoner.ts
+++ b/src/entity/units/poisoner.ts
@@ -19,7 +19,7 @@ const unit: UnitSource = {
     subtype: UnitSubType.RANGED_RADIUS,
   },
   unitProps: {
-    damage: 1,
+    damage: 20,
     attackRange: 350,
     healthMax: 60,
     mana: 60,
@@ -56,16 +56,11 @@ const unit: UnitSource = {
         ).then(async () => {
           // Add projectile hit animation
           Image.addOneOffAnimation(chosenUnit, 'projectile/poisonerProjectileHit');
-          const cardsIds = [];
-          // Casts one stack of poison per damage
-          for (let i = 0; i < unit.damage; i++) {
-            cardsIds.push(poison.poisonCardId);
-          }
           await underworld.castCards({
             casterCardUsage: {},
             casterUnit: unit,
             casterPositionAtTimeOfCast: Vec.clone(unit),
-            cardIds: cardsIds,
+            cardIds: [poison.poisonCardId],
             castLocation: chosenUnit,
             initialTargetedUnitId: chosenUnit.id,
             prediction: false,

--- a/src/entity/units/urn_explosive.ts
+++ b/src/entity/units/urn_explosive.ts
@@ -9,7 +9,6 @@ import { defaultPushDistance } from '../../effects/force_move';
 
 export const urn_explosive_id = 'Explosive Urn'
 const baseRadius = 140;
-const damage = 80;
 const unit: UnitSource = {
   id: urn_explosive_id,
   info: {
@@ -18,7 +17,7 @@ const unit: UnitSource = {
     subtype: UnitSubType.DOODAD,
   },
   unitProps: {
-    damage,
+    damage: 80,
     attackRange: baseRadius,
     staminaMax: 0,
     healthMax: 1,

--- a/src/entity/units/urn_poison.ts
+++ b/src/entity/units/urn_poison.ts
@@ -16,7 +16,7 @@ const urnPoisonSource: UnitSource = {
     subtype: UnitSubType.DOODAD,
   },
   unitProps: {
-    damage: 0,
+    damage: 20,
     attackRange: baseExplosionRadius,
     staminaMax: 0,
     healthMax: 1,
@@ -65,7 +65,7 @@ export function registerUrnPoisonExplode() {
           if (!prediction) {
             animateSpell(u, 'spell-effects/spellPoison'); // TODO - Put in poison modifier "add" function?
           }
-          Unit.addModifier(u, poison.poisonCardId, underworld, prediction, 1);
+          Unit.addModifier(u, poison.poisonCardId, underworld, prediction, unit.damage);
         });
       // Remove corpse
       if (!prediction) {


### PR DESCRIPTION
Closes #578 

Spells now scale off of the player unit's damage stat via a damage multiplier, instead of having a constant damage value.

## TODO
- Update mods?
- Consider adding "Damage" stat option to player perk selection
- Consider rebalancing the Goru (since its bone shrapnel now scales with damage)
- QA Multiplayer