### PR TITLE
Optimize predict ai turn

### DIFF
--- a/src/Underworld.ts
+++ b/src/Underworld.ts
@@ -3643,7 +3643,9 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       globalThis.currentChunk = 0;
     }
 
+    // Optimization, search for "chunks" / "chunking strategy" to learn more
     let startChunk = globalThis.currentChunk || 0;
+    // Optimization, search for "chunks" / "chunking strategy" to learn more
     let counter = 0;
 
     const cachedTargets: { [id: number]: { targets: Unit.IUnit[], canAttack: boolean } } = {};
@@ -3651,11 +3653,15 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
       const readyToTakeTurnUnits = units.filter(u => Unit.canAct(u) && subTypes.includes(u.unitSubType));
       // Loop through planned unit actions for smart targeting
       for (let u of readyToTakeTurnUnits) {
+        // Optimization; count how many units have been processed
         counter++;
+        // Optimization; if the counter hasn't yet reached the currentChunk
+        // keep going, don't reprocess units at the beginning of the array
         if (!skipChunking && counter < globalThis.currentChunk) {
           continue;
         }
-        if (!skipChunking && (globalThis.currentChunk || 0) >= startChunk + config.ChunkSize) {
+        // Optimization; Once we have processed config.ChunkSize, return what has been cached so far.
+        if (!skipChunking && (globalThis.currentChunk || 0) >= startChunk + config.getSmartTargetsChunkSize) {
           return cachedTargets;
         }
         const unitSource = allUnits[u.unitSourceId];
@@ -3681,11 +3687,12 @@ ${CardUI.cardListToImages(player.stats.longestSpell)}
             }
           }
         }
+        // Optimization; Increment the currentChunk (one per unit processed)
         globalThis.currentChunk = (globalThis.currentChunk || 0) + 1;
       }
     }
 
-    // Set to -1 when finished
+    // Optimization; Set to -1 to denote that it has finished processing all units
     globalThis.currentChunk = -1;
     return cachedTargets;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,4 +94,4 @@ export const PATHING_POLYGON_OFFSET = 10;
 export const WALL_BOUNDS_OFFSET = 14;
 export const STAT_POINTS_PER_LEVEL = 120;
 export const RUNES_PER_LEVEL = 6;
-export const ChunkSize = 50;
+export const getSmartTargetsChunkSize = 50;

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,4 +94,4 @@ export const PATHING_POLYGON_OFFSET = 10;
 export const WALL_BOUNDS_OFFSET = 14;
 export const STAT_POINTS_PER_LEVEL = 120;
 export const RUNES_PER_LEVEL = 6;
-export const ChunkSize = 100;
+export const ChunkSize = 50;

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,3 +94,4 @@ export const PATHING_POLYGON_OFFSET = 10;
 export const WALL_BOUNDS_OFFSET = 14;
 export const STAT_POINTS_PER_LEVEL = 120;
 export const RUNES_PER_LEVEL = 6;
+export const ChunkSize = 100;

--- a/src/entity/Unit.ts
+++ b/src/entity/Unit.ts
@@ -147,6 +147,9 @@ export type IUnit = HasSpace & HasLife & HasMana & HasStamina & {
   modifiers: { [key: string]: Modifier };
   // Used for more intelligent AI battles so many unit don't overkill a single unit and leave a bunch of others untouched
   predictedNextTurnDamage: number;
+  // Shows icons above the heads of enemies who will damage you next turn
+  // Larger units need their marker positioned higher, which is why we need scaleY
+  attentionMarker?: { imagePath: string, pos: Vec2, unitSpriteScaleY: number, markerScale: number, removalTimeout?: number };
 }
 // This does not need to be unique to underworld, it just needs to be unique
 let lastPredictionUnitId = 0;

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -648,10 +648,8 @@ export function predictAIActions(underworld: Underworld, restartChunks: boolean)
     return;
   }
   if (!restartChunks && globalThis.currentChunk === -1) {
+    // Done but not restarting
     return;
-  }
-  if (restartChunks || globalThis.attentionMarkers === undefined) {
-    globalThis.attentionMarkers = [];
   }
   const aiUnits = underworld.unitsPrediction.filter(u => u.unitType == UnitType.AI);
   // Careful when making enemy predictions:
@@ -673,8 +671,9 @@ export function predictAIActions(underworld: Underworld, restartChunks: boolean)
 
   for (let u of aiUnits) {
     const unitSource = allUnits[u.unitSourceId];
-    if (unitSource) {
-      const { targets, canAttack } = cachedTargets[u.id] || { targets: [], canAttack: false };
+    const thisUnitsCachedTargets = cachedTargets[u.id];
+    if (unitSource && thisUnitsCachedTargets) {
+      const { targets, canAttack } = thisUnitsCachedTargets;
       const pos = clone(u);
       // Exception: Ancients are short,
       // draw their attention marker lower
@@ -686,7 +685,9 @@ export function predictAIActions(underworld: Underworld, restartChunks: boolean)
         if (targets.length) {
           // use u.predictionScale here since we are dealing with prediction units
           // prediction units don't have images, and thus sprite.scale.y
-          globalThis.attentionMarkers.push({ imagePath: Unit.subTypeToAttentionMarkerImage(u), pos, unitSpriteScaleY: u.predictionScale || 1, markerScale: 1 });
+          u.attentionMarker = { imagePath: Unit.subTypeToAttentionMarkerImage(u), pos, unitSpriteScaleY: u.predictionScale || 1, markerScale: 1 };
+        } else {
+          delete u.attentionMarker;
         }
       }
       else {
@@ -694,7 +695,9 @@ export function predictAIActions(underworld: Underworld, restartChunks: boolean)
         if (globalThis.player && targets.includes(globalThis.player.unit) && canAttack) {
           // use u.predictionScale here since we are dealing with prediction units
           // prediction units don't have images, and thus sprite.scale.y
-          globalThis.attentionMarkers.push({ imagePath: Unit.subTypeToAttentionMarkerImage(u), pos, unitSpriteScaleY: u.predictionScale || 1, markerScale: 1 });
+          u.attentionMarker = { imagePath: Unit.subTypeToAttentionMarkerImage(u), pos, unitSpriteScaleY: u.predictionScale || 1, markerScale: 1 };
+        } else {
+          delete u.attentionMarker;
         }
       }
     }

--- a/src/graphics/PlanningView.ts
+++ b/src/graphics/PlanningView.ts
@@ -643,10 +643,15 @@ export async function runPredictions(underworld: Underworld) {
 // but only to process a few units (a chunk) at a time
 // and it restarts explicitly when something changes.
 export function predictAIActions(underworld: Underworld, restartChunks: boolean) {
+  // Optimization: if predictAIActions is invoked with restartChunks, but
+  // it is still processing, exit early so it will keep processing until finished.
+  // This ensures the attentionMarkers don't just render the first chunk over and over
   if (restartChunks && globalThis.currentChunk > 0) {
     // Don't restart until previous is finished processing
     return;
   }
+  // If all chunks have finished processing but we're not starting processing over,
+  // abort.
   if (!restartChunks && globalThis.currentChunk === -1) {
     // Done but not restarting
     return;
@@ -666,7 +671,7 @@ export function predictAIActions(underworld: Underworld, restartChunks: boolean)
   // Allies, Bloat/Effects, Debilitate/Damage Modifiers
   // So may sometimes lead to false positives/negatives
 
-  // Optimized: This function is FPS heavy
+  // Optimized: This function is FPS heavy.  See "chunks" / "chunking strategy"
   let cachedTargets = underworld.getSmartTargets(aiUnits, restartChunks);
 
   for (let u of aiUnits) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,6 @@ globalThis.lobbyPlayerList = [];
 
 globalThis.intentionalDisconnect = false;
 globalThis.playerWalkingPromise = Promise.resolve();
-globalThis.attentionMarkers = [];
 globalThis.resMarkers = [];
 globalThis.isSuperMe = false;
 globalThis.devAutoPickUpgrades = location.href.includes('localhost');

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -51,3 +51,4 @@ globalThis.monitorFPS = () => {
   }
 
 }
+monitorFPS();

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -47,7 +47,7 @@ globalThis.monitorFPS = () => {
     stats.dom.classList.add('doob-stats');
     document.body?.appendChild(stats.dom);
     // Show the latency panel
-    stats.showPanel(3);
+    stats.showPanel(0);
   }
 
 }

--- a/src/types/globalTypesHeadless.d.ts
+++ b/src/types/globalTypesHeadless.d.ts
@@ -379,4 +379,5 @@ declare global {
   var test_ignorePromiseTracking: string | undefined;
   var showCastRangeForUpgrade: boolean | undefined;
   var alwaysDrawHealthBars: boolean | undefined;
+  var currentChunk: number | undefined;
 }

--- a/src/types/globalTypesHeadless.d.ts
+++ b/src/types/globalTypesHeadless.d.ts
@@ -69,7 +69,6 @@ declare global {
   // var zoomTarget: any;
   // var enemyEncountered: undefined;
   // var superMe: undefined;
-  // var attentionMarkers: undefined;
   // var resMarkers: undefined;
   // var castThisTurn: undefined;
   // var monitorFPS: undefined;
@@ -179,9 +178,6 @@ declare global {
   var superMe: undefined | ((underworld: Underworld, player?: Player.IPlayer) => void);
   // set to true once superMe is used
   var isSuperMe: undefined | boolean;
-  // Shows icons above the heads of enemies who will damage you next turn
-  // Larger units need their marker positioned higher, which is why we need scaleY
-  var attentionMarkers: undefined | { imagePath: string, pos: Vec2, unitSpriteScaleY: number, markerScale: number }[];
   // Shows icon for units that will be successfully resurrected
   var resMarkers: undefined | Vec2[];
   // True if client player has casted this turn;

--- a/src/types/globalTypesMain.d.ts
+++ b/src/types/globalTypesMain.d.ts
@@ -115,9 +115,6 @@ declare global {
   var superMe: undefined | ((underworld: Underworld, player?: Player.IPlayer) => void);
   // set to true once superMe is used
   var isSuperMe: undefined | boolean;
-  // Shows icons above the heads of enemies who will damage you next turn
-  // Larger units need their marker positioned higher, which is why we need scaleY
-  var attentionMarkers: undefined | { imagePath: string, pos: Vec2, unitSpriteScaleY: number, markerScale: number }[];
   // Shows icon for units that will be successfully resurrected
   var resMarkers: undefined | Vec2[];
   // True if client player has casted this turn;

--- a/src/types/globalTypesMain.d.ts
+++ b/src/types/globalTypesMain.d.ts
@@ -312,4 +312,5 @@ declare global {
   var test_ignorePromiseTracking: string | undefined;
   var showCastRangeForUpgrade: boolean | undefined;
   var alwaysDrawHealthBars: boolean | undefined;
+  var currentChunk: number;
 }


### PR DESCRIPTION
Predicting the AI turn with getSmartTargeting was a huge performance bottleneck and lagged the FPS when there were many enemies on screen.

This commit changes how attentionMarkers are rendered by generating them in chunks so that if there are lots of enemies it will generate them over time instead of lagging the game out.