### PR TITLE
Split Fixes

### DIFF
--- a/src/Overworld.ts
+++ b/src/Overworld.ts
@@ -163,13 +163,17 @@ export function ensureAllClientsHaveAssociatedPlayers(overworld: Overworld, clie
   underworld.tryRestartTurnPhaseLoop();
 }
 export function recalculateGameDifficulty(underworld: Underworld) {
-  const newDifficulty = calculateGameDifficulty(underworld);
-  underworld.units.forEach(unit => {
-    // Adjust stats for all non-player units
-    if (unit.unitType !== UnitType.PLAYER_CONTROLLED) {
-      Unit.adjustUnitDifficulty(unit, newDifficulty);
-    }
-  });
-  console.log('adjusting game difficulty to ', newDifficulty, ' for ', underworld.players.filter(p => p.clientConnected).length, ' connected players.');
-
+  const oldDifficulty = underworld.difficulty;
+  underworld.difficulty = calculateGameDifficulty(underworld);
+  // The host should be the only one to update unit difficulty, 
+  // otherwise the stat changes will be applied multiple times (once for each connected player)
+  if (globalThis.isHost(underworld.pie)) {
+    underworld.units.forEach(unit => {
+      // Adjust stats for all non-player units
+      if (unit.unitType !== UnitType.PLAYER_CONTROLLED) {
+        Unit.adjustUnitDifficulty(unit, oldDifficulty, underworld.difficulty);
+      }
+    });
+  }
+  console.log('adjusting game difficulty from ', oldDifficulty, ' to ', underworld.difficulty, ' for ', underworld.players.filter(p => p.clientConnected).length, ' connected players.');
 }

--- a/src/Overworld.ts
+++ b/src/Overworld.ts
@@ -165,8 +165,7 @@ export function ensureAllClientsHaveAssociatedPlayers(overworld: Overworld, clie
 export function recalculateGameDifficulty(underworld: Underworld) {
   const newDifficulty = calculateGameDifficulty(underworld);
   underworld.units.forEach(unit => {
-    // Adjust npc unit strength when the number of players changes
-    // Do NOT adjust player unit strength
+    // Adjust stats for all non-player units
     if (unit.unitType !== UnitType.PLAYER_CONTROLLED) {
       Unit.adjustUnitDifficulty(unit, newDifficulty);
     }

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -91,7 +91,7 @@ import { BLOOD_GOLEM_ID } from './entity/units/bloodGolem';
 import { MANA_VAMPIRE_ID } from './entity/units/manaVampire';
 import { DARK_PRIEST_ID } from './entity/units/darkPriest';
 import { LAST_LEVEL_INDEX } from './config';
-import { unavailableUntilLevelIndexDifficultyModifier } from './Difficulty';
+import { calculateGameDifficulty, unavailableUntilLevelIndexDifficultyModifier } from './Difficulty';
 import { View } from './View';
 import { skyBeam } from './VisualEffects';
 import { urn_explosive_id } from './entity/units/urn_explosive';
@@ -144,6 +144,7 @@ let localUnderworldCount = 0;
 export default class Underworld {
   seed: string;
   gameMode?: GameMode;
+  difficulty: number = 1;
   // A simple number to keep track of which underworld this is
   // Used for development to help ensure that all references to the underworld are current
   localUnderworldNumber: number;

--- a/src/cards/bloat.ts
+++ b/src/cards/bloat.ts
@@ -19,9 +19,6 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity:
     isCurse: true, quantity,
   }, () => {
     Unit.addEvent(unit, id);
-
-    // Visually "bloat" the image
-    addScaleModifier(unit.image, { x: 1.5, id }, unit.strength);
   });
   if (!modifier.radiusBoost) {
     modifier.radiusBoost = 0;
@@ -56,6 +53,11 @@ const spell: Spell = {
   },
   modifiers: {
     add,
+    addModifierVisuals(unit, underworld) {
+      // Visually "bloat" the image
+      addScaleModifier(unit.image, { x: 1.5, id }, unit.strength);
+
+    },
     remove,
     subsprite: {
       imageName,

--- a/src/cards/blood_curse.ts
+++ b/src/cards/blood_curse.ts
@@ -26,10 +26,12 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean) {
   }
 
   getOrInitModifier(unit, id, { isCurse: true, quantity: 1 }, () => {
+    // Add event
     Unit.addEvent(unit, id);
-
-    unit.healthMax *= healthMultiplier;
-    unit.health *= healthMultiplier;
+    // This is done in first time setup because the modified stats are stored on the unit
+    // otherwise it would apply the multiplier each time the unit is loaded
+    unit.healthMax = Math.floor(unit.healthMax *= healthMultiplier);
+    unit.health = Math.floor(unit.health *= healthMultiplier);
   });
 
   if (!prediction) {
@@ -42,10 +44,9 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean) {
 }
 
 function remove(unit: IUnit, underworld: Underworld) {
-  unit.health /= healthMultiplier;
-  unit.health = Math.round(unit.health);
-  unit.healthMax /= healthMultiplier;
-  unit.healthMax = Math.round(unit.healthMax);
+  // Health should not go below 1
+  unit.healthMax = Math.max(1, Math.floor(unit.healthMax / healthMultiplier));
+  unit.health = Math.max(1, Math.floor(unit.health / healthMultiplier));
 }
 
 

--- a/src/cards/blood_curse.ts
+++ b/src/cards/blood_curse.ts
@@ -30,8 +30,8 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean) {
     Unit.addEvent(unit, id);
     // This is done in first time setup because the modified stats are stored on the unit
     // otherwise it would apply the multiplier each time the unit is loaded
-    unit.healthMax = Math.floor(unit.healthMax *= healthMultiplier);
-    unit.health = Math.floor(unit.health *= healthMultiplier);
+    unit.healthMax = Math.floor(unit.healthMax * healthMultiplier);
+    unit.health = Math.floor(unit.health * healthMultiplier);
   });
 
   if (!prediction) {

--- a/src/cards/clone.ts
+++ b/src/cards/clone.ts
@@ -94,8 +94,7 @@ export function cloneEffect(addClonesToTargetArray: boolean): EffectFn {
                   addTarget(clone, state, underworld, prediction);
                 }
               }
-            }
-            if (Pickup.isPickup(target)) {
+            } else if (Pickup.isPickup(target)) {
               const targetName = target.name;
               const validSpawnCoords = underworld.findValidSpawn({ spawnSource: cloneSourceCoords, ringLimit: 5, prediction, radius: 15 })
               if (validSpawnCoords) {
@@ -104,9 +103,9 @@ export function cloneEffect(addClonesToTargetArray: boolean): EffectFn {
                   const clone = Pickup.create({ pos: target, pickupSource: foundPickup, logSource: 'Clone' }, underworld, prediction);
                   if (clone) {
                     Pickup.setPosition(clone, validSpawnCoords.x, validSpawnCoords.y);
+                    // Add clones to target list
+                    addTarget(clone, state, underworld, prediction);
                   }
-                  // Add clones to target list
-                  addTarget(clone, state, underworld, prediction);
                 } else {
                   console.log('Pickup', target);
                   console.error('Could not clone pickup because source could not be found');

--- a/src/cards/clone.ts
+++ b/src/cards/clone.ts
@@ -103,6 +103,7 @@ export function cloneEffect(addClonesToTargetArray: boolean): EffectFn {
                   const clone = Pickup.create({ pos: target, pickupSource: foundPickup, logSource: 'Clone' }, underworld, prediction);
                   if (clone) {
                     Pickup.setPosition(clone, validSpawnCoords.x, validSpawnCoords.y);
+                    Pickup.setPower(clone, target.power);
                     // Add clones to target list
                     addTarget(clone, state, underworld, prediction);
                   }

--- a/src/cards/freeze.ts
+++ b/src/cards/freeze.ts
@@ -75,7 +75,7 @@ const spell: Spell = {
     },
   },
 };
-function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld, prediction: boolean) {
+function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld) {
   // Add subsprite image
   Image.addSubSprite(unit.image, imageName);
   // Stop the animation
@@ -92,7 +92,6 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean) {
   getOrInitModifier(unit, freezeCardId, { isCurse: true, quantity: 1 }, () => {
     unit.radius = config.COLLISION_MESH_RADIUS;
     Unit.addEvent(unit, freezeCardId);
-    addModifierVisuals(unit, underworld, prediction);
 
     // Prevents units from being pushed out of the way and units
     // act as a blockade

--- a/src/cards/immune.ts
+++ b/src/cards/immune.ts
@@ -16,7 +16,7 @@ export default function registerImmune() {
   });
 }
 const imageName = 'spell-effects/modifierShield.png';
-export function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld, prediction: boolean) {
+export function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld) {
   // Add subsprite image
   // @ts-ignore: imagePath is a property that i've added and is not a part of the PIXI type
   // which is used for identifying the sprite or animation that is currently active
@@ -28,9 +28,7 @@ export function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld, pre
   }
 }
 export function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) {
-  getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
-    addModifierVisuals(unit, underworld, prediction)
-  });
+  getOrInitModifier(unit, id, { isCurse: false, quantity }, () => { });
 }
 export function remove(unit: Unit.IUnit, underworld: Underworld) {
   Image.removeSubSprite(unit.image, imageName);

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -142,7 +142,7 @@ export interface Modifiers {
   // see 'poison' for example
   // init is inteded to be called within add.
   // Anything that is not governed by the unit's state should be set in addModifierVisuals
-  addModifierVisuals?: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean) => void;
+  addModifierVisuals?: (unit: Unit.IUnit, underworld: Underworld) => void;
   add?: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number, extra?: object) => void;
   remove?: (unit: Unit.IUnit, underworld: Underworld) => void;
   description?: string;

--- a/src/cards/poison.ts
+++ b/src/cards/poison.ts
@@ -12,7 +12,7 @@ import { getOrInitModifier } from './util';
 
 export const poisonCardId = 'poison';
 const baseDamage = 20;
-function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld, prediction: boolean) {
+function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld) {
   Image.addSubSprite(unit.image, subspriteImageName);
   if (spell.modifiers?.subsprite) {
     // @ts-ignore: imagePath is a property that i've added and is not a part of the PIXI type
@@ -31,12 +31,6 @@ function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld, prediction
 function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1, extra?: { [key: string]: any }) {
   const modifier = getOrInitModifier(unit, poisonCardId, { isCurse: true, quantity }, () => {
     Unit.addEvent(unit, poisonCardId);
-    // Add subsprite image
-    if (!prediction) {
-      if (spell.modifiers?.subsprite) {
-        addModifierVisuals(unit, underworld, prediction);
-      }
-    }
   });
 
   if (!prediction) {

--- a/src/cards/shield.ts
+++ b/src/cards/shield.ts
@@ -48,6 +48,10 @@ const spell: Spell = {
   },
   modifiers: {
     add,
+    addModifierVisuals(unit, underworld) {
+      // Add subsprite image
+      Image.addSubSprite(unit.image, modifierImagePath);
+    },
     subsprite: {
       imageName: modifierImagePath,
       alpha: 0.5,
@@ -107,8 +111,6 @@ function updateTooltip(unit: Unit.IUnit) {
 function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, quantity: number = 1) {
   const modifier = getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
     Unit.addEvent(unit, id);
-    // Add subsprite image
-    Image.addSubSprite(unit.image, modifierImagePath);
   });
   // Increment the number of damage_block on this modifier
   // Note: This is only adding the quantity of this invokation, NOT any preexisting

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -24,8 +24,8 @@ function remove(unit: Unit.IUnit, underworld: Underworld) {
 
   const inverseMult = 1 / splitStatMultiplier;
   for (let i = 0; i < modifier.quantity; i++) {
-    unit.healthMax = Math.max(1, Math.floor(unit.healthMax *= inverseMult));
-    unit.health = Math.max(1, Math.floor(unit.health *= inverseMult));
+    unit.healthMax = Math.max(1, Math.floor(unit.healthMax * inverseMult));
+    unit.health = Math.max(1, Math.floor(unit.health * inverseMult));
     //unit.manaMax = Math.floor(unit.manaMax * inverseMult);
     unit.mana = Math.floor(unit.mana * inverseMult);
     unit.manaPerTurn = Math.floor(unit.manaPerTurn * inverseMult);
@@ -54,8 +54,8 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
   modifier.quantity = Math.min(modifier.quantity, splitLimit);
 
   for (let i = 0; i < timesToSplit; i++) {
-    unit.healthMax = Math.max(1, Math.floor(unit.healthMax *= splitStatMultiplier));
-    unit.health = Math.max(1, Math.floor(unit.health *= splitStatMultiplier));
+    unit.healthMax = Math.max(1, Math.floor(unit.healthMax * splitStatMultiplier));
+    unit.health = Math.max(1, Math.floor(unit.health * splitStatMultiplier));
     //unit.manaMax = Math.floor(unit.manaMax * splitStatMultiplier);
     unit.mana = Math.floor(unit.mana * splitStatMultiplier);
     unit.manaPerTurn = Math.floor(unit.manaPerTurn * splitStatMultiplier);

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -32,7 +32,7 @@ function remove(unit: Unit.IUnit, underworld: Underworld) {
     unit.staminaMax = Math.floor(unit.staminaMax * inverseMult);
     unit.stamina = Math.floor(unit.stamina * inverseMult);
     unit.damage = Math.floor(unit.damage * inverseMult);
-    unit.moveSpeed = Math.floor(unit.moveSpeed * inverseMult);
+    unit.moveSpeed *= inverseMult;
   }
 
   removeScaleModifier(unit.image, splitId, unit.strength);
@@ -62,7 +62,7 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
     unit.staminaMax = Math.floor(unit.staminaMax * splitStatMultiplier);
     unit.stamina = Math.floor(unit.stamina * splitStatMultiplier);
     unit.damage = Math.floor(unit.damage * splitStatMultiplier);
-    unit.moveSpeed = Math.floor(unit.moveSpeed * splitStatMultiplier);
+    unit.moveSpeed *= splitStatMultiplier;
   }
 
   addScaleModifier(unit.image, { x: Math.pow(scaleMultiplier, modifier.quantity), y: Math.pow(scaleMultiplier, modifier.quantity), id: splitId }, unit.strength)

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -67,8 +67,6 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
     unit.moveSpeed *= splitStatMultiplier;
   }
 
-  addScaleModifier(unit.image, { x: Math.pow(scaleMultiplier, modifier.quantity), y: Math.pow(scaleMultiplier, modifier.quantity), id: splitId }, unit.strength)
-
   if (unit.modifiers[suffocateCardId]) {
     updateSuffocate(unit, underworld, prediction);
   }
@@ -127,7 +125,14 @@ const spell: Spell = {
   },
   modifiers: {
     add,
-    remove
+    remove,
+    addModifierVisuals: (unit: Unit.IUnit, underworld: Underworld) => {
+      const modifier = unit.modifiers[splitId];
+      if (modifier) {
+        addScaleModifier(unit.image, { x: Math.pow(scaleMultiplier, modifier.quantity), y: Math.pow(scaleMultiplier, modifier.quantity), id: splitId }, unit.strength);
+      }
+
+    }
   }
 };
 export default spell;

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -51,7 +51,6 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
   modifier.quantity = Math.min(modifier.quantity, splitLimit);
 
   for (let i = 0; i < timesToSplit; i++) {
-    addScaleModifier(unit.image, { x: scaleMultiplier, y: scaleMultiplier, splitId }, unit.strength)
     unit.healthMax = Math.max(1, Math.floor(unit.healthMax *= splitStatMultiplier));
     unit.health = Math.max(1, Math.floor(unit.health *= splitStatMultiplier));
     //unit.manaMax = Math.floor(unit.manaMax * splitStatMultiplier);
@@ -62,6 +61,8 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
     unit.damage = Math.floor(unit.damage * splitStatMultiplier);
     unit.moveSpeed = Math.floor(unit.moveSpeed * splitStatMultiplier);
   }
+
+  addScaleModifier(unit.image, { x: Math.pow(scaleMultiplier, modifier.quantity), y: Math.pow(scaleMultiplier, modifier.quantity), id: splitId }, unit.strength)
 
   if (unit.modifiers[suffocateCardId]) {
     updateSuffocate(unit, underworld, prediction);

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -28,7 +28,7 @@ function remove(unit: Unit.IUnit, underworld: Underworld) {
   for (let i = 0; i < modifier.quantity; i++) {
     unit.healthMax = Math.max(1, Math.floor(unit.healthMax * inverseMult));
     unit.health = Math.max(1, Math.floor(unit.health * inverseMult));
-    //unit.manaMax = Math.floor(unit.manaMax * inverseMult);
+    // Note: manaMax is not changed or else it would render casters useless
     unit.mana = Math.floor(unit.mana * inverseMult);
     unit.manaPerTurn = Math.floor(unit.manaPerTurn * inverseMult);
     unit.staminaMax = Math.floor(unit.staminaMax * inverseMult);
@@ -58,7 +58,7 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
   for (let i = 0; i < timesToSplit; i++) {
     unit.healthMax = Math.max(1, Math.floor(unit.healthMax * splitStatMultiplier));
     unit.health = Math.max(1, Math.floor(unit.health * splitStatMultiplier));
-    //unit.manaMax = Math.floor(unit.manaMax * splitStatMultiplier);
+    // Note: manaMax is not changed or else it would render casters useless
     unit.mana = Math.floor(unit.mana * splitStatMultiplier);
     unit.manaPerTurn = Math.floor(unit.manaPerTurn * splitStatMultiplier);
     unit.staminaMax = Math.floor(unit.staminaMax * splitStatMultiplier);

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -37,6 +37,9 @@ function remove(unit: Unit.IUnit, underworld: Underworld) {
 
   removeScaleModifier(unit.image, splitId, unit.strength);
 
+  if (unit.modifiers[suffocateCardId]) {
+    updateSuffocate(unit, underworld, false);
+  }
 }
 function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) {
 

--- a/src/cards/summon_generic.ts
+++ b/src/cards/summon_generic.ts
@@ -136,9 +136,8 @@ export default function makeSpellForUnitId(unitId: string, asMiniboss: boolean, 
     let manaMax = unitSource.unitProps.manaMax || 0;
     let manaPerTurn = unitSource.unitProps.manaPerTurn || 0;
     if (difficulty && unitSource) {
-      const adjustedUnitProps = Unit.adjustUnitPropsDueToDifficulty(unitSource, difficulty);
+      const adjustedUnitProps = Unit.adjustUnitPropsDueToDifficulty({ healthMax, health: healthMax }, difficulty);
       healthMax = adjustedUnitProps.healthMax;
-      manaMax = adjustedUnitProps.manaMax;
     }
 
     if (asMiniboss) {

--- a/src/entity/Pickup.ts
+++ b/src/entity/Pickup.ts
@@ -126,14 +126,15 @@ export function create({ pos, pickupSource, idOverride, logSource }:
   if (isNaN(x) || isNaN(y)) {
     console.error('Unexpected: Created pickup at NaN', pickupSource.name);
   }
-  if (idOverride !== undefined) {
-    underworld.lastPickupId = idOverride;
-  }
   const id = idOverride !== undefined
     ? idOverride
     : prediction
       ? ++lastPredictionPickupId
       : ++underworld.lastPickupId;
+
+  if (!prediction && id > underworld.lastPickupId) {
+    underworld.lastPickupId = id;
+  }
   const duplicatePickup = (prediction ? underworld.pickupsPrediction : underworld.pickups).find(p => p.id == id)
   if (duplicatePickup) {
     if (prediction) {
@@ -334,6 +335,9 @@ export function load(pickup: IPickupSerialized, underworld: Underworld, predicti
       return undefined;
     }
     const newPickup = create({ pos: pickup, pickupSource: foundPickup, idOverride: pickup.id }, underworld, prediction);
+    if (!prediction && newPickup.id > underworld.lastPickupId) {
+      underworld.lastPickupId = newPickup.id;
+    }
     // Note: It is important here to use Object.assign so that the pickup reference is the SAME ref as is created in the
     // create function because the create function passes that ref to the underworld pickups array.
     // So when you mutate the properties, the ref must stay the same.

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -380,6 +380,9 @@ export function addModifier(unit: IUnit, key: string, underworld: Underworld, pr
     } else {
       console.error('No "add" modifier for ', key);
     }
+    if (modifier.addModifierVisuals && !prediction) {
+      modifier.addModifierVisuals(unit, underworld);
+    }
   } else {
     console.error('Modifier ', key, 'never registered.');
   }
@@ -495,10 +498,10 @@ export function load(unit: IUnitSerialized, underworld: Underworld, prediction: 
   }
   for (let key of Object.keys(loadedunit.modifiers)) {
     const modifier = allModifiers[key];
-    if (modifier && modifier.addModifierVisuals) {
+    if (modifier && modifier.addModifierVisuals && !prediction) {
       // Invoke modifier.addModifierVisuals so that special init logic
       // such as there is in 'poison' will run
-      modifier.addModifierVisuals(loadedunit, underworld, prediction);
+      modifier.addModifierVisuals(loadedunit, underworld);
     } else {
       console.warn('No init for modifier with key', key)
     }

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -490,7 +490,7 @@ export function load(unit: IUnitSerialized, underworld: Underworld, prediction: 
         : Image.create({ x: unit.x, y: unit.y }, unit.defaultImagePath, containerUnits),
   };
 
-  if (loadedunit.id > underworld.lastUnitId) {
+  if (!prediction && loadedunit.id > underworld.lastUnitId) {
     underworld.lastUnitId = loadedunit.id;
   }
   for (let key of Object.keys(loadedunit.modifiers)) {

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -1117,11 +1117,10 @@ export function registerAdminContextMenuOptions(overworld: Overworld) {
             console.error('Cannot spawn unit, underworld does not exist');
             return;
           }
-          overworld.underworld.spawnEnemy(u.id, pos, false);
-          // Orient newly spawned units towards the player
-          if (globalThis.player) {
-            const justSpawnedUnit = overworld.underworld.units[overworld.underworld.units.length - 1];
-            if (justSpawnedUnit) {
+          const justSpawnedUnit = overworld.underworld.spawnEnemy(u.id, pos, false);
+          if (justSpawnedUnit) {
+            // Orient newly spawned units towards the player
+            if (globalThis.player) {
               Unit.orient(justSpawnedUnit, globalThis.player.unit);
             }
           }

--- a/src/modifierPrimedCorpse.ts
+++ b/src/modifierPrimedCorpse.ts
@@ -11,11 +11,10 @@ import { makePrimedCorpseParticles, stopAndDestroyForeverEmitter } from "./graph
 export const primedCorpseId = 'Primed Corpse';
 export default function registerPrimedCorpse() {
   registerModifiers(primedCorpseId, {
-    addModifierVisuals: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean) => initCorpsePrimed(unit, underworld, prediction),
+    addModifierVisuals: (unit: Unit.IUnit, underworld: Underworld) => initCorpsePrimed(unit, underworld, false),
     add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
       const modifier = getOrInitModifier(unit, primedCorpseId, { isCurse: false, quantity, keepOnDeath: true }, () => {
         Unit.addEvent(unit, primedCorpseId);
-        initCorpsePrimed(unit, underworld, prediction);
       });
 
       // Limit to 1 quantity

--- a/src/modifierTargetImmune.ts
+++ b/src/modifierTargetImmune.ts
@@ -6,7 +6,7 @@ import Underworld from './Underworld';
 
 export const targetImmuneId = 'Target Immune';
 const subspriteId = 'spell-effects/targetImmune';
-function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld, prediction: boolean) {
+function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld) {
   Image.addSubSprite(unit.image, subspriteId);
 }
 export default function registerTargetImmune() {
@@ -16,7 +16,6 @@ export default function registerTargetImmune() {
     add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
       getOrInitModifier(unit, targetImmuneId, { isCurse: false, quantity, keepOnDeath: true }, () => {
         Unit.addEvent(unit, targetImmuneId);
-        addModifierVisuals(unit, underworld, prediction);
       });
     },
     subsprite: {


### PR DESCRIPTION
- closes #565 
  - ... fixes a blood curse/split exploit where units could obtain infinite health
- closes #566 
  - ... fixes an issue where all stat changes from any source (split, blood curse, empower, enfeeble, goru eating, etc.) would be removed upon recalculation of game difficulty
- fixes an issue where multiple splits would not further decrease sprite size
- fixes an issue where split would incorrectly set zero and negative value stats to 1
- added: split can now affect pickups (note: strength/power scaling formula doesn't look very impressive at values < 1, pickups don't get much smaller after being split)

- closes #843 (Not split related, should do in a separate PR)
 
## TODO
- #822 