### PR TITLE
Fix descriptions and names of spells

### DIFF
--- a/src/cards/arrow3.ts
+++ b/src/cards/arrow3.ts
@@ -5,7 +5,7 @@ import { arrowEffect } from './arrow';
 import { arrow2CardId } from './arrow2';
 import { takeDamage } from '../entity/Unit';
 
-export const arrow3CardId = 'Arrow3';
+export const arrow3CardId = 'Arrow 3';
 const damageDone = 30;
 const spell: Spell = {
   card: {

--- a/src/cards/bloat.ts
+++ b/src/cards/bloat.ts
@@ -42,7 +42,7 @@ const spell: Spell = {
     expenseScaling: 1,
     probability: probabilityMap[CardRarity.COMMON],
     thumbnail: 'spellIconBloat.png',
-    description: ['spell_bloat', id, damage.toString(), id],
+    description: ['spell_bloat', i18n(id), damage.toString(), i18n(id)],
     effect: async (state, card, quantity, underworld, prediction) => {
       // .filter: only target living units
       for (let unit of state.targetedUnits.filter(u => u.alive)) {

--- a/src/cards/cursify.ts
+++ b/src/cards/cursify.ts
@@ -17,7 +17,7 @@ const spell: Spell = {
     // minibosses and with it's synergies
     probability: probabilityMap[CardRarity.FORBIDDEN],
     thumbnail: 'spellIconCursify.png',
-    description: ['Designates target\'s blessings as curses.  Does not change the functionality of the blessings.'],
+    description: 'spell_cursify',
     effect: async (state, card, quantity, underworld, prediction) => {
       // .filter: only target living units
       for (let unit of state.targetedUnits.filter(u => u.alive)) {

--- a/src/cards/summon_decoy.ts
+++ b/src/cards/summon_decoy.ts
@@ -12,11 +12,10 @@ import { thornsId } from '../modifierThorns';
 import { runeThornyDecoysId } from '../modifierThornyDecoys';
 import { runeHardenedMinionsId } from '../modifierHardenedMinions';
 
-const id = 'decoy';
-export { id as decoyId };
+export const decoyId = 'decoy';
 const spell: Spell = {
   card: {
-    id,
+    id: decoyId,
     category: CardCategory.Soul,
     sfx: 'summonDecoy',
     supportQuantity: true,

--- a/src/cards/summon_decoy2.ts
+++ b/src/cards/summon_decoy2.ts
@@ -8,17 +8,18 @@ import { playDefaultSpellSFX } from './cardUtils';
 import floatingText from '../graphics/FloatingText';
 import { addWarningAtMouse } from '../graphics/PlanningView';
 import { CardRarity, probabilityMap } from '../types/commonTypes';
-import { runeThornyDecoysId } from '../modifierThornyDecoys';
 import { thornsId } from '../modifierThorns';
+import { runeThornyDecoysId } from '../modifierThornyDecoys';
 import { runeHardenedMinionsId } from '../modifierHardenedMinions';
+import { decoyId } from './summon_decoy';
 
-const id = 'decoy 2';
+export const decoy2Id = 'decoy 2';
 const spell: Spell = {
   card: {
-    id,
+    id: decoy2Id,
     category: CardCategory.Soul,
     sfx: 'summonDecoy',
-    requires: ['decoy'],
+    requires: [decoyId],
     supportQuantity: true,
     manaCost: 80,
     healthCost: 0,

--- a/src/cards/summon_decoy3.ts
+++ b/src/cards/summon_decoy3.ts
@@ -10,14 +10,15 @@ import { CardRarity, probabilityMap } from '../types/commonTypes';
 import { thornsId } from '../modifierThorns';
 import { runeThornyDecoysId } from '../modifierThornyDecoys';
 import { runeHardenedMinionsId } from '../modifierHardenedMinions';
+import { decoy2Id } from './summon_decoy2';
 
-const id = 'decoy 3';
+export const decoy3Id = 'decoy 3';
 const spell: Spell = {
   card: {
-    id,
+    id: decoy3Id,
     category: CardCategory.Soul,
     sfx: 'summonDecoy',
-    requires: ['decoy2'],
+    requires: [decoy2Id],
     supportQuantity: true,
     manaCost: 100,
     healthCost: 0,

--- a/src/cards/summon_generic.ts
+++ b/src/cards/summon_generic.ts
@@ -179,7 +179,7 @@ export default function makeSpellForUnitId(unitId: string, asMiniboss: boolean, 
       // These cards are not available as upgrades and must be accessed through capture_soul
       probability: 0,
       thumbnail: `spellIconSummon_${unitId.split(' ').join('').toLowerCase()}.png`,
-      description: i18n([`spell_summon_generic`, unitId, expenseScaling.toString()]) + '\n' + unitStats,
+      description: i18n([`spell_summon_generic`, i18n(unitId), expenseScaling.toString()]) + '\n' + unitStats,
       allowNonUnitTarget: true,
       effect: async (state, card, quantity, underworld, prediction) => {
         const sourceUnit = allUnits[unitId];

--- a/src/graphics/ui/CardUI.ts
+++ b/src/graphics/ui/CardUI.ts
@@ -1174,7 +1174,7 @@ export function getReplacesCardText(replaces: string[], requires?: string[]) {
         thumbnail.style.padding = '0 4px';
         replacesEl.appendChild(thumbnail);
         const label = document.createElement('span');
-        label.innerText = r;
+        label.innerText = globalThis.i18n(r);
         replacesEl.appendChild(label);
       }
     }


### PR DESCRIPTION
- Fixed description in cursify.ts (Now data is taken from localization file)
- Changed description of enhancement (Now data is taken from localization file instead of id) (CardUI.ts)
- Changed description of summon (Now the data is taken from localization file instead of id) (summon_generic.ts)
- Changed description of “Bloat” spell (Now data is taken from localization file instead of id) (bloat.ts)
- Fixed CardId typo in arrow3.ts file.
- Fixed requirement id in Decoy 3 (summon_decoy3.ts)