### PR TITLE
Add Shield Regen

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -891,7 +891,7 @@ export default class Underworld {
         Unit.syncImage(u)
         drawHealthBarAboveHead(i, this, zoom);
         // Animate shield modifier sprites
-        if ((u.modifiers[shield.id] || u.modifiers[fortify.id] || u.modifiers[immune.id]) && u.image) {
+        if ((u.modifiers[shield.shieldId] || u.modifiers[fortify.id] || u.modifiers[immune.id]) && u.image) {
           // @ts-ignore: imagePath is a property that i've added and is not a part of the PIXI type
           // which is used for identifying the sprite or animation that is currently active
           const modifierSprite = u.image.sprite.children.find(c => c.imagePath == shield.modifierImagePath)

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -136,6 +136,7 @@ import registerPrimedCorpse from '../modifierPrimedCorpse';
 import registerSlime from '../modifierSlime';
 import registerTargetImmune, { targetImmuneId } from '../modifierTargetImmune';
 import registerGrowth from '../modifierGrowth';
+import registerShieldRegen from '../modifierShieldRegen';
 
 export interface Modifiers {
   subsprite?: Subsprite;
@@ -379,6 +380,8 @@ export function registerCards(overworld: Overworld) {
   registerUrnPoisonExplode();
   registerUrnExplosiveExplode();
   registerDeathmasonEvents();
+
+  registerShieldRegen();
 }
 
 // This is necessary because unit stats change with difficulty.

--- a/src/cards/shield.ts
+++ b/src/cards/shield.ts
@@ -39,7 +39,7 @@ const spell: Spell = {
         // Add the modifier after the animation so that the subsprite doesn't get added until after the animation is
         // complete
         for (let unit of targets) {
-          Unit.addModifier(unit, shieldId, underworld, prediction, shieldToAdd);
+          Unit.addModifier(unit, shieldId, underworld, prediction, shieldToAdd * quantity);
         }
       }
 

--- a/src/modifierShieldRegen.ts
+++ b/src/modifierShieldRegen.ts
@@ -8,6 +8,7 @@ import Underworld from './Underworld';
 export const shieldRegenId = 'Shield Regen';
 export default function registerShieldRegen() {
   registerModifiers(shieldRegenId, {
+    description: 'shield regen',
     add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
       getOrInitModifier(unit, shieldRegenId, { isCurse: false, quantity, keepOnDeath: true }, () => {
         Unit.addEvent(unit, shieldRegenId);

--- a/src/modifierShieldRegen.ts
+++ b/src/modifierShieldRegen.ts
@@ -4,6 +4,7 @@ import { getOrInitModifier } from "./cards/util";
 import * as Unit from './entity/Unit';
 import Underworld from './Underworld';
 
+// Regenerates (quantity) shield at the start of each turn
 export const shieldRegenId = 'Shield Regen';
 export default function registerShieldRegen() {
   registerModifiers(shieldRegenId, {

--- a/src/modifierShieldRegen.ts
+++ b/src/modifierShieldRegen.ts
@@ -1,0 +1,36 @@
+import { registerEvents, registerModifiers } from "./cards";
+import { shieldId } from "./cards/shield";
+import { getOrInitModifier } from "./cards/util";
+import * as Unit from './entity/Unit';
+import Underworld from './Underworld';
+
+export const shieldRegenId = 'Shield Regen';
+export default function registerShieldRegen() {
+  registerModifiers(shieldRegenId, {
+    add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
+      getOrInitModifier(unit, shieldRegenId, { isCurse: false, quantity, keepOnDeath: true }, () => {
+        Unit.addEvent(unit, shieldRegenId);
+      });
+
+      if (!prediction) {
+        updateTooltip(unit);
+      }
+    }
+  });
+  registerEvents(shieldRegenId, {
+    onTurnStart: async (unit: Unit.IUnit, underworld: Underworld, prediction: boolean) => {
+      const modifier = unit.modifiers[shieldRegenId];
+      if (modifier) {
+        Unit.addModifier(unit, shieldId, underworld, prediction, modifier.quantity);
+      }
+    }
+  });
+}
+
+function updateTooltip(unit: Unit.IUnit) {
+  const modifier = unit.modifiers[shieldRegenId];
+  if (modifier) {
+    // Set tooltip:
+    modifier.tooltip = `${modifier.quantity} ${i18n('Shield')} ${i18n('Regen')}`
+  }
+}


### PR DESCRIPTION
New Rune/Modifier:

Shield Regen
Regenerates (quantity) shield at the start of each turn

- This PR also makes some changes to how the Shield modifier works: 1 stack/quantity of shield now = 1 damage blocked instead of 30, and the spell has been changed to account for that, now adding 30 quantity per cast

## TODO
- Done