### PR TITLE
Souls as a Resource

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -107,8 +107,6 @@ import { slashCardId } from './cards/slash';
 import { pushId } from './cards/push';
 import { test_endCheckPromises, test_startCheckPromises } from './promiseSpy';
 import { targetCursedId } from './cards/target_curse';
-import { splitId } from './cards/split';
-import { soulShardId } from './cards/soul_shard';
 
 const loopCountLimit = 10000;
 export enum turn_phase {
@@ -3852,7 +3850,7 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
             const singleCardCost = calculateCostForSingleCard(card, timesUsedSoFar, casterPlayer);
             spellCostTally.manaCost += singleCardCost.manaCost;
             spellCostTally.healthCost += singleCardCost.healthCost;
-            if (card.category == CardCategory.Soul || [splitId, soulShardId].includes(card.id)) {
+            if (card.category == CardCategory.Soul) {
               spellCostTally.souls += 1
             }
           }

--- a/src/cards/purify.ts
+++ b/src/cards/purify.ts
@@ -5,6 +5,7 @@ import { CardCategory } from '../types/commonTypes';
 import { playDefaultSpellAnimation, playDefaultSpellSFX } from './cardUtils';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import * as Pickup from '../entity/Pickup';
+import { splitId } from './split';
 
 
 export const purifyCardId = 'purify';
@@ -42,7 +43,7 @@ const spell: Spell = {
 export function apply(unit: Unit.IUnit, underworld: Underworld) {
 
   for (let [modifier, modifierProperties] of Object.entries(unit.modifiers)) {
-    if (modifierProperties.isCurse) {
+    if (modifierProperties.isCurse || [splitId].includes(modifier)) {
       Unit.removeModifier(unit, modifier, underworld);
     }
   }

--- a/src/cards/soul_shard.ts
+++ b/src/cards/soul_shard.ts
@@ -18,7 +18,7 @@ export const soulShardId = 'Soul Shard';
 const spell: Spell = {
   card: {
     id: soulShardId,
-    category: CardCategory.Curses,
+    category: CardCategory.Soul,
     sfx: 'sacrifice',
     supportQuantity: false,
     manaCost: 60,

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -102,7 +102,7 @@ function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quan
 const spell: Spell = {
   card: {
     id: splitId,
-    category: CardCategory.Curses,
+    category: CardCategory.Soul,
     manaCost: 80,
     healthCost: 0,
     probability: probabilityMap[CardRarity.FORBIDDEN],

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -324,6 +324,7 @@ export function resetPlayerForNextLevel(player: IPlayer, underworld: Underworld)
     }
   }
 
+  player.unit.souls = player.mageType == 'Necromancer' ? 3 : 0;
   Unit.resetUnitStats(player.unit, underworld);
   Unit.syncPlayerHealthManaUI(underworld);
 }

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -49,6 +49,7 @@ import { darkTideId } from '../cards/dark_tide';
 import { GORU_UNIT_ID } from './units/goru';
 import { undyingModifierId } from '../modifierUndying';
 import { primedCorpseId } from '../modifierPrimedCorpse';
+import { makeManaTrail } from '../graphics/Particles';
 
 const elCautionBox = document.querySelector('#caution-box') as HTMLElement;
 const elCautionBoxText = document.querySelector('#caution-box-text') as HTMLElement;
@@ -140,6 +141,8 @@ export type IUnit = HasSpace & HasLife & HasMana & HasStamina & {
   modifiers: { [key: string]: Modifier };
   // Used for more intelligent AI battles so many unit don't overkill a single unit and leave a bunch of others untouched
   predictedNextTurnDamage: number;
+  // A resource used for powerful "soul" spells
+  souls: number;
 }
 // This does not need to be unique to underworld, it just needs to be unique
 let lastPredictionUnitId = 0;
@@ -207,7 +210,8 @@ export function create(
       inLiquid: false,
       UITargetCircleOffsetY: -10,
       beingPushed: false,
-      predictedNextTurnDamage: 0
+      predictedNextTurnDamage: 0,
+      souls: 0,
     }, sourceUnitProps);
 
     if (unit.image && !unit.image.sprite.filters) {
@@ -854,6 +858,11 @@ export function die(unit: IUnit, underworld: Underworld, prediction: boolean) {
 
   if (!prediction && unit.originalLife && unit.faction !== globalThis.player?.unit.faction) {
     underworld.reportEnemyKilled(unit);
+    // Give 1 soul to each player
+    underworld.players.forEach(p => {
+      makeManaTrail(unit, p.unit, underworld, colors.convertToHashColor(colors.trueWhite), colors.convertToHashColor(colors.manaBrightBlue), 1);
+      p.unit.souls++;
+    });
   }
   if (unit.originalLife && unit.faction == Faction.ENEMY) {
     // Reset kill switch since the allies are making progress

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -889,6 +889,7 @@ ${globalThis.selectedUnit.faction == Faction.ALLY ? '🤝' : '⚔️️'} ${i18n
 🎯 ${globalThis.selectedUnit.attackRange} ${i18n(['attack range'])}` : ''}
 ❤️ ${globalThis.selectedUnit.health}/${globalThis.selectedUnit.healthMax} ${i18n(['health capacity'])}
 🔵 ${globalThis.selectedUnit.mana}/${globalThis.selectedUnit.manaMax} + ${globalThis.selectedUnit.manaPerTurn} ${i18n('Mana')} ${i18n('per turn')}
+👻 ${globalThis.selectedUnit.souls} ${i18n('Souls')}
 ${extraText}
 ${playerSpecificInfo}
       `;

--- a/src/graphics/ui/CardUI.ts
+++ b/src/graphics/ui/CardUI.ts
@@ -605,7 +605,6 @@ async function selectCard(player: Player.IPlayer, element: HTMLElement, cardId: 
         })
         explain(EXPLAIN_END_TURN);
         deselectLastCard(underworld);
-
       }
 
       if (predictionPlayerUnit.health < 0) {
@@ -615,7 +614,15 @@ async function selectCard(player: Player.IPlayer, element: HTMLElement, cardId: 
           style: { fill: colors.errorRed, fontSize: '50px', ...config.PIXI_TEXT_DROP_SHADOW }
         })
         deselectLastCard(underworld);
+      }
 
+      if (predictionPlayerUnit.souls < 0) {
+        floatingText({
+          coords: underworld.getMousePos(),
+          text: 'Insufficient Souls',
+          style: { fill: colors.errorRed, fontSize: '50px', ...config.PIXI_TEXT_DROP_SHADOW }
+        })
+        deselectLastCard(underworld);
       }
     } else {
       console.warn('Unexpected: predictionPlayerUnit is undefined');


### PR DESCRIPTION
#759 

### PROTOTYPE - FOR TESTING ONLY

- Adds a new resource called "Souls"
- Spells in the soul category cost 1 soul per quantity, in addition to their mana cost
- Players can acquire souls by killing originalLife units
- Souls are currently displayed in the selected unit info panel
- Start each level with 0 souls (Necromancer starts each level with 3 souls instead)

## TODO
- Test and discuss