### PR TITLE
Add Revitalize

### DIFF
--- a/src/cards/debilitate.ts
+++ b/src/cards/debilitate.ts
@@ -9,7 +9,7 @@ import { getOrInitModifier } from './util';
 
 const id = 'Debilitate';
 const imageName = 'spellIconDebilitate.png';
-const proportion = 2;
+const percentDamageIncrease = 100;
 const spell: Spell = {
   card: {
     id,
@@ -22,7 +22,7 @@ const spell: Spell = {
     probability: probabilityMap[CardRarity.UNCOMMON],
     thumbnail: 'spellIconDebilitate.png',
     animationPath: 'spell-effects/spellDebilitate',
-    description: ['spell_debilitate', (proportion * 100).toString()],
+    description: ['spell_debilitate', percentDamageIncrease.toString()],
     effect: async (state, card, quantity, underworld, prediction) => {
       // .filter: only target living units
       const targets = state.targetedUnits.filter(u => u.alive);
@@ -30,7 +30,7 @@ const spell: Spell = {
         playDefaultSpellSFX(card, prediction);
         await playDefaultSpellAnimation(card, targets, prediction);
         for (let unit of targets) {
-          Unit.addModifier(unit, id, underworld, prediction, quantity);
+          Unit.addModifier(unit, id, underworld, prediction, 100);
         }
       }
       return state;
@@ -41,14 +41,16 @@ const spell: Spell = {
   },
   events: {
     onTakeDamage: (unit, amount, _underworld, damageDealer) => {
-      const quantity = unit.modifiers[id]?.quantity || 1;
-      // Magnify positive damage
-      if (amount > 0) {
-        return amount * proportion * quantity;
-      } else {
-        // Do not magnify negative damage (which is healing)
-        return amount;
+      const modifier = unit.modifiers[id];
+      if (modifier) {
+        // Will only increase damage (doesn't affect incoming healing)
+        if (amount > 0) {
+          // Each quantity = 1% damage boost
+          amount = Math.floor(amount * CalcMult(modifier.quantity));
+        }
       }
+
+      return amount;
     },
   },
 };
@@ -57,5 +59,20 @@ function add(unit: Unit.IUnit, _underworld: Underworld, _prediction: boolean, qu
   getOrInitModifier(unit, id, { isCurse: true, quantity }, () => {
     Unit.addEvent(unit, id);
   });
+
+  updateTooltip(unit);
+}
+
+function updateTooltip(unit: Unit.IUnit) {
+  const modifier = unit.modifiers[id];
+  if (modifier) {
+    // Set tooltip:
+    modifier.tooltip = `${CalcMult(modifier.quantity)}x ${i18n('Incoming')} ${i18n('Damage')}`;
+  }
+}
+
+function CalcMult(quantity: number): number {
+  // Each Quantity = 1% damage boost
+  return 1 + (quantity / 100);
 }
 export default spell;

--- a/src/cards/debilitate.ts
+++ b/src/cards/debilitate.ts
@@ -30,7 +30,7 @@ const spell: Spell = {
         playDefaultSpellSFX(card, prediction);
         await playDefaultSpellAnimation(card, targets, prediction);
         for (let unit of targets) {
-          Unit.addModifier(unit, id, underworld, prediction, 100);
+          Unit.addModifier(unit, id, underworld, prediction, percentDamageIncrease * quantity);
         }
       }
       return state;

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -136,6 +136,7 @@ import registerPrimedCorpse from '../modifierPrimedCorpse';
 import registerSlime from '../modifierSlime';
 import registerTargetImmune, { targetImmuneId } from '../modifierTargetImmune';
 import registerGrowth from '../modifierGrowth';
+import registerRevitalize from '../modifierRevitalize';
 
 export interface Modifiers {
   subsprite?: Subsprite;
@@ -379,6 +380,8 @@ export function registerCards(overworld: Overworld) {
   registerUrnPoisonExplode();
   registerUrnExplosiveExplode();
   registerDeathmasonEvents();
+
+  registerRevitalize();
 }
 
 // This is necessary because unit stats change with difficulty.

--- a/src/modifierRevitalize.ts
+++ b/src/modifierRevitalize.ts
@@ -1,0 +1,46 @@
+import { registerEvents, registerModifiers } from "./cards";
+import { getOrInitModifier } from "./cards/util";
+import * as Unit from './entity/Unit';
+import Underworld from './Underworld';
+
+export const revitalizeId = 'Revitalize';
+export default function registerRevitalize() {
+  registerModifiers(revitalizeId, {
+    add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
+      getOrInitModifier(unit, revitalizeId, { isCurse: false, quantity, keepOnDeath: true }, () => {
+        Unit.addEvent(unit, revitalizeId);
+      });
+
+      if (!prediction) {
+        updateTooltip(unit);
+      }
+    }
+  });
+  registerEvents(revitalizeId, {
+    onTakeDamage: (unit: Unit.IUnit, amount: number, underworld: Underworld, prediction: boolean, damageDealer?: Unit.IUnit) => {
+      const modifier = unit.modifiers[revitalizeId];
+      if (modifier) {
+        // Will only increase healing (doesn't affect incoming damage)
+        if (amount < 0) {
+          // Each quantity = 1% healing boost
+          amount = Math.ceil(amount * CalcMult(modifier.quantity));
+        }
+      }
+
+      return amount;
+    }
+  });
+}
+
+function updateTooltip(unit: Unit.IUnit) {
+  const modifier = unit.modifiers[revitalizeId];
+  if (modifier) {
+    // Set tooltip:
+    modifier.tooltip = `${CalcMult(modifier.quantity)}x ${i18n('Incoming')} ${i18n('Healing')}`;
+  }
+}
+
+function CalcMult(quantity: number): number {
+  // Each Quantity = 1% healing boost
+  return 1 + (quantity / 100);
+}

--- a/src/modifierRevitalize.ts
+++ b/src/modifierRevitalize.ts
@@ -7,6 +7,7 @@ import Underworld from './Underworld';
 export const revitalizeId = 'Revitalize';
 export default function registerRevitalize() {
   registerModifiers(revitalizeId, {
+    description: 'revitalize description',
     add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
       getOrInitModifier(unit, revitalizeId, { isCurse: false, quantity, keepOnDeath: true }, () => {
         Unit.addEvent(unit, revitalizeId);

--- a/src/modifierRevitalize.ts
+++ b/src/modifierRevitalize.ts
@@ -3,6 +3,7 @@ import { getOrInitModifier } from "./cards/util";
 import * as Unit from './entity/Unit';
 import Underworld from './Underworld';
 
+// Increases incoming healing by (quantity)%
 export const revitalizeId = 'Revitalize';
 export default function registerRevitalize() {
   registerModifiers(revitalizeId, {


### PR DESCRIPTION
New Rune/Modifier:

Revitalize
Increases incoming healing by (quantity)%

- This PR also makes some changes to debilitate quantity, such that each quantity of debilitate increases incoming damage by 1%. The spell has been adjusted to reflect this change
- Also fixes a bug + formula issue where each debilitate after the first would give +200% incoming damage instead of +100%

## TODO
- Done