### PR TITLE
Improved targeting prediction

### DIFF
--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -547,6 +547,10 @@ export async function runPredictions(underworld: Underworld) {
   }
   const startTime = Date.now();
   const mousePos = underworld.getMousePos();
+  // Queue mousePosition from the start of runPredictions so that when
+  // runPredictions is successful it can be saved to
+  // check if castLocation is different from last successful runPredictions
+  globalThis._queueLastPredictionMousePos = mousePos;
   // Clear the spelleffectprojection in preparation for showing the current ones
   clearSpellEffectProjection(underworld);
 

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -797,7 +797,6 @@ export function clickHandler(overworld: Overworld, e: MouseEvent) {
         if (globalThis.lastPredictionMousePos && !Vec.equal(target, globalThis.lastPredictionMousePos)) {
           const distFromLastPredictionMouse = distance(target, globalThis.lastPredictionMousePos);
           const isSmallDistFromLastPrediction = distFromLastPredictionMouse < config.COLLISION_MESH_RADIUS;
-          console.debug('Mouse position override; dist from last position: ', distFromLastPredictionMouse);
           if (isSmallDistFromLastPrediction) {
             target = globalThis.lastPredictionMousePos;
             console.log("Quality of Life: Overriding mouse position with last successful runPrediction mouse position.")

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -794,8 +794,7 @@ export function clickHandler(overworld: Overworld, e: MouseEvent) {
         // Ensure that click sent in cast is not slightly different from last 
         // runPrediction target which can result in different outcomes than the
         // user is expecting
-        if (globalThis.lastPredictionMouse) {
-
+        if (globalThis.lastPredictionMouse && !Vec.equal(target, globalThis.lastPredictionMouse.pos)) {
           const distFromLastPredictionMouse = distance(target, globalThis.lastPredictionMouse.pos);
           const isSmallDistFromLastPrediction = distFromLastPredictionMouse < config.COLLISION_MESH_RADIUS;
           const timeFromLastPredictionMouse = Date.now() - globalThis.lastPredictionMouse.time;

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -794,14 +794,13 @@ export function clickHandler(overworld: Overworld, e: MouseEvent) {
         // Ensure that click sent in cast is not slightly different from last 
         // runPrediction target which can result in different outcomes than the
         // user is expecting
-        if (globalThis.lastPredictionMouse && !Vec.equal(target, globalThis.lastPredictionMouse.pos)) {
-          const distFromLastPredictionMouse = distance(target, globalThis.lastPredictionMouse.pos);
+        if (globalThis.lastPredictionMousePos && !Vec.equal(target, globalThis.lastPredictionMousePos)) {
+          const distFromLastPredictionMouse = distance(target, globalThis.lastPredictionMousePos);
           const isSmallDistFromLastPrediction = distFromLastPredictionMouse < config.COLLISION_MESH_RADIUS;
-          const timeFromLastPredictionMouse = Date.now() - globalThis.lastPredictionMouse.time;
-          const isSmallTimeFromLastPrediction = timeFromLastPredictionMouse < 100;
-          if (isSmallDistFromLastPrediction && isSmallTimeFromLastPrediction) {
+          console.debug('Mouse position override; dist from last position: ', distFromLastPredictionMouse);
+          if (isSmallDistFromLastPrediction) {
+            target = globalThis.lastPredictionMousePos;
             console.log("Quality of Life: Overriding mouse position with last successful runPrediction mouse position.")
-            target = globalThis.lastPredictionMouse.pos;
           }
         }
 

--- a/src/graphics/ui/eventListeners.ts
+++ b/src/graphics/ui/eventListeners.ts
@@ -42,6 +42,7 @@ import { errorRed } from './colors';
 import { isSinglePlayer } from '../../network/wsPieSetup';
 import { elAdminPowerBar, elAdminPowerBarInput, elAdminPowerBarOptions } from '../../HTMLElements';
 import { targetCursedId } from '../../cards/target_curse';
+import { distance } from '../../jmath/math';
 
 export const keyDown = {
   showWalkRope: false,
@@ -789,6 +790,23 @@ export function clickHandler(overworld: Overworld, e: MouseEvent) {
       if (selfPlayer) {
         // cast the spell
         let target = mousePos;
+        // Improved targeting:
+        // Ensure that click sent in cast is not slightly different from last 
+        // runPrediction target which can result in different outcomes than the
+        // user is expecting
+        if (globalThis.lastPredictionMouse) {
+
+          const distFromLastPredictionMouse = distance(target, globalThis.lastPredictionMouse.pos);
+          const isSmallDistFromLastPrediction = distFromLastPredictionMouse < config.COLLISION_MESH_RADIUS;
+          const timeFromLastPredictionMouse = Date.now() - globalThis.lastPredictionMouse.time;
+          const isSmallTimeFromLastPrediction = timeFromLastPredictionMouse < 100;
+          if (isSmallDistFromLastPrediction && isSmallTimeFromLastPrediction) {
+            console.log("Quality of Life: Overriding mouse position with last successful runPrediction mouse position.")
+            target = globalThis.lastPredictionMouse.pos;
+          }
+        }
+
+        // End Improved targeting
         const cardIds = CardUI.getSelectedCardIds();
         const cards = CardUI.getSelectedCards();
 

--- a/src/types/globalTypesHeadless.d.ts
+++ b/src/types/globalTypesHeadless.d.ts
@@ -368,4 +368,6 @@ declare global {
   var noGore: undefined | boolean;
   // True when a SPELL message is currently being executed
   var spellCasting: boolean | undefined;
+  var _queueLastPredictionMousePos: Vec2 | undefined;
+  var lastPredictionMouse: { time: number, pos: Vec2 } | undefined;
 }

--- a/src/types/globalTypesHeadless.d.ts
+++ b/src/types/globalTypesHeadless.d.ts
@@ -369,5 +369,5 @@ declare global {
   // True when a SPELL message is currently being executed
   var spellCasting: boolean | undefined;
   var _queueLastPredictionMousePos: Vec2 | undefined;
-  var lastPredictionMouse: { time: number, pos: Vec2 } | undefined;
+  var lastPredictionMousePos: Vec2 | undefined;
 }

--- a/src/types/globalTypesMain.d.ts
+++ b/src/types/globalTypesMain.d.ts
@@ -302,5 +302,5 @@ declare global {
   // True when a SPELL message is currently being executed
   var spellCasting: boolean | undefined;
   var _queueLastPredictionMousePos: Vec2 | undefined;
-  var lastPredictionMouse: { time: number, pos: Vec2 } | undefined;
+  var lastPredictionMousePos: Vec2 | undefined;
 }

--- a/src/types/globalTypesMain.d.ts
+++ b/src/types/globalTypesMain.d.ts
@@ -301,4 +301,6 @@ declare global {
   var noGore: undefined | boolean;
   // True when a SPELL message is currently being executed
   var spellCasting: boolean | undefined;
+  var _queueLastPredictionMousePos: Vec2 | undefined;
+  var lastPredictionMouse: { time: number, pos: Vec2 } | undefined;
 }

--- a/src/views.ts
+++ b/src/views.ts
@@ -242,7 +242,7 @@ export function addOverworldEventListeners(overworld: Overworld) {
             if (e.target && (e.target as HTMLElement).tagName === 'CANVAS') {
               runPredictions(overworld.underworld);
               if (globalThis._queueLastPredictionMousePos) {
-                globalThis.lastPredictionMouse = { time: Date.now(), pos: globalThis._queueLastPredictionMousePos };
+                globalThis.lastPredictionMousePos = globalThis._queueLastPredictionMousePos;
               } else {
                 console.warn('Could not assign _queueLastPredictionMousePos');
               }

--- a/src/views.ts
+++ b/src/views.ts
@@ -241,6 +241,11 @@ export function addOverworldEventListeners(overworld: Overworld) {
             // when browsing the spellbook or hovering over your toolbar
             if (e.target && (e.target as HTMLElement).tagName === 'CANVAS') {
               runPredictions(overworld.underworld);
+              if (globalThis._queueLastPredictionMousePos) {
+                globalThis.lastPredictionMouse = { time: Date.now(), pos: globalThis._queueLastPredictionMousePos };
+              } else {
+                console.warn('Could not assign _queueLastPredictionMousePos');
+              }
             }
           }
         }


### PR DESCRIPTION
closes #893 
closes #721 

Attempt to solve the "target cone + slash" and the "many add_bounce + arrow" issue where the actual spell can cast with slightly different coordinates than the last successful runPrediction which leads to the frustrating scenario where the prediction appears to have been wrong, but the game just sent the cast with very slightly different coordinates than the last calculated prediction.