### PR TITLE
Refactor events

### DIFF
--- a/public/spellmasons-mods/Renes_gimmicks/cards/Burning_rage.ts
+++ b/public/spellmasons-mods/Renes_gimmicks/cards/Burning_rage.ts
@@ -171,10 +171,7 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity:
     cardsUtil.getOrInitModifier(unit, cardId, {
         isCurse: true, quantity, persistBetweenLevels: false,
     }, () => {
-        //Adds event
-        if (!unit.onTurnStartEvents.includes(cardId)) {
-            unit.onTurnStartEvents.push(cardId);
-        }
+        SpellmasonsAPI.Unit.addEvent(unit, cardId);
         makeBurningRageParticles(unit, underworld, prediction);
     });
 }

--- a/public/spellmasons-mods/Renes_gimmicks/cards/Caltrops.ts
+++ b/public/spellmasons-mods/Renes_gimmicks/cards/Caltrops.ts
@@ -60,16 +60,13 @@ const spell: Spell = {
 };
 
 function add(unit: IUnit, _underworld: Underworld, prediction: boolean, quantity: number, extra: any) {
-    let firstStack = !unit.onTurnStartEvents.includes(cardId);
+    let firstStack = !unit.events.includes(cardId);
     const modifier = cardsUtil.getOrInitModifier(unit, cardId, {
         isCurse: false, quantity, persistBetweenLevels: false,
     }, () => {
         //Register onTurn
         if (firstStack) {
-            //unit.onMove.push(cardId);
-            unit.onTurnEndEvents.push(cardId);
-            unit.onTurnStartEvents.push(cardId);
-            unit.onTakeDamageEvents.push(cardId);
+            SpellmasonsAPI.Unit.addEvent(unit, cardId);
         }
     });
     if (firstStack) {

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Decay.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Decay.ts
@@ -27,7 +27,6 @@ const spell: Spell = {
         thumbnail: 'spellmasons-mods/Wodes_Grimoire/graphics/icons/spelliconDecay.png',
         sfx: 'poison',
         description: [`Causes the target to take damage equal to the number of decay stacks squared at the start of their turn. The target then gains another stack.`],
-        timeoutMs: 20,
         effect: async (state, card, quantity, underworld, prediction) => {
             //Only filter unit thats are alive
             const targets = state.targetedUnits.filter(u => u.alive);
@@ -68,10 +67,7 @@ function add(unit: IUnit, _underworld: Underworld, _prediction: boolean, quantit
     cardsUtil.getOrInitModifier(unit, cardId, {
         isCurse: true, quantity, persistBetweenLevels: false,
     }, () => {
-        //Adds event
-        if (!unit.onTurnStartEvents.includes(cardId)) {
-            unit.onTurnStartEvents.push(cardId);
-        }
+        SpellmasonsAPI.Unit.addEvent(unit, cardId);
     });
 }
 export default spell;

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Dominate.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Dominate.ts
@@ -25,7 +25,6 @@ const spell: Spell = {
         thumbnail: 'spellmasons-mods/Wodes_Grimoire/graphics/icons/spelliconDominate.png',
         sfx: 'suffocate',
         description: [`Converts an enemy to fight for you if they are below ${healthThreshhold * 100}% health.`], //Wololo
-        timeoutMs: 20,
         effect: async (state, card, quantity, underworld, prediction) => {
             //Living units, Units below threshhold, and units that are in your faction
             const targets = state.targetedUnits.filter(u => u.alive && u.health <= u.healthMax * healthThreshhold && u.faction !== state.casterUnit.faction);

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Ensnare.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Ensnare.ts
@@ -27,7 +27,6 @@ const spell: Spell = {
         thumbnail: 'spellmasons-mods/Wodes_Grimoire/graphics/icons/spelliconEnsnare.png',
         sfx: '',
         description: [`Prevents the target from moving for one turn. Furthur casts increase duration.`],
-        timeoutMs: 20,
         effect: async (state, card, quantity, underworld, prediction) => {
             //Only filter unit thats are alive.
             const targets = state.targetedUnits.filter(u => u.alive);
@@ -69,10 +68,7 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity:
         isCurse: true, quantity, persistBetweenLevels: false,
         originalstat: unit.staminaMax,
     }, () => {
-        //Register onTurnEndEvents
-        if (!unit.onTurnEndEvents.includes(cardId)) {
-            unit.onTurnEndEvents.push(cardId);
-        }
+        SpellmasonsAPI.Unit.addEvent(unit, cardId);
         unit.stamina = 0;
         unit.staminaMax = 0;
     });

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Fast_Forward.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Fast_Forward.ts
@@ -30,7 +30,6 @@ const spell: Spell = {
         thumbnail: 'spellmasons-mods/Wodes_Grimoire/graphics/icons/spelliconFastForward.png',
         sfx: 'push', //TODO
         description: [`Shunt the target forward through time. Causes progression of spell effects but does not affect cooldowns.`], //TODO: better deffinition
-        timeoutMs: 20,
         effect: async (state, card, quantity, underworld, prediction) => {
             //Living units
             const targets = state.targetedUnits.filter(u => u.alive);
@@ -70,8 +69,8 @@ const spell: Spell = {
 };
 async function procEvents(unit: IUnit, underworld: Underworld, prediction: boolean) {
     //onTurnStart events first for order.
-    for (let i = 0; i < unit.onTurnStartEvents.length; i++) {
-        const eventName = unit.onTurnStartEvents[i];
+    for (let i = 0; i < unit.events.length; i++) {
+        const eventName = unit.events[i];
         if (eventName) {
             //Made into function because eventName points to a modifier (probably) whose arguments need to be pass in.
             const fns = Events.default.onTurnStartSource[eventName];
@@ -80,8 +79,8 @@ async function procEvents(unit: IUnit, underworld: Underworld, prediction: boole
             }
         }
     }
-    for (let i = 0; i < unit.onTurnEndEvents.length; i++) {
-        const eventName = unit.onTurnEndEvents[i];
+    for (let i = 0; i < unit.events.length; i++) {
+        const eventName = unit.events[i];
         if (eventName) {
             const fne = Events.default.onTurnEndSource[eventName];
             if (fne) {

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/FlameStrike.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/FlameStrike.ts
@@ -31,7 +31,6 @@ const spell: Spell = {
         thumbnail: 'spellmasons-mods/Wodes_Grimoire/graphics/icons/spelliconFlameStrike.png',
         sfx: 'burst',
         description: [`Deals ${damageMain} damage to the target and ${damageSplash} damage to nearby targets in a small area.`],
-        timeoutMs: 400,
         effect: async (state, card, quantity, underworld, prediction) => {
             //Using await new Promise instead of the other way spells work to force
             //Flamestrike to finish before continue to the next spell.

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Grace.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Grace.ts
@@ -31,7 +31,6 @@ const spell: Spell = {
         thumbnail: 'spellmasons-mods/Wodes_Grimoire/graphics/icons/spelliconGrace.png',
         sfx: 'purify', //TODO
         description: [`Heals the target for ${-healingAmount} after 3 turns. Stacks increase the amount, but do not change duration`],
-        timeoutMs: 20,
         effect: async (state, card, quantity, underworld, prediction) => {
             //Only filter unit thats are alive
             const targets = state.targetedUnits.filter(u => u.alive);
@@ -81,10 +80,7 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity:
     const modifier = cardsUtil.getOrInitModifier(unit, cardId, {
         isCurse: false, quantity, persistBetweenLevels: false,
     }, () => {
-        // Register onTurnStart event
-        if (!unit.onTurnStartEvents.includes(cardId)) {
-            unit.onTurnStartEvents.push(cardId);
-        }
+        SpellmasonsAPI.Unit.addEvent(unit, cardId);
     });
 
     if (!modifier.graceCountdown) {

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Harvest.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Harvest.ts
@@ -28,7 +28,6 @@ const spell: Spell = {
         thumbnail: 'spellmasons-mods/Wodes_Grimoire/graphics/icons/spelliconHarvest.png',
         sfx: 'sacrifice',
         description: [`Consumes target corpse for ${manaRegain} mana. Does not work on player corpses. Unstackable.\n\nTastes like chicken.`],
-        timeoutMs: 900,
         effect: async (state, card, quantity, underworld, prediction) => {
             let promises: any[] = [];
             let totalManaHarvested = 0;

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Pacify.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Pacify.ts
@@ -27,7 +27,6 @@ const spell: Spell = {
         thumbnail: 'spellmasons-mods/Wodes_Grimoire/graphics/icons/spelliconPacify.png',
         sfx: '',
         description: [`Prevents the target from attacking for one turn. Stacks increase duration. Does not affect Support Class units such as summoners or priests.`],
-        timeoutMs: 20,
         effect: async (state, card, quantity, underworld, prediction) => {
             //Only filter unit thats are alive and can attack. u.unitSubType[3] presumed SUPPORT_CLASS, cant effect summoners, prists dont attack
             const targets = state.targetedUnits.filter(u => u.alive && !(u.unitSubType == 3));
@@ -69,10 +68,7 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity:
         isCurse: true, quantity, persistBetweenLevels: false,
         originalstat: unit.attackRange,
     }, () => {
-        //Register onTurnEndEvents
-        if (!unit.onTurnEndEvents.includes(cardId)) {
-            unit.onTurnEndEvents.push(cardId);
-        }
+        SpellmasonsAPI.Unit.addEvent(unit, cardId);
         unit.attackRange = 0;
     });
 }

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Regen.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Regen.ts
@@ -28,7 +28,6 @@ const spell: Spell = {
         thumbnail: 'spellmasons-mods/Wodes_Grimoire/graphics/icons/spelliconRegen.png',
         sfx: 'heal', //TODO
         description: [`Heals the target for 10 health at the end of their turn for 5 turns. Stacks increase the amount and refresh the duration.`],
-        timeoutMs: 20,
         effect: async (state, card, quantity, underworld, prediction) => {
             //Only filter unit thats are alive
             const targets = state.targetedUnits.filter(u => u.alive);
@@ -83,10 +82,7 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity:
     const modifier = cardsUtil.getOrInitModifier(unit, cardId, {
         isCurse: false, quantity, persistBetweenLevels: false,
     }, () => {
-        //Register onTurnEndEvents
-        if (!unit.onTurnEndEvents.includes(cardId)) {
-            unit.onTurnEndEvents.push(cardId);
-        }
+        SpellmasonsAPI.Unit.addEvent(unit, cardId);
     });
     if (modifier.quantity > 5) {
         modifier.quantity = 5; //All casts give 5 turns, the max duration. When over 5, a new cast was done so update stacks

--- a/public/spellmasons-mods/Wodes_Grimoire/cards/Vengeance.ts
+++ b/public/spellmasons-mods/Wodes_Grimoire/cards/Vengeance.ts
@@ -26,7 +26,6 @@ const spell: Spell = {
         thumbnail: 'spellmasons-mods/Wodes_Grimoire/graphics/icons/spelliconVengeance.png',
         sfx: 'hurt',
         description: [`Deals damage equal to your missing health. This harms you first if you are targeted, then enemies.`],
-        timeoutMs: 840,
         effect: async (state, card, quantity, underworld, prediction) => {
             let promises: any[] = [];
             //Living units

--- a/public/spellmasons-mods/build/SpellmasonsMods.cjs.js
+++ b/public/spellmasons-mods/build/SpellmasonsMods.cjs.js
@@ -145,9 +145,7 @@ function add$6(unit, _underworld, _prediction, quantity) {
     quantity,
     persistBetweenLevels: false
   }, () => {
-    if (!unit.onTurnStartEvents.includes(cardId$e)) {
-      unit.onTurnStartEvents.push(cardId$e);
-    }
+    SpellmasonsAPI.Unit.addEvent(unit, cardId$e);
   });
 }
 const {
@@ -250,9 +248,7 @@ function add$5(unit, underworld, prediction, quantity) {
     persistBetweenLevels: false,
     originalstat: unit.staminaMax
   }, () => {
-    if (!unit.onTurnEndEvents.includes(cardId$c)) {
-      unit.onTurnEndEvents.push(cardId$c);
-    }
+    SpellmasonsAPI.Unit.addEvent(unit, cardId$c);
     unit.stamina = 0;
     unit.staminaMax = 0;
   });
@@ -319,8 +315,8 @@ const spell$b = {
   }
 };
 async function procEvents(unit, underworld, prediction) {
-  for (let i = 0; i < unit.onTurnStartEvents.length; i++) {
-    const eventName = unit.onTurnStartEvents[i];
+  for (let i = 0; i < unit.events.length; i++) {
+    const eventName = unit.events[i];
     if (eventName) {
       const fns = Events.default.onTurnStartSource[eventName];
       if (fns) {
@@ -328,8 +324,8 @@ async function procEvents(unit, underworld, prediction) {
       }
     }
   }
-  for (let i = 0; i < unit.onTurnEndEvents.length; i++) {
-    const eventName = unit.onTurnEndEvents[i];
+  for (let i = 0; i < unit.events.length; i++) {
+    const eventName = unit.events[i];
     if (eventName) {
       const fne = Events.default.onTurnEndSource[eventName];
       if (fne) {
@@ -555,9 +551,7 @@ function add$4(unit, underworld, prediction, quantity, extra) {
     quantity,
     persistBetweenLevels: false
   }, () => {
-    if (!unit.onTurnStartEvents.includes(cardId$9)) {
-      unit.onTurnStartEvents.push(cardId$9);
-    }
+    SpellmasonsAPI.Unit.addEvent(unit, cardId$9);
   });
   if (!modifier.graceCountdown) {
     modifier.graceCountdown = 3;
@@ -716,9 +710,7 @@ function add$3(unit, underworld, prediction, quantity, extra) {
     quantity,
     persistBetweenLevels: false
   }, () => {
-    if (!unit.onTurnEndEvents.includes(cardId$7)) {
-      unit.onTurnEndEvents.push(cardId$7);
-    }
+    SpellmasonsAPI.Unit.addEvent(unit, cardId$7);
   });
   if (modifier.quantity > 5) {
     modifier.quantity = 5;
@@ -802,9 +794,7 @@ function add$2(unit, underworld, prediction, quantity) {
     persistBetweenLevels: false,
     originalstat: unit.attackRange
   }, () => {
-    if (!unit.onTurnEndEvents.includes(cardId$6)) {
-      unit.onTurnEndEvents.push(cardId$6);
-    }
+    SpellmasonsAPI.Unit.addEvent(unit, cardId$6);
     unit.attackRange = 0;
   });
 }
@@ -1204,9 +1194,7 @@ function add$1(unit, underworld, prediction, quantity) {
     quantity,
     persistBetweenLevels: false
   }, () => {
-    if (!unit.onTurnStartEvents.includes(cardId$1)) {
-      unit.onTurnStartEvents.push(cardId$1);
-    }
+    SpellmasonsAPI.Unit.addEvent(unit, cardId$1);
     makeBurningRageParticles(unit, underworld, prediction);
   });
 }
@@ -1277,16 +1265,14 @@ const spell = {
   }
 };
 function add(unit, _underworld, prediction, quantity, extra) {
-  let firstStack = !unit.onTurnStartEvents.includes(cardId);
+  let firstStack = !unit.events.includes(cardId);
   const modifier = cardsUtil.getOrInitModifier(unit, cardId, {
     isCurse: false,
     quantity,
     persistBetweenLevels: false
   }, () => {
     if (firstStack) {
-      unit.onTurnEndEvents.push(cardId);
-      unit.onTurnStartEvents.push(cardId);
-      unit.onTakeDamageEvents.push(cardId);
+      SpellmasonsAPI.Unit.addEvent(unit, cardId);
     }
   });
   if (firstStack) {

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -48,7 +48,7 @@ export type onDrawSelected = {
 };
 const onDrawSelectedSource: { [name: string]: onDrawSelected } = {};
 
-export type onProjectileCollision = ({ unit, pickup, underworld, prediction }: { unit?: IUnit, pickup?: IPickup, projectile: ForceMoveProjectile, underworld: Underworld, prediction: boolean }) => void;
+export type onProjectileCollision = ({ unit, pickup, projectile, underworld, prediction }: { unit?: IUnit, pickup?: IPickup, projectile: ForceMoveProjectile, underworld: Underworld, prediction: boolean }) => void;
 const onProjectileCollisionSource: { [name: string]: onProjectileCollision } = {};
 
 export default {

--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -4389,7 +4389,7 @@ async function introduceBoss(unit: UnitSource, underworld: Underworld) {
     // because we only want to add it in this special case/boss sequence
     // and not any other time (I.E. admin/player summoned Deathmasons)
     if (newBossUnitInstance.unitSourceId == bossmasonUnitId) {
-      newBossUnitInstance.onDeathEvents.push(ORIGINAL_DEATHMASON_DEATH);
+      Unit.addEvent(newBossUnitInstance, ORIGINAL_DEATHMASON_DEATH);
     }
   } else {
     console.error("Failed to spawn newBossUnitInstance for id: ", unit.id);

--- a/src/cards/bloat.ts
+++ b/src/cards/bloat.ts
@@ -18,14 +18,7 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity:
   const modifier = getOrInitModifier(unit, id, {
     isCurse: true, quantity,
   }, () => {
-    // Add event
-    if (!unit.onDeathEvents.includes(id)) {
-      unit.onDeathEvents.push(id);
-    }
-    // Add event
-    if (!unit.onDrawSelectedEvents.includes(id)) {
-      unit.onDrawSelectedEvents.push(id);
-    }
+    Unit.addEvent(unit, id);
 
     // Visually "bloat" the image
     addScaleModifier(unit.image, { x: 1.5, id }, unit.strength);

--- a/src/cards/blood_curse.ts
+++ b/src/cards/blood_curse.ts
@@ -25,9 +25,8 @@ function add(unit: IUnit, underworld: Underworld, prediction: boolean) {
     return;
   }
 
-  const modifier = getOrInitModifier(unit, id, { isCurse: true, quantity: 1 }, () => {
-    // Add event
-    unit.onTakeDamageEvents.push(id);
+  getOrInitModifier(unit, id, { isCurse: true, quantity: 1 }, () => {
+    Unit.addEvent(unit, id);
 
     unit.healthMax *= healthMultiplier;
     unit.health *= healthMultiplier;

--- a/src/cards/conserve.ts
+++ b/src/cards/conserve.ts
@@ -69,9 +69,7 @@ const spell: Spell = {
 
 function add(unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, quantity: number = 1) {
   getOrInitModifier(unit, conserveSpellId, { isCurse: false, quantity }, () => {
-    if (!unit.onTurnStartEvents.includes(conserveSpellId)) {
-      unit.onTurnStartEvents.push(conserveSpellId);
-    }
+    Unit.addEvent(unit, conserveSpellId);
   });
 }
 

--- a/src/cards/dark_tide.ts
+++ b/src/cards/dark_tide.ts
@@ -59,8 +59,8 @@ const spell: Spell = {
 };
 
 function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, quantity: number = 1) {
-  const modifier = getOrInitModifier(unit, darkTideId, { isCurse: true, quantity }, () => {
-    unit.onTurnEndEvents.push(darkTideId);
+  getOrInitModifier(unit, darkTideId, { isCurse: true, quantity }, () => {
+    Unit.addEvent(unit, darkTideId);
   });
 }
 export default spell;

--- a/src/cards/debilitate.ts
+++ b/src/cards/debilitate.ts
@@ -54,8 +54,8 @@ const spell: Spell = {
 };
 
 function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, quantity: number = 1) {
-  const modifier = getOrInitModifier(unit, id, { isCurse: true, quantity }, () => {
-    unit.onTakeDamageEvents.push(id);
+  getOrInitModifier(unit, id, { isCurse: true, quantity }, () => {
+    Unit.addEvent(unit, id);
   });
 }
 export default spell;

--- a/src/cards/fortify.ts
+++ b/src/cards/fortify.ts
@@ -102,10 +102,8 @@ const spell: Spell = {
 };
 
 function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, quantity: number = 1) {
-  const modifier = getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
-    // Add event
-    unit.onTakeDamageEvents.push(id);
-    unit.onTurnStartEvents.push(id);
+  getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
+    Unit.addEvent(unit, id);
     // Add subsprite image
     const animatedFortifySprite = Image.addSubSprite(unit.image, modifierImagePath);
     if (animatedFortifySprite) {

--- a/src/cards/freeze.ts
+++ b/src/cards/freeze.ts
@@ -28,7 +28,7 @@ const spell: Spell = {
     description: ['spell_freeze', immuneForTurns.toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       // .filter: only target living units
-      const targets = state.targetedUnits.filter(u => u.alive && !u.onTurnEndEvents.includes(freezeCardId));
+      const targets = state.targetedUnits.filter(u => u.alive && !u.events.includes(freezeCardId));
       if (targets.length) {
         let spellAnimationPromise = Promise.resolve();
         targets.forEach(t => {
@@ -91,10 +91,7 @@ function updateTooltip(unit: Unit.IUnit, quantity: number, prediction: boolean) 
 function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean) {
   getOrInitModifier(unit, freezeCardId, { isCurse: true, quantity: 1 }, () => {
     unit.radius = config.COLLISION_MESH_RADIUS;
-    // Add event
-    if (!unit.onTurnEndEvents.includes(freezeCardId)) {
-      unit.onTurnEndEvents.push(freezeCardId);
-    }
+    Unit.addEvent(unit, freezeCardId);
     addModifierVisuals(unit, underworld, prediction);
 
     // Prevents units from being pushed out of the way and units

--- a/src/cards/lastwill.ts
+++ b/src/cards/lastwill.ts
@@ -13,11 +13,8 @@ import { getOrInitModifier } from './util';
 export const id = 'Last Will';
 const imageName = 'unknown.png';
 function add(unit: IUnit, underworld: Underworld, prediction: boolean, quantity: number) {
-  const modifier = getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
-    // Add event
-    if (!unit.onDeathEvents.includes(id)) {
-      unit.onDeathEvents.push(id);
-    }
+  getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
+    Unit.addEvent(unit, id);
   });
 }
 function remove(unit: IUnit, underworld: Underworld) {

--- a/src/cards/poison.ts
+++ b/src/cards/poison.ts
@@ -30,10 +30,7 @@ function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld, prediction
 }
 function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1, extra?: { [key: string]: any }) {
   const modifier = getOrInitModifier(unit, poisonCardId, { isCurse: true, quantity }, () => {
-    // Add event
-    if (!unit.onTurnEndEvents.includes(poisonCardId)) {
-      unit.onTurnEndEvents.push(poisonCardId);
-    }
+    Unit.addEvent(unit, poisonCardId);
     // Add subsprite image
     if (!prediction) {
       if (spell.modifiers?.subsprite) {

--- a/src/cards/shield.ts
+++ b/src/cards/shield.ts
@@ -106,8 +106,7 @@ function updateTooltip(unit: Unit.IUnit) {
 
 function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, quantity: number = 1) {
   const modifier = getOrInitModifier(unit, id, { isCurse: false, quantity }, () => {
-    // Add event
-    unit.onTakeDamageEvents.push(id);
+    Unit.addEvent(unit, id);
     // Add subsprite image
     Image.addSubSprite(unit.image, modifierImagePath);
   });

--- a/src/cards/soul_bind.ts
+++ b/src/cards/soul_bind.ts
@@ -50,9 +50,9 @@ const spell: Spell = {
       for (let i = 0; i < units.length; i++) {
         const unit = units[i];
         if (unit) {
-          const index = unit.onTakeDamageEvents.findIndex(e => e == soulBindId);
+          const index = unit.events.findIndex(e => e == soulBindId);
           // Remove Soul Bind damage event to prevent infinite loop
-          unit.onTakeDamageEvents.splice(index, 1);
+          unit.events.splice(index, 1);
           // Deal damage to unit
           Unit.takeDamage({
             unit: unit,
@@ -60,7 +60,7 @@ const spell: Spell = {
           }, underworld, prediction);
           // Return Soul Bind damage event if the unit is not dead
           if (unit.alive) {
-            unit.onTakeDamageEvents.splice(index, 0, soulBindId);
+            unit.events.splice(index, 0, soulBindId);
           }
         }
       }
@@ -88,8 +88,7 @@ const spell: Spell = {
 
 function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, quantity: number = 1) {
   getOrInitModifier(unit, soulBindId, { isCurse: true, quantity }, () => {
-    unit.onTakeDamageEvents.push(soulBindId);
-    unit.onDrawSelectedEvents.push(soulBindId);
+    Unit.addEvent(unit, soulBindId);
   });
 }
 export default spell;

--- a/src/cards/soul_shard.ts
+++ b/src/cards/soul_shard.ts
@@ -121,8 +121,7 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
   }
 
   const modifier = getOrInitModifier(unit, soulShardId, { isCurse: true, quantity }, () => {
-    unit.onTakeDamageEvents.push(soulShardId);
-    unit.onDrawSelectedEvents.push(soulShardId);
+    Unit.addEvent(unit, soulShardId);
   });
 
   if (modifier.shardOwnerId != extra.shardOwnerId) {

--- a/src/cards/suffocate.ts
+++ b/src/cards/suffocate.ts
@@ -14,10 +14,7 @@ import { buildMatchMemberExpression } from '@babel/types';
 export const suffocateCardId = 'suffocate';
 function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) {
   const modifier = getOrInitModifier(unit, suffocateCardId, { isCurse: true, quantity }, () => {
-    // Add event
-    if (!unit.onTurnEndEvents.includes(suffocateCardId)) {
-      unit.onTurnEndEvents.push(suffocateCardId);
-    }
+    Unit.addEvent(unit, suffocateCardId);
     // Add subsprite image
     if (!prediction) {
       if (spell.modifiers?.subsprite) {

--- a/src/entity/units/urn_explosive.ts
+++ b/src/entity/units/urn_explosive.ts
@@ -43,9 +43,7 @@ const unit: UnitSource = {
   },
   // Warning: init must be idempotent
   init: (unit: Unit.IUnit, underworld: Underworld) => {
-    if (!unit.onDeathEvents.includes(urnexplosiveExplode)) {
-      unit.onDeathEvents.push(urnexplosiveExplode);
-    }
+    Unit.addEvent(unit, urnexplosiveExplode);
   },
   action: async (unit: Unit.IUnit, attackTargets: Unit.IUnit[] | undefined, underworld: Underworld, canAttackTarget: boolean) => {
   },

--- a/src/entity/units/urn_ice.ts
+++ b/src/entity/units/urn_ice.ts
@@ -40,9 +40,7 @@ const unit: UnitSource = {
   },
   // Warning: init must be idempotent
   init: (unit: Unit.IUnit, underworld: Underworld) => {
-    if (!unit.onDeathEvents.includes(urnIceExplode)) {
-      unit.onDeathEvents.push(urnIceExplode);
-    }
+    Unit.addEvent(unit, urnIceExplode);
   },
   action: async (unit: Unit.IUnit, attackTargets: Unit.IUnit[] | undefined, underworld: Underworld, canAttackTarget: boolean) => {
   },

--- a/src/entity/units/urn_poison.ts
+++ b/src/entity/units/urn_poison.ts
@@ -41,9 +41,7 @@ const urnPoisonSource: UnitSource = {
   },
   // Warning: init must be idempotent
   init: (unit: Unit.IUnit, underworld: Underworld) => {
-    if (!unit.onDeathEvents.includes(urnpoisonExplode)) {
-      unit.onDeathEvents.push(urnpoisonExplode);
-    }
+    Unit.addEvent(unit, urnpoisonExplode);
   },
   action: async (unit: Unit.IUnit, attackTargets: Unit.IUnit[] | undefined, underworld: Underworld, canAttackTarget: boolean) => {
   },

--- a/src/modifierCorpseDecay.ts
+++ b/src/modifierCorpseDecay.ts
@@ -15,10 +15,7 @@ export default function registerCorpseDecay() {
       if (unit.unitType == UnitType.PLAYER_CONTROLLED || unit.alive) return;
 
       const modifier = getOrInitModifier(unit, corpseDecayId, { isCurse: true, quantity }, () => {
-        // Add event
-        if (!unit.onTurnEndEvents.includes(corpseDecayId)) {
-          unit.onTurnEndEvents.push(corpseDecayId);
-        }
+        Unit.addEvent(unit, corpseDecayId);
       });
       modifier.turnsLeftToLive = 1;
 

--- a/src/modifierImpendingDoom.ts
+++ b/src/modifierImpendingDoom.ts
@@ -11,9 +11,7 @@ export default function registerImpendingDoom() {
   registerModifiers(impendingDoomId, {
     add: (unit: Unit.IUnit, underworld: Underworld, _prediction: boolean, quantity: number = 1) => {
       getOrInitModifier(unit, impendingDoomId, { isCurse: true, quantity }, () => {
-        if (!unit.onTurnEndEvents.includes(impendingDoomId)) {
-          unit.onTurnEndEvents.push(impendingDoomId);
-        }
+        Unit.addEvent(unit, impendingDoomId);
       });
       updateTooltip(unit);
     }

--- a/src/modifierPrimedCorpse.ts
+++ b/src/modifierPrimedCorpse.ts
@@ -14,10 +14,7 @@ export default function registerPrimedCorpse() {
     addModifierVisuals: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean) => initCorpsePrimed(unit, underworld, prediction),
     add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
       const modifier = getOrInitModifier(unit, primedCorpseId, { isCurse: false, quantity, keepOnDeath: true }, () => {
-        // Add events
-        if (!unit.onDrawSelectedEvents.includes(primedCorpseId)) {
-          unit.onDrawSelectedEvents.push(primedCorpseId);
-        }
+        Unit.addEvent(unit, primedCorpseId);
         initCorpsePrimed(unit, underworld, prediction);
       });
 

--- a/src/modifierSlime.ts
+++ b/src/modifierSlime.ts
@@ -12,10 +12,7 @@ export default function registerSlime() {
     description: 'Causes a unit to split into two units every turn.',
     add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
       getOrInitModifier(unit, slimeId, { isCurse: false, quantity, keepOnDeath: true }, () => {
-        // Add events
-        if (!unit.onTurnEndEvents.includes(slimeId)) {
-          unit.onTurnEndEvents.push(slimeId);
-        }
+        Unit.addEvent(unit, slimeId);
       });
     },
   });

--- a/src/modifierSoulShardOwner.ts
+++ b/src/modifierSoulShardOwner.ts
@@ -20,13 +20,7 @@ export default function registerSoulShardOwner() {
   registerModifiers(soulShardOwnerModifierId, {
     add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
       getOrInitModifier(unit, soulShardOwnerModifierId, { isCurse: true, quantity, keepOnDeath: true }, () => {
-        // Add event
-        if (!unit.onTurnStartEvents.includes(soulShardOwnerModifierId)) {
-          unit.onTurnStartEvents.push(soulShardOwnerModifierId);
-        }
-        if (!unit.onDrawSelectedEvents.includes(soulShardOwnerModifierId)) {
-          unit.onDrawSelectedEvents.push(soulShardOwnerModifierId);
-        }
+        Unit.addEvent(unit, soulShardOwnerModifierId);
       });
     }
   });

--- a/src/modifierSummoningSickness.ts
+++ b/src/modifierSummoningSickness.ts
@@ -19,13 +19,7 @@ export default function registerSummoningSickness() {
       getOrInitModifier(unit, summoningSicknessId, { isCurse: true, quantity }, () => {
         // Immediately set stamina to 0 so they can't move
         unit.stamina = 0;
-        // Add event
-        if (!unit.onTurnStartEvents.includes(summoningSicknessId)) {
-          unit.onTurnStartEvents.push(summoningSicknessId);
-        }
-        if (!unit.onTurnEndEvents.includes(summoningSicknessId)) {
-          unit.onTurnEndEvents.push(summoningSicknessId);
-        }
+        Unit.addEvent(unit, summoningSicknessId);
       });
     }
   });

--- a/src/modifierTargetImmune.ts
+++ b/src/modifierTargetImmune.ts
@@ -15,11 +15,8 @@ export default function registerTargetImmune() {
     addModifierVisuals,
     add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
       getOrInitModifier(unit, targetImmuneId, { isCurse: false, quantity, keepOnDeath: true }, () => {
-        // Add events
-        if (!unit.onTurnEndEvents.includes(targetImmuneId)) {
-          unit.onTurnEndEvents.push(targetImmuneId);
-          addModifierVisuals(unit, underworld, prediction);
-        }
+        Unit.addEvent(unit, targetImmuneId);
+        addModifierVisuals(unit, underworld, prediction);
       });
     },
     subsprite: {

--- a/src/modifierUndying.ts
+++ b/src/modifierUndying.ts
@@ -14,10 +14,7 @@ export default function registerUndying() {
   registerModifiers(undyingModifierId, {
     add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
       getOrInitModifier(unit, undyingModifierId, { isCurse: false, quantity, keepOnDeath: true }, () => {
-        // Add event
-        if (!unit.onTurnStartEvents.includes(undyingModifierId)) {
-          unit.onTurnStartEvents.push(undyingModifierId);
-        }
+        Unit.addEvent(unit, undyingModifierId);
       });
     }
   });


### PR DESCRIPTION
ref: Collect all events in a single array
    
    This removes several footguns that occurred when
    adding a new type of event.
    Much less boilerplate now that all events are handled in
    the same array and since it always has to check the eventSource
    in order to invoke the function it is okay that different
    event types are stored in the same array.
    
    One potential (I think unrealized) problem with this approach
    is if some modifier needs to selectively remove one event type
    but not another - however this can now just be done with
    different event ids. And I don't think this currently happens in the
    codebase so I don't see it as a problem.
    
    This commit paves the way for Runes which will be very event heavy
    and will add lots of new event source types.