### PR TITLE
Add Thorns

### DIFF
--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -136,6 +136,7 @@ import registerPrimedCorpse from '../modifierPrimedCorpse';
 import registerSlime from '../modifierSlime';
 import registerTargetImmune, { targetImmuneId } from '../modifierTargetImmune';
 import registerGrowth from '../modifierGrowth';
+import registerThorns from '../modifierThorns';
 
 export interface Modifiers {
   subsprite?: Subsprite;
@@ -379,6 +380,8 @@ export function registerCards(overworld: Overworld) {
   registerUrnPoisonExplode();
   registerUrnExplosiveExplode();
   registerDeathmasonEvents();
+
+  registerThorns();
 }
 
 // This is necessary because unit stats change with difficulty.

--- a/src/modifierThorns.ts
+++ b/src/modifierThorns.ts
@@ -7,6 +7,7 @@ import Underworld from './Underworld';
 export const thornsId = 'Thorns';
 export default function registerThorns() {
   registerModifiers(thornsId, {
+    description: 'thorns description',
     add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
       getOrInitModifier(unit, thornsId, { isCurse: false, quantity, keepOnDeath: true }, () => {
         Unit.addEvent(unit, thornsId);

--- a/src/modifierThorns.ts
+++ b/src/modifierThorns.ts
@@ -3,6 +3,7 @@ import { getOrInitModifier } from "./cards/util";
 import * as Unit from './entity/Unit';
 import Underworld from './Underworld';
 
+// Deals (quantity) damage to an attacker when taking damage
 export const thornsId = 'Thorns';
 export default function registerThorns() {
   registerModifiers(thornsId, {

--- a/src/modifierThorns.ts
+++ b/src/modifierThorns.ts
@@ -1,0 +1,46 @@
+import { registerEvents, registerModifiers } from "./cards";
+import { getOrInitModifier } from "./cards/util";
+import * as Unit from './entity/Unit';
+import Underworld from './Underworld';
+
+export const thornsId = 'Thorns';
+export default function registerThorns() {
+  registerModifiers(thornsId, {
+    add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
+      getOrInitModifier(unit, thornsId, { isCurse: false, quantity, keepOnDeath: true }, () => {
+        Unit.addEvent(unit, thornsId);
+      });
+
+      if (!prediction) {
+        updateTooltip(unit);
+      }
+    }
+  });
+  registerEvents(thornsId, {
+    onTakeDamage: (unit: Unit.IUnit, amount: number, underworld: Underworld, prediction: boolean, damageDealer?: Unit.IUnit) => {
+      const modifier = unit.modifiers[thornsId];
+      if (modifier) {
+        // Thorns will not deal damage if we are being healed
+        if (damageDealer && amount > 0) {
+          // Deal flat damage to the attacker
+          Unit.takeDamage({
+            unit: damageDealer,
+            amount: modifier.quantity,
+            sourceUnit: unit,
+          }, underworld, prediction);
+        }
+      }
+
+      // Thorns does not modify incoming damage
+      return amount;
+    }
+  });
+}
+
+function updateTooltip(unit: Unit.IUnit) {
+  const modifier = unit.modifiers[thornsId];
+  if (modifier) {
+    // Set tooltip:
+    modifier.tooltip = `${modifier.quantity} ${i18n('Thorns')} ${i18n('Damage')}`
+  }
+}


### PR DESCRIPTION
New Rune/Modifier:

Thorns
Deals (quantity) damage to an attacker when taking damage

## TODO:
- Bug: If a unit with thorns damages a unit with thorns (itself or other) it will cause a chain reaction until one unit dies.
  - We will have to decide exactly what sources trigger what effects and how/why in a way that is intuitive. Will thorns trigger another thorns, or apply onHit poison/lifesteal? A lot of games differentiate between a "hit" and "dealing damage", where a "hit" can come from a spell like slash, and "damage" can come from thorns or damage over time. 