### PR TITLE
Add On-Hit Poison

### DIFF
--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -136,6 +136,7 @@ import registerPrimedCorpse from '../modifierPrimedCorpse';
 import registerSlime from '../modifierSlime';
 import registerTargetImmune, { targetImmuneId } from '../modifierTargetImmune';
 import registerGrowth from '../modifierGrowth';
+import registerOnHitPoison from '../modifierOnHitPoison';
 
 export interface Modifiers {
   subsprite?: Subsprite;
@@ -379,6 +380,8 @@ export function registerCards(overworld: Overworld) {
   registerUrnPoisonExplode();
   registerUrnExplosiveExplode();
   registerDeathmasonEvents();
+
+  registerOnHitPoison();
 }
 
 // This is necessary because unit stats change with difficulty.

--- a/src/cards/poison.ts
+++ b/src/cards/poison.ts
@@ -12,42 +12,6 @@ import { getOrInitModifier } from './util';
 
 export const poisonCardId = 'poison';
 const basePoisonStacks = 20;
-function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld) {
-  Image.addSubSprite(unit.image, subspriteImageName);
-  if (spell.modifiers?.subsprite) {
-    // @ts-ignore: imagePath is a property that i've added and is not a part of the PIXI type
-    // which is used for identifying the sprite or animation that is currently active
-    const poisonSubsprite = unit.image?.sprite.children.find(c => c.imagePath == spell.modifiers?.subsprite?.imageName)
-    if (poisonSubsprite) {
-      const animatedSprite = poisonSubsprite as PIXI.AnimatedSprite;
-      animatedSprite.onFrameChange = (currentFrame) => {
-        if (currentFrame == 5) {
-          animatedSprite.anchor.x = (3 + Math.random() * (6 - 3)) / 10;
-        }
-      }
-    }
-  }
-}
-function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1, extra?: { [key: string]: any }) {
-  const modifier = getOrInitModifier(unit, poisonCardId, { isCurse: true, quantity }, () => {
-    Unit.addEvent(unit, poisonCardId);
-  });
-
-  if (!prediction) {
-    updateTooltip(unit);
-  }
-
-  modifier.sourceUnitId = extra?.sourceUnitId;
-}
-
-function updateTooltip(unit: Unit.IUnit) {
-  const modifier = unit.modifiers[poisonCardId];
-  if (modifier) {
-    // Set tooltip:
-    modifier.tooltip = `${modifier.quantity} ${i18n('Poison')}`;
-  }
-}
-
 const subspriteImageName = 'spell-effects/modifierPoisonDrip';
 const spell: Spell = {
   card: {
@@ -89,7 +53,6 @@ const spell: Spell = {
         y: 1.0,
       },
     },
-
   },
   events: {
     onTurnEnd: async (unit: IUnit, underworld: Underworld, prediction: boolean) => {
@@ -118,4 +81,42 @@ const spell: Spell = {
     },
   },
 };
+
+function add(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1, extra?: { [key: string]: any }) {
+  const modifier = getOrInitModifier(unit, poisonCardId, { isCurse: true, quantity }, () => {
+    Unit.addEvent(unit, poisonCardId);
+  });
+
+  if (!prediction) {
+    updateTooltip(unit);
+  }
+
+  modifier.sourceUnitId = extra?.sourceUnitId;
+}
+
+function updateTooltip(unit: Unit.IUnit) {
+  const modifier = unit.modifiers[poisonCardId];
+  if (modifier) {
+    // Set tooltip:
+    modifier.tooltip = `${modifier.quantity} ${i18n('Poison')}`;
+  }
+}
+
+function addModifierVisuals(unit: Unit.IUnit, underworld: Underworld) {
+  Image.addSubSprite(unit.image, subspriteImageName);
+  if (spell.modifiers?.subsprite) {
+    // @ts-ignore: imagePath is a property that i've added and is not a part of the PIXI type
+    // which is used for identifying the sprite or animation that is currently active
+    const poisonSubsprite = unit.image?.sprite.children.find(c => c.imagePath == spell.modifiers?.subsprite?.imageName)
+    if (poisonSubsprite) {
+      const animatedSprite = poisonSubsprite as PIXI.AnimatedSprite;
+      animatedSprite.onFrameChange = (currentFrame) => {
+        if (currentFrame == 5) {
+          animatedSprite.anchor.x = (3 + Math.random() * (6 - 3)) / 10;
+        }
+      }
+    }
+  }
+}
+
 export default spell;

--- a/src/modifierOnHitPoison.ts
+++ b/src/modifierOnHitPoison.ts
@@ -1,0 +1,45 @@
+import { registerEvents, registerModifiers } from "./cards";
+import { poisonCardId } from "./cards/poison";
+import { getOrInitModifier } from "./cards/util";
+import * as Unit from './entity/Unit';
+import Underworld from './Underworld';
+
+// Applies (quantity) poison to a unit when hitting it
+export const onHitPoisonId = 'On Hit Poison';
+export default function registerOnHitPoison() {
+  registerModifiers(onHitPoisonId, {
+    description: 'on hit poison description',
+    add: (unit: Unit.IUnit, underworld: Underworld, prediction: boolean, quantity: number = 1) => {
+      getOrInitModifier(unit, onHitPoisonId, { isCurse: false, quantity, keepOnDeath: true }, () => {
+        Unit.addEvent(unit, onHitPoisonId);
+      });
+
+      if (!prediction) {
+        updateTooltip(unit);
+      }
+    }
+  });
+  registerEvents(onHitPoisonId, {
+    onDealDamage: (damageDealer: Unit.IUnit, amount: number, underworld: Underworld, prediction: boolean, damageReciever?: Unit.IUnit) => {
+      const modifier = damageDealer.modifiers[onHitPoisonId];
+      if (modifier) {
+        // Poison is only applied if damage is dealt, not when healing
+        if (damageReciever && amount > 0) {
+          // Apply poison to the damage reciever
+          Unit.addModifier(damageReciever, poisonCardId, underworld, prediction, modifier.quantity, { sourceUnitId: damageDealer.id });
+        }
+      }
+
+      // On Hit Poison does not modify outgoing damage
+      return amount;
+    }
+  });
+}
+
+function updateTooltip(unit: Unit.IUnit) {
+  const modifier = unit.modifiers[onHitPoisonId];
+  if (modifier) {
+    // Set tooltip:
+    modifier.tooltip = `${modifier.quantity} ${i18n('On Hit')} ${i18n('Poison')}`
+  }
+}


### PR DESCRIPTION
New Rune/Modifier:

On Hit Poison
Applies (quantity) poison to a unit when hitting it

- This PR also makes some changes to poison quantity, such that each quantity of poison deals 1 damage per turn, making it more modular and compatible with the rune system. The spell has been adjusted to reflect this change

## TODO
- Better name?