### PR TITLE
ref: Ordered modifier events

### DIFF
--- a/src/cards/blood_curse.ts
+++ b/src/cards/blood_curse.ts
@@ -77,6 +77,7 @@ const spell: Spell = {
     },
   },
   modifiers: {
+    stage: 'Blood Curse',
     add,
     remove,
   },

--- a/src/cards/index.test.ts
+++ b/src/cards/index.test.ts
@@ -1,0 +1,36 @@
+
+import { eventsSorter, type MODIFIER_STAGE } from "./index";
+
+describe('eventSorter', () => {
+    const lookup: { [id: string]: { id: string, stage: MODIFIER_STAGE } } = {
+        'eventA': {
+            id: 'eventA',
+            stage: 'Amount Flat',
+        },
+        'eventZ': {
+            id: 'eventZ',
+            stage: 'Amount Flat',
+        },
+        'eventBefore': {
+            id: 'eventBefore',
+            stage: 'Amount Multiplier',
+        },
+        'eventAfter': {
+            id: 'eventAfter',
+            stage: 'Reactive Effects',
+        },
+
+    };
+    it('should sort events in the same stage alphabetically', () => {
+        const events = ['eventAfter', 'eventZ', 'eventA', 'eventBefore'];
+        events.sort(eventsSorter(lookup))
+        expect(events).toEqual([
+            'eventBefore',
+            'eventA',
+            'eventZ',
+            'eventAfter'
+        ])
+
+    });
+
+})

--- a/src/cards/index.test.ts
+++ b/src/cards/index.test.ts
@@ -2,7 +2,7 @@
 import { eventsSorter, type MODIFIER_STAGE } from "./index";
 
 describe('eventSorter', () => {
-    const lookup: { [id: string]: { id: string, stage: MODIFIER_STAGE } } = {
+    const lookup: { [id: string]: { id: string, stage?: MODIFIER_STAGE } } = {
         'eventA': {
             id: 'eventA',
             stage: 'Amount Flat',
@@ -19,16 +19,21 @@ describe('eventSorter', () => {
             id: 'eventAfter',
             stage: 'Reactive Effects',
         },
+        'eventUnstaged': {
+            id: 'eventUnstaged',
+        },
 
     };
     it('should sort events in the same stage alphabetically', () => {
-        const events = ['eventAfter', 'eventZ', 'eventA', 'eventBefore'];
+        const events = ['eventAfter', 'eventZ', 'eventUnstaged', 'eventA', 'eventBefore'];
         events.sort(eventsSorter(lookup))
         expect(events).toEqual([
             'eventBefore',
             'eventA',
             'eventZ',
-            'eventAfter'
+            'eventAfter',
+            // Unstaged events are sorted to the end
+            'eventUnstaged'
         ])
 
     });

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -780,21 +780,23 @@ export function getMaxRuneQuantity(modifier: Modifiers) {
 }
 
 export type MODIFIER_STAGE = 'Soul Bind' | 'Amount Multiplier' | 'Amount Flat' | 'Amount Override'
-  | 'Blood Curse' | 'Reactive Effects';
+  | 'Blood Curse' | 'Reactive Effects' | 'Unstaged Events';
 export const MODIFIER_ORDER: MODIFIER_STAGE[] = [
   'Soul Bind',
   'Amount Multiplier',
   'Amount Flat',
   'Amount Override',
   'Blood Curse',
-  'Reactive Effects'
+  'Reactive Effects',
+  'Unstaged Events'
 ]
 
 // Returns a sorting function to be used in .sort
 // Pass in allModifiers as lookup for real use.  Injectable for testing.
 export function eventsSorter(lookup: typeof allModifiers): (eventA: string, eventB: string) => number {
   return (eventA: string, eventB: string): number => {
-    const DEFAULT_STAGE = "Amount Flat";
+    // Unstaged events trigger last so they are easier to debug
+    const DEFAULT_STAGE = 'Unstaged Events';
     const lookupA = lookup[eventA];
     const eventAStage: MODIFIER_STAGE = lookupA?.stage !== undefined ? lookupA.stage : DEFAULT_STAGE;
     const lookupB = lookup[eventB];

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -188,13 +188,15 @@ import registerLiquidmancer from '../modifierLiquidmancer';
 import registerHeavyImpacts from '../modifierHeavyImpact';
 import registerPotionEffectiveness from '../modifierPotionEffectiveness';
 import registerPotionBarrier from '../modifierPotionBarrier';
-import type { Modifier } from './util';
 
 
 export interface Modifiers {
   // modifier sthat are not attached to a spell need an explicit id set
   id?: string;
   subsprite?: Subsprite;
+  // Controls the order in which a modifier's events trigger
+  // relative to other events
+  stage?: MODIFIER_STAGE;
   // run special init logic (usually for visuals) when a modifier is added or loaded
   // see 'poison' for example
   // init is inteded to be called within add.
@@ -775,4 +777,37 @@ export function getMaxRuneQuantity(modifier: Modifiers) {
     return (modifier.maxUpgradeCount * (modifier.quantityPerUpgrade || 1));
   }
   return Infinity
+}
+
+export type MODIFIER_STAGE = 'Soul Bind' | 'Amount Multiplier' | 'Amount Flat' | 'Amount Override'
+  | 'Blood Curse' | 'Reactive Effects';
+export const MODIFIER_ORDER: MODIFIER_STAGE[] = [
+  'Soul Bind',
+  'Amount Multiplier',
+  'Amount Flat',
+  'Amount Override',
+  'Blood Curse',
+  'Reactive Effects'
+]
+
+// Returns a sorting function to be used in .sort
+// Pass in allModifiers as lookup for real use.  Injectable for testing.
+export function eventsSorter(lookup: typeof allModifiers): (eventA: string, eventB: string) => number {
+  return (eventA: string, eventB: string): number => {
+    const DEFAULT_STAGE = "Amount Flat";
+    const lookupA = lookup[eventA];
+    const eventAStage: MODIFIER_STAGE = lookupA?.stage !== undefined ? lookupA.stage : DEFAULT_STAGE;
+    const lookupB = lookup[eventB];
+    const eventBStage: MODIFIER_STAGE = lookupB?.stage !== undefined ? lookupB.stage : DEFAULT_STAGE;
+    const indexA = MODIFIER_ORDER.indexOf(eventAStage);
+    const indexB = MODIFIER_ORDER.indexOf(eventBStage);
+    const orderA = indexA === -1 ? MODIFIER_ORDER.indexOf(DEFAULT_STAGE) : indexA;
+    const orderB = indexB === -1 ? MODIFIER_ORDER.indexOf(DEFAULT_STAGE) : indexB;
+    if (orderA === orderB) {
+      // Sort alphabetically by event title if they are in the same stage
+      return eventA.localeCompare(eventB);
+    } else {
+      return orderA - orderB;
+    }
+  }
 }

--- a/src/cards/poison.ts
+++ b/src/cards/poison.ts
@@ -39,6 +39,7 @@ const spell: Spell = {
     },
   },
   modifiers: {
+    stage: 'Amount Flat',
     add,
     addModifierVisuals,
     subsprite: {

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -14,7 +14,7 @@ import Events from '../Events';
 import makeAllRedShader from '../graphics/shaders/selected';
 import { addLerpable } from '../lerpList';
 import { allUnits } from './units';
-import { allCards, allModifiers } from '../cards';
+import { allCards, allModifiers, eventsSorter } from '../cards';
 import * as immune from '../cards/immune';
 import { checkIfNeedToClearTooltip, clearSpellEffectProjection, drawUICircle } from '../graphics/PlanningView';
 import floatingText, { queueCenteredFloatingText } from '../graphics/FloatingText';
@@ -1839,5 +1839,6 @@ export function getFactionsOf(units: { faction: Faction }[]): Faction[] {
 export function addEvent(unit: IUnit, eventId: string) {
   if (!unit.events.includes(eventId)) {
     unit.events.push(eventId);
+    unit.events.sort(eventsSorter(allModifiers));
   }
 }


### PR DESCRIPTION
Modifier events must be ordered so that
their effects are not dependent on the order in
which the modifier was added to the unit.

Tested in cards/index.test.ts
Validated by adding poison and bloodcurse to a unit in any order and in the events array poison always comes first now.

TODO: Actually specify the orders for all units.
Closes: #933