### PR TITLE
Use shallow copy for events

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3091,7 +3091,8 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
     // Trigger full turn cycle events now that it's restarting at the playerTurn
     if (phase == turn_phase[turn_phase.PlayerTurns]) {
       for (let unit of this.units) {
-        await Promise.all(unit.events.map(
+        const events = [...unit.events];
+        await Promise.all(events.map(
           async (eventName) => {
             const fn = Events.onFullTurnCycleSource[eventName];
             if (fn) {

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -815,7 +815,8 @@ export function die(unit: IUnit, underworld: Underworld, prediction: boolean, so
   // Clear unit path to prevent further movement in case of ressurect or similar
   unit.path = undefined;
 
-  for (let eventName of unit.events) {
+  const events = [...unit.events];
+  for (let eventName of events) {
     if (eventName) {
       const fn = Events.onDeathSource[eventName];
       if (fn) {
@@ -828,7 +829,8 @@ export function die(unit: IUnit, underworld: Underworld, prediction: boolean, so
   // This must occur before onDeath events are removed (Bounty)
   // Doodads don't trigger onKill effects
   if (sourceUnit && unit.unitSubType != UnitSubType.DOODAD) {
-    for (let eventName of sourceUnit.events) {
+    const events = [...sourceUnit.events];
+    for (let eventName of events) {
       if (eventName) {
         const fn = Events.onKillSource[eventName];
         if (fn) {
@@ -906,7 +908,8 @@ export function composeOnDealDamageEvents(damageArgs: damageArgs, underworld: Un
   if (!sourceUnit) return amount;
 
   // Compose onDamageEvents
-  for (let eventName of sourceUnit.events) {
+  const events = [...sourceUnit.events]
+  for (let eventName of events) {
     const fn = Events.onDealDamageSource[eventName];
     if (fn) {
       // onDamage events can trigger effects and alter damage amount
@@ -919,7 +922,8 @@ export function composeOnTakeDamageEvents(damageArgs: damageArgs, underworld: Un
   let { unit, amount, sourceUnit } = damageArgs;
 
   // Compose onDamageEvents
-  for (let eventName of unit.events) {
+  const events = [...unit.events]
+  for (let eventName of events) {
     const fn = Events.onTakeDamageSource[eventName];
     if (fn) {
       // onDamage events can trigger effects and alter damage amount
@@ -1474,7 +1478,8 @@ export async function endTurnForUnits(units: IUnit[], underworld: Underworld, pr
 }
 
 export async function runTurnStartEvents(unit: IUnit, underworld: Underworld, prediction: boolean) {
-  await Promise.all(unit.events.map(
+  const events = [...unit.events];
+  await Promise.all(events.map(
     async (eventName) => {
       const fn = Events.onTurnStartSource[eventName];
       if (fn) {
@@ -1485,7 +1490,8 @@ export async function runTurnStartEvents(unit: IUnit, underworld: Underworld, pr
 }
 
 export async function runTurnEndEvents(unit: IUnit, underworld: Underworld, prediction: boolean) {
-  await Promise.all(unit.events.map(
+  const events = [...unit.events];
+  await Promise.all(events.map(
     async (eventName) => {
       const fn = Events.onTurnEndSource[eventName];
       if (fn) {
@@ -1496,8 +1502,9 @@ export async function runTurnEndEvents(unit: IUnit, underworld: Underworld, pred
 }
 
 export async function runPickupEvents(unit: IUnit, pickup: IPickup, underworld: Underworld, prediction: boolean) {
+  const events = [...unit.events];
   await raceTimeout(3000, `RunPickupEvents (Unit: ${unit.unitSourceId} | Pickup: ${pickup.name} | Prediction: ${prediction})`,
-    Promise.all(unit.events.map(
+    Promise.all(events.map(
       async (eventName) => {
         const fn = Events.onPickupSource[eventName];
         if (fn) {

--- a/src/network/networkHandler.ts
+++ b/src/network/networkHandler.ts
@@ -781,7 +781,8 @@ async function handleOnDataMessage(d: OnDataArgs, overworld: Overworld): Promise
           teleport(fromPlayer.unit, payload, underworld, false);
 
           // Trigger onSpawn events
-          for (let eventName of fromPlayer.unit.events) {
+          const events = [...fromPlayer.unit.events]
+          for (let eventName of events) {
             if (eventName) {
               const fn = Events.onSpawnSource[eventName];
               if (fn) {


### PR DESCRIPTION
closes #985 

Prevents a bug where adding or removing events while iterating over the event loop would cause some effects to be skipped or triggered multiple times

Did some quick testing with the heal/overheal/shield regen combo, as well as with the "give all modifiers" command, everything seems to be working at first glance