### PR TITLE
Find Valid Spawn

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -2018,7 +2018,7 @@ export default class Underworld {
     // Ex. This can be used to prevent a summoner from summoning over a wall
     if (unobstructedPoint) {
       // Ensure spawnPoint isn't through any walls or liquidBounds
-      if ([...this.walls, ...this.liquidBounds].some(wall => lineSegmentIntersection({ p1: unobstructedPoint, p2: spawnPoint }, wall))) {
+      if ([...this.walls, ...this.liquidBounds].some(wall => unobstructedPoint != undefined && lineSegmentIntersection({ p1: unobstructedPoint, p2: spawnPoint }, wall))) {
         return false;
       }
     }

--- a/src/cards/clone.ts
+++ b/src/cards/clone.ts
@@ -9,6 +9,8 @@ import { IImageAnimated } from '../graphics/Image';
 import { raceTimeout } from '../Promise';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import Underworld from '../Underworld';
+import seedrandom from 'seedrandom';
+import { getUniqueSeedString } from '../jmath/rand';
 
 export const clone_id = 'clone';
 const spell: Spell = {
@@ -65,7 +67,8 @@ export function cloneEffect(addClonesToTargetArray: boolean): EffectFn {
               }
             } else if (Pickup.isPickup(target)) {
               const targetName = target.name;
-              const validSpawnCoords = underworld.findValidSpawn({ spawnSource: cloneSourceCoords, ringLimit: 5, prediction, radius: 15 })
+              const seed = seedrandom(`${getUniqueSeedString(underworld)}-${target.id}`);
+              const validSpawnCoords = underworld.findValidSpawnInRadius(target, prediction, seed, { allowLiquid: target.inLiquid });
               if (validSpawnCoords) {
                 let foundPickup = Pickup.pickups.find((p) => p.name == targetName);
                 if (foundPickup) {
@@ -95,7 +98,8 @@ export function cloneEffect(addClonesToTargetArray: boolean): EffectFn {
   }
 }
 export function doCloneUnit(unit: Unit.IUnit, underworld: Underworld, prediction: boolean, spawnSource?: Vec2): Unit.IUnit | undefined {
-  const validSpawnCoords = underworld.findValidSpawn({ spawnSource: spawnSource || unit, ringLimit: 5, prediction, radius: 10 });
+  const seed = seedrandom(`${getUniqueSeedString(underworld)}-${unit.id}`);
+  const validSpawnCoords = underworld.findValidSpawnInRadius(unit, prediction, seed, { allowLiquid: unit.inLiquid });
   if (validSpawnCoords) {
     const clone = Unit.load(Unit.serialize(unit), underworld, prediction);
     if (!prediction) {

--- a/src/cards/clone.ts
+++ b/src/cards/clone.ts
@@ -11,6 +11,7 @@ import { CardRarity, probabilityMap } from '../types/commonTypes';
 import Underworld from '../Underworld';
 import seedrandom from 'seedrandom';
 import { getUniqueSeedString } from '../jmath/rand';
+import * as config from '../config';
 
 export const clone_id = 'clone';
 const spell: Spell = {
@@ -68,7 +69,7 @@ export function cloneEffect(addClonesToTargetArray: boolean): EffectFn {
             } else if (Pickup.isPickup(target)) {
               const targetName = target.name;
               const seed = seedrandom(`${getUniqueSeedString(underworld)}-${target.id}`);
-              const validSpawnCoords = underworld.findValidSpawnInRadius(target, prediction, seed, { allowLiquid: target.inLiquid });
+              const validSpawnCoords = underworld.findValidSpawnInRadius(target, prediction, seed, { allowLiquid: target.inLiquid, maxRadius: config.COLLISION_MESH_RADIUS });
               if (validSpawnCoords) {
                 let foundPickup = Pickup.pickups.find((p) => p.name == targetName);
                 if (foundPickup) {

--- a/src/cards/displace.ts
+++ b/src/cards/displace.ts
@@ -31,7 +31,7 @@ const spell: Spell = {
 
       // Seed is set before targets are looped so that each target goes to a different location but
       // also so that it is consistent and seeded for a given cast
-      const seed = seedrandom(`${getUniqueSeedString(underworld)}`);
+      const seed = seedrandom(`${getUniqueSeedString(underworld)}-${state.casterUnit.id}`);
       for (let i = 0; i < quantity; i++) {
         // Loop through all targets and batch swap locations
         const swaps: [HasSpace, Vec2][] = [];

--- a/src/cards/lastwill.ts
+++ b/src/cards/lastwill.ts
@@ -4,11 +4,12 @@ import * as Pickup from '../entity/Pickup';
 import { Spell } from './index';
 import type Underworld from '../Underworld';
 import { CardCategory } from '../types/commonTypes';
-import { chooseObjectWithProbability } from '../jmath/rand';
+import { chooseObjectWithProbability, getUniqueSeedString } from '../jmath/rand';
 import seedrandom from 'seedrandom';
 import floatingText from '../graphics/FloatingText';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { getOrInitModifier } from './util';
+import { COLLISION_MESH_RADIUS } from '../config';
 
 export const lastWillId = 'Last Will';
 const imageName = 'unknown.png';
@@ -60,9 +61,9 @@ const spell: Spell = {
       // Last Will should not stack for balance reasons
       const quantity = 1;
       // Unique for the unit and for quantity and same across all clients due to turn_number and unit.id
-      const seed = seedrandom(`${underworld.turn_number} - ${unit.id}`);
+      const seed = seedrandom(`${getUniqueSeedString(underworld)}-${unit.id}`);
       for (let i = 0; i < quantity; i++) {
-        const coord = underworld.findValidSpawn({ spawnSource: unit, ringLimit: 3, prediction, radius: 32 });
+        const coord = underworld.findValidSpawnInRadius(unit, prediction, seed, { maxRadius: COLLISION_MESH_RADIUS * 2, allowLiquid: unit.inLiquid });
         const choice = chooseObjectWithProbability(Pickup.pickups.map((p, index) => {
           return {
             index, probability: p.name.includes('Potion') ? p.probability : 0

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -12,6 +12,8 @@ import { isPickup } from '../entity/Pickup';
 import { suffocateCardId, updateSuffocate } from './suffocate';
 import { addScaleModifier, removeScaleModifier } from '../graphics/Image';
 import floatingText from '../graphics/FloatingText';
+import seedrandom from 'seedrandom';
+import { getUniqueSeedString } from '../jmath/rand';
 
 export const splitId = 'split';
 const splitLimit = 3;
@@ -137,7 +139,8 @@ export function doSplit(target: Vec2 | undefined, underworld: Underworld, quanti
   if (target) {
     // If there is are clone coordinates to clone into
     if (Unit.isUnit(target)) {
-      const validSpawnCoords = underworld.findValidSpawn({ spawnSource: target, ringLimit: 5, prediction, radius: 10 });
+      const seed = seedrandom(`${getUniqueSeedString(underworld)}-${target.id}`);
+      const validSpawnCoords = underworld.findValidSpawnInRadius(target, prediction, seed, { allowLiquid: target.inLiquid });
       if (validSpawnCoords) {
         const clone = Unit.load(Unit.serialize(target), underworld, prediction);
         if (!prediction) {
@@ -176,7 +179,8 @@ export function doSplit(target: Vec2 | undefined, underworld: Underworld, quanti
         return clone;
       }
     } else if (Pickup.isPickup(target)) {
-      const validSpawnCoords = underworld.findValidSpawn({ spawnSource: target, ringLimit: 5, prediction, radius: 20 })
+      const seed = seedrandom(`${getUniqueSeedString(underworld)}-${target.id}`);
+      const validSpawnCoords = underworld.findValidSpawnInRadius(target, prediction, seed, { allowLiquid: target.inLiquid });
       if (validSpawnCoords) {
         // Since there is a safety for loading/creating pickups of duplicate id's
         const serializedPickup = Pickup.serialize(target);

--- a/src/cards/split.ts
+++ b/src/cards/split.ts
@@ -14,6 +14,7 @@ import { addScaleModifier, removeScaleModifier } from '../graphics/Image';
 import floatingText from '../graphics/FloatingText';
 import seedrandom from 'seedrandom';
 import { getUniqueSeedString } from '../jmath/rand';
+import * as config from '../config';
 
 export const splitId = 'split';
 const splitLimit = 3;
@@ -140,7 +141,7 @@ export function doSplit(target: Vec2 | undefined, underworld: Underworld, quanti
     // If there is are clone coordinates to clone into
     if (Unit.isUnit(target)) {
       const seed = seedrandom(`${getUniqueSeedString(underworld)}-${target.id}`);
-      const validSpawnCoords = underworld.findValidSpawnInRadius(target, prediction, seed, { allowLiquid: target.inLiquid });
+      const validSpawnCoords = underworld.findValidSpawnInRadius(target, prediction, seed, { allowLiquid: target.inLiquid, maxRadius: config.COLLISION_MESH_RADIUS });
       if (validSpawnCoords) {
         const clone = Unit.load(Unit.serialize(target), underworld, prediction);
         if (!prediction) {

--- a/src/entity/Pickup.ts
+++ b/src/entity/Pickup.ts
@@ -540,7 +540,7 @@ export const pickups: IPickupSource[] = [
           // Note: pickup MUST be removed before checking if the point is valid because
           // isPointValidSpawn returns false if it's spawning a unit on a point taken up by a pickup
           // (that isn't flagged for removal)
-          if (underworld.isPointValidSpawn(randomOtherRedPortal, config.COLLISION_MESH_RADIUS / 2, prediction)) {
+          if (underworld.isPointValidSpawn(randomOtherRedPortal, prediction)) {
             teleport(player.unit, randomOtherRedPortal, underworld, prediction);
             playSFXKey('swap');
             skyBeam(pickup);
@@ -580,7 +580,7 @@ export const pickups: IPickupSource[] = [
           // Note: pickup MUST be removed before checking if the point is valid because
           // isPointValidSpawn returns false if it's spawning a unit on a point taken up by a pickup
           // (that isn't flagged for removal)
-          if (underworld.isPointValidSpawn(randomOtherBluePortal, config.COLLISION_MESH_RADIUS / 2, prediction)) {
+          if (underworld.isPointValidSpawn(randomOtherBluePortal, prediction)) {
             teleport(player.unit, randomOtherBluePortal, underworld, prediction);
             skyBeam(pickup);
             skyBeam(randomOtherBluePortal);

--- a/src/entity/units/deathmason.ts
+++ b/src/entity/units/deathmason.ts
@@ -10,7 +10,6 @@ import sacrifice from '../../cards/sacrifice';
 import { calculateCost } from '../../cards/cardUtils';
 import seedrandom from 'seedrandom';
 import { makeManaTrail } from '../../graphics/Particles';
-import { findRandomGroundLocation } from './summoner';
 import { pickups, RED_PORTAL, removePickup } from '../Pickup';
 import { skyBeam } from '../../VisualEffects';
 import * as Pickup from '../Pickup';
@@ -80,7 +79,7 @@ const deathmason: UnitSource = {
           let lastPromise = Promise.resolve();
           const portalCoords = [];
           for (let i = 0; i < numberOfSummons; i++) {
-            const coords = findRandomGroundLocation(underworld, unit, seed);
+            const coords = underworld.findValidSpawnInRadius(unit, false, seed, { maxRadius: unit.attackRange, unobstructedPoint: unit });
             if (coords) {
               portalCoords.push(coords);
             } else {
@@ -209,7 +208,7 @@ export function registerDeathmasonEvents() {
             let retryAttempts = 0;
             for (let i = 0; (i < 3 && retryAttempts < 10); i++) {
               const seed = seedrandom(`${underworld.seed}-${underworld.turn_number}-${unit.id}`);
-              const coords = findRandomGroundLocation(underworld, unit, seed);
+              const coords = underworld.findValidSpawnInRadius(unit, false, seed, { maxRadius: unit.attackRange });
               if (!coords) {
                 console.warn("Deathmason onDeath() spawning failed attempt: ", retryAttempts);
                 retryAttempts++;

--- a/src/entity/units/goru.ts
+++ b/src/entity/units/goru.ts
@@ -14,10 +14,9 @@ import { primedCorpseId } from '../../modifierPrimedCorpse';
 import { boneShrapnelCardId, boneShrapnelRadius } from '../../cards/bone_shrapnel';
 import { makeManaTrail } from '../../graphics/Particles';
 import seedrandom from 'seedrandom';
-import { findRandomGroundLocation } from './summoner';
 import { Vec2 } from '../../jmath/Vec';
 import { summoningSicknessId } from '../../modifierSummoningSickness';
-import { chooseOneOfSeeded } from '../../jmath/rand';
+import { chooseOneOfSeeded, getUniqueSeedString } from '../../jmath/rand';
 import { oneOffImage } from '../../cards/cardUtils';
 import { containerUnits } from '../../graphics/PixiUtils';
 import { BLOOD_GOLEM_ID } from './bloodGolem';
@@ -314,9 +313,9 @@ const unit: UnitSource = {
         const numberOfSummons = 4;
         const summonTypes = [allUnits[BLOOD_GOLEM_ID], allUnits[BLOOD_ARCHER_ID]];
         const summons: { coords: Vec2, sourceUnit: UnitSource }[] = [];
-        const seed = seedrandom(`${underworld.seed}-${underworld.turn_number}-${unit.id}`);
+        const seed = seedrandom(`${getUniqueSeedString(underworld)}-${unit.id}`);
         for (let i = 0; i < numberOfSummons; i++) {
-          const coords = findRandomGroundLocation(underworld, unit, seed);
+          const coords = underworld.findValidSpawnInRadius(unit, false, seed, { maxRadius: unit.attackRange, unobstructedPoint: unit });
           if (coords) {
             const sourceUnit = chooseOneOfSeeded(summonTypes, seed);
             if (sourceUnit) {

--- a/src/jmath/lineSegment.ts
+++ b/src/jmath/lineSegment.ts
@@ -75,6 +75,7 @@ function findWherePointIntersectLineAtRightAngle(point: Vec.Vec2, line: LineInSt
 // the right angle point of intersection will be outside of the line segment (unless the circle is positioned at a 
 // perfect right angle to the endpoint).  So this function should be used together with other functions to account
 // for the endpoints of the line segment
+// https://github.com/jdoleary/Spellmasons/issues/983
 export function findWherePointIntersectLineSegmentAtRightAngle(point: Vec.Vec2, line: LineSegment): Vec.Vec2 | undefined {
   const lineInStandardForm = toStandardForm(line);
   const largestX = Math.max(line.p1.x, line.p2.x);

--- a/src/modifierBountyGolem.ts
+++ b/src/modifierBountyGolem.ts
@@ -9,8 +9,8 @@ import { allUnits } from "./entity/units";
 import { UnitType } from "./types/commonTypes";
 import { makeRisingParticles } from "./graphics/ParticleCollection";
 import { COLLISION_MESH_RADIUS } from "./config";
-import { findRandomSummonLocation } from "./modifierGolemancer";
 import seedrandom from "seedrandom";
+import { getUniqueSeedString } from "./jmath/rand";
 
 // Spawn [quantity] golems when claiming a bounty
 export const bountyGolemId = 'Bounty: Golem';
@@ -32,11 +32,11 @@ export default function registerBountyGolem() {
       if (modifier) {
         // Create golems on kill
         if (killedUnit.modifiers[bountyId]) {
-          const seed = seedrandom(`${underworld.seed}-${underworld.turn_number}-${killedUnit.id}`);
+          const seed = seedrandom(`${getUniqueSeedString(underworld)}-${killedUnit.id}`);
           // Summon quantity ally golems
           const golemsToSummon = modifier.quantity;
           for (let i = 0; i < golemsToSummon; i++) {
-            const coords = findRandomSummonLocation(killedUnit, COLLISION_MESH_RADIUS, underworld, prediction, seed)
+            const coords = underworld.findValidSpawnInRadius(killedUnit, prediction, seed, { allowLiquid: killedUnit.inLiquid });
             if (coords) {
               let sourceUnit = allUnits[golem_unit_id];
               if (sourceUnit) {

--- a/src/modifierBountyPotion.ts
+++ b/src/modifierBountyPotion.ts
@@ -7,7 +7,6 @@ import { bountyId } from "./modifierBounty";
 import { bountyHunterId } from "./modifierBountyHunter";
 import Underworld from './Underworld';
 import { chooseObjectWithProbability, getUniqueSeedString, randFloat } from "./jmath/rand";
-import { findPotionSummonLocation } from "./modifierAlchemist";
 import floatingText from "./graphics/FloatingText";
 import { COLLISION_MESH_RADIUS } from "./config";
 
@@ -31,8 +30,8 @@ export default function registerBountyPotion() {
       if (modifier) {
         // Only drop a potion if the killed unit has a bounty
         if (killedUnit.modifiers[bountyId]) {
-          const random = seedrandom(`${getUniqueSeedString(underworld)} - ${killedUnit.id}`);
-          const coords = findPotionSummonLocation(killedUnit, COLLISION_MESH_RADIUS * 2, underworld, prediction, random)
+          const random = seedrandom(`${getUniqueSeedString(underworld)}-${killedUnit.id}`);
+          const coords = underworld.findValidSpawnInRadius(killedUnit, prediction, random, { maxRadius: COLLISION_MESH_RADIUS * 2, allowLiquid: killedUnit.inLiquid });
           if (coords) {
             const pickupChoice = chooseObjectWithProbability(Pickup.pickups.map((p, index) => {
               return { index, probability: p.name.includes('Potion') ? p.probability : 0 }

--- a/src/modifierCloneOnTeleport.ts
+++ b/src/modifierCloneOnTeleport.ts
@@ -1,3 +1,4 @@
+import seedrandom from "seedrandom";
 import { registerEvents, registerModifiers } from "./cards";
 import { animateMitosis, doCloneUnit } from "./cards/clone";
 import { getOrInitModifier } from "./cards/util";
@@ -25,10 +26,14 @@ export default function registerContaminateSelfOnTeleport() {
           const clone = doCloneUnit(unit, underworld, prediction);
           // Attempt to put the Changling where the player was, but in the event
           // that the player is swapping that location might now be full
-          const validSpawnCoords = underworld.findValidSpawn({ spawnSource: originalLocation, ringLimit: 5, prediction, radius: 10 });
-          if (clone && validSpawnCoords) {
-            clone.x = validSpawnCoords.x;
-            clone.y = validSpawnCoords.y;
+          let coords = originalLocation;
+          if (!underworld.isPointValidSpawn(coords, prediction)) {
+            coords = underworld.findValidSpawnInRadius(originalLocation, prediction, seedrandom(`${unit.id}`)) || coords;
+          }
+
+          if (clone && coords) {
+            clone.x = coords.x;
+            clone.y = coords.y;
             clone.name = 'Changeling';
             // Wait a bit for floating text otherwise it gets covered by sky beam
             setTimeout(() => {

--- a/src/modifierCloneOnTeleport.ts
+++ b/src/modifierCloneOnTeleport.ts
@@ -27,7 +27,7 @@ export default function registerContaminateSelfOnTeleport() {
           // Attempt to put the Changling where the player was, but in the event
           // that the player is swapping that location might now be full
           let coords = originalLocation;
-          if (!underworld.isPointValidSpawn(coords, prediction)) {
+          if (!underworld.isPointValidSpawn(coords, prediction, { allowLiquid: true })) {
             coords = underworld.findValidSpawnInRadius(originalLocation, prediction, seedrandom(`${unit.id}`)) || coords;
           }
 


### PR DESCRIPTION
closes #968 
closes #977 

- Adds underworld.FindValidSpawnInRadius()
- Adds underworld.FindValidSpawnInWorldBounds()
- Removes FindValidSpawn() (commented out in case it's wanted for later use: rng-independent hex grid)
- Removes FindRandomGroundLocation() from summoner
- Removes FindRandomDisplaceLocation() from displace
- Removes FindPotionSummonLocation() from alchemist
- Removes FindRandomSummonLocation() from golemancer
- Bosses spawn anywhere on the map instead of next to the player